### PR TITLE
fix: bad create link

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap4/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap4/List.cshtml
@@ -38,7 +38,7 @@
         //    PushIndent("    ");
     }
 @:<p>
-    @:<a asp-action="Create">Create New</a>
+    @:<a asp-action="./Create">Create New</a>
 @:</p>
 @:<table class="table">
     @:<thead>


### PR DESCRIPTION
The link is generated is not working most of the time. This should fix the problem, which was probably a typo.