### PR TITLE
Removed duplicated instruction from NoCodeGeneratorsFound

### DIFF
--- a/src/dotnet-aspnet-codegenerator/Resources.resx
+++ b/src/dotnet-aspnet-codegenerator/Resources.resx
@@ -181,6 +181,6 @@
     <value>Scaffolding failed.</value>
   </data>
   <data name="NoCodeGeneratorsFound" xml:space="preserve">
-    <value>No code generators are available in this project. Add the 'Microsoft.VisualStudio.Web.CodeGeneration.Design' NuGet package to the project.</value>
+    <value>No code generators are available in this project.</value>
   </data>
 </root>


### PR DESCRIPTION
The only place where Resources.NoCodeGeneratorsFound is used is
followed immediately by a use of Resources.AddDesignPackage
resulting in a duplicated instruction:

"No code generators are available in this project. Please add the
'Microsoft.VisualStudio.Web.CodeGeneration.Design' NuGet package
to the project.Please add
Microsoft.VisualStudio.Web.CodeGeneration.Design package to the
project as a NuGet package reference."