### PR TITLE
changing win64 to anycpu.

### DIFF
--- a/global_install.cmd
+++ b/global_install.cmd
@@ -1,7 +1,7 @@
 set VERSION=
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/
-call git clean -xdf
+call taskkill /f /im dotnet.exe
 call build.cmd  
 call dotnet tool uninstall -g dotnet-aspnet-codegenerator 
 call cd  %NUPKG% 

--- a/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -51,10 +51,7 @@
         OutputBinary=$(OutputPath)$(AssemblyName).dll;
         OutputDocumentation=$(OutputPath)$(AssemblyName).xml;
         OutputSymbol=$(OutputPath)$(AssemblyName).pdb;
-
-        OutputAnyExe=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).exe;
-        OutputAnyDocumentation=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).xml;
-        OutputAnySymbol=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).pdb;
+        
         OutputX86Exe=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).exe;
         OutputX86Documentation=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).xml;
         OutputX86Symbol=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).pdb;

--- a/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -55,11 +55,6 @@
         OutputAnyExe=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).exe;
         OutputAnyDocumentation=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).xml;
         OutputAnySymbol=$(AnyCpuBinDirectory)$(Configuration)\net5.0\$(AssemblyName).pdb;
-
-        OutputX64Exe=$(OutputPath)$(AssemblyName).exe;
-        OutputX64Documentation=$(OutputPath)$(AssemblyName).xml;
-        OutputX64Symbol=$(OutputPath)$(AssemblyName).pdb;
-
         OutputX86Exe=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).exe;
         OutputX86Documentation=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).xml;
         OutputX86Symbol=$(X86BinDirectory)$(Configuration)\net5.0\win7-x86\$(AssemblyName).pdb;

--- a/src/VS.Web.CG.Design/VS.Web.CG.Design.nuspec
+++ b/src/VS.Web.CG.Design/VS.Web.CG.Design.nuspec
@@ -23,10 +23,6 @@
     <file src="$OutputDocumentation$" target="lib\net5.0\$AssemblyName$.xml" />
     <file src="$OutputSymbol$" target="lib\net5.0\$AssemblyName$.pdb" />
 
-    <file src="$OutputAnyExe$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.exe" />
-    <file src="$OutputAnyDocumentation$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.xml" />
-    <file src="$OutputAnySymbol$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.pdb" />
-
     <file src="$OutputX86Exe$" target="runtimes\win7-x86\lib\net5.0\$AssemblyName$.exe" />
     <file src="$OutputX86Documentation$" target="runtimes\win7-x86\lib\net5.0\$AssemblyName$.xml" />
     <file src="$OutputX86Symbol$" target="runtimes\win7-x86\lib\net5.0\$AssemblyName$.pdb" />

--- a/src/VS.Web.CG.Design/VS.Web.CG.Design.nuspec
+++ b/src/VS.Web.CG.Design/VS.Web.CG.Design.nuspec
@@ -23,9 +23,9 @@
     <file src="$OutputDocumentation$" target="lib\net5.0\$AssemblyName$.xml" />
     <file src="$OutputSymbol$" target="lib\net5.0\$AssemblyName$.pdb" />
 
-    <file src="$OutputX64Exe$" target="runtimes\win7-x64\lib\net5.0\$AssemblyName$.exe" />
-    <file src="$OutputX64Documentation$" target="runtimes\win7-x64\lib\net5.0\$AssemblyName$.xml" />
-    <file src="$OutputX64Symbol$" target="runtimes\win7-x64\lib\net5.0\$AssemblyName$.pdb" />
+    <file src="$OutputAnyExe$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.exe" />
+    <file src="$OutputAnyDocumentation$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.xml" />
+    <file src="$OutputAnySymbol$" target="runtimes\anycpu\lib\net5.0\$AssemblyName$.pdb" />
 
     <file src="$OutputX86Exe$" target="runtimes\win7-x86\lib\net5.0\$AssemblyName$.exe" />
     <file src="$OutputX86Documentation$" target="runtimes\win7-x86\lib\net5.0\$AssemblyName$.xml" />


### PR DESCRIPTION
removing win64 and changing it to anycpu to fix error with msbuild. 

tested with Windows, and Mac. 