### PR TITLE
Adding --excludeFiles for identity scaffolding

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "userClass", ShortName = "u", Description = "Name of the User class to generate.")]
         public string UserClass { get; set; }
 
-        [Option(Name = "files", ShortName = "fi", Description = "List of semicolon separated files to scaffold. Use the --listFiles option to see the available options.")]
+        [Option(Name = "files", ShortName = "fi", Description = "List of semicolon separated files to scaffold. Use --listFiles option to see the available options.")]
         public string Files { get; set; }
 
         [Option(Name = "listFiles", ShortName ="lf", Description = "Lists the files that can be scaffolded by using the '--files' option.")]
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
         [Option(Name ="bootstrapVersion", ShortName = "b", Description = "Specify the bootstrap version. Valid values: '3', '4'. Default is 4.")]
         public string BootstrapVersion { get; set; }
+
+        [Option(Name ="excludeFiles", ShortName="exf", Description = "Use this option to overwrite all but list of semicolon seperated files.  Use --listFiles option to see the available options.")]
+        public string ExcludeFiles { get; set; }
 
         public bool IsGenerateCustomUser
         {

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModel.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModel.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         public bool UseSQLite { get; set; }
         public bool IsUsingExistingDbContext { get; set; }
         public bool IsGenerateCustomUser { get; set; }
-        public bool IsGeneratingIndividualFiles { get; set; }
         public IdentityGeneratorFile[] FilesToGenerate { get; set; }
         public bool UseDefaultUI { get; set; }
         public bool GenerateLayout { get; set; }

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -198,7 +198,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 IsUsingExistingDbContext = IsUsingExistingDbContext,
                 Namespace = RootNamespace,
                 IsGenerateCustomUser = IsGenerateCustomUser,
-                IsGeneratingIndividualFiles = IsFilesSpecified || IsExcludeSpecificed,
                 UseDefaultUI = _commandlineModel.UseDefaultUI,
                 GenerateLayout = !hasExistingLayout,
                 Layout = layout,
@@ -227,11 +226,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 {
                     contentVersion = IdentityGenerator.ContentVersionDefault;
                 }
-                IEnumerable<string> excludedFiles = _commandlineModel.ExcludeFiles.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                const IEnumerable<string> allFiles = IdentityGeneratorFilesConfig.GetFilesToList(contentVersion);
+                IEnumerable<string> excludedFiles = _commandlineModel.ExcludeFiles.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim()).ToList();
+                IEnumerable<string> allFiles = IdentityGeneratorFilesConfig.GetFilesToList(contentVersion);
                 //validate excluded files
                 var errors = new List<string>();
-                var invalidFiles = excludedFiles.Where(f => allFiles.Contains(f));
+                var invalidFiles = excludedFiles.Where(f => !allFiles.Contains(f));
                 if (invalidFiles.Any())
                 {
                     errors.Add(MessageStrings.InvalidFilesListMessage);

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -80,6 +80,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         }
 
         internal bool IsFilesSpecified => !string.IsNullOrEmpty(_commandlineModel.Files);
+        internal bool IsExcludeSpecificed => !string.IsNullOrEmpty(_commandlineModel.ExcludeFiles);
         internal bool IsDbContextSpecified => !string.IsNullOrEmpty(_commandlineModel.DbContext);
         internal bool IsUsingExistingDbContext { get; set; }
 
@@ -197,7 +198,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 IsUsingExistingDbContext = IsUsingExistingDbContext,
                 Namespace = RootNamespace,
                 IsGenerateCustomUser = IsGenerateCustomUser,
-                IsGeneratingIndividualFiles = IsFilesSpecified,
+                IsGeneratingIndividualFiles = IsFilesSpecified || IsExcludeSpecificed,
                 UseDefaultUI = _commandlineModel.UseDefaultUI,
                 GenerateLayout = !hasExistingLayout,
                 Layout = layout,
@@ -210,13 +211,50 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
             templateModel.ContentVersion = DetermineContentVersion(templateModel);
 
+            ValidateIndividualFileOptions();
             if (!string.IsNullOrEmpty(_commandlineModel.Files))
             {
                 NamedFiles = _commandlineModel.Files.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
+            else if(!string.IsNullOrEmpty(_commandlineModel.ExcludeFiles))
+            {
+                string contentVersion;
+                if (templateModel is IdentityGeneratorTemplateModel2 templateModel2)
+                {
+                    contentVersion = templateModel2.ContentVersion;
+                }
+                else
+                {
+                    contentVersion = IdentityGenerator.ContentVersionDefault;
+                }
+                IEnumerable<string> excludedFiles = _commandlineModel.ExcludeFiles.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                const IEnumerable<string> allFiles = IdentityGeneratorFilesConfig.GetFilesToList(contentVersion);
+                //validate excluded files
+                var errors = new List<string>();
+                var invalidFiles = excludedFiles.Where(f => allFiles.Contains(f));
+                if (invalidFiles.Any())
+                {
+                    errors.Add(MessageStrings.InvalidFilesListMessage);
+                    errors.AddRange(invalidFiles);
+                }
+
+                if (errors.Any())
+                {
+                    throw new InvalidOperationException(string.Join(Environment.NewLine, errors));
+                }
+                
+                //get files to overwrite
+                NamedFiles = allFiles.Except(excludedFiles);
+            }
+
             templateModel.FilesToGenerate = DetermineFilesToGenerate(templateModel);
 
             if (IsFilesSpecified)
+            {
+                ValidateFilesOption(templateModel);
+            }
+
+            if (IsExcludeSpecificed)
             {
                 ValidateFilesOption(templateModel);
             }
@@ -407,6 +445,14 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             }
         }
 
+        private void ValidateIndividualFileOptions() 
+        {
+            //both options should not be selected. Users should either scaffold a particular set of files OR exclude a particular set of files.
+            if(IsFilesSpecified && IsExcludeSpecificed)
+            {
+                throw new InvalidOperationException(string.Format(MessageStrings.InvalidOptionCombination,"--files", "--excludeFiles"));
+            }
+        }
         private void ValidateDefaultUIOption()
         {
             var errorStrings = new List<string>();
@@ -414,6 +460,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             if (IsFilesSpecified)
             {
                 errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--files", "--useDefaultUI"));
+            }
+
+            if(IsExcludeSpecificed)
+            {
+                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--excludeFiles", "--useDefaultUI"));
             }
 
             if (IsUsingExistingDbContext)


### PR DESCRIPTION
--excludeFiles/-exf allows users to scaffold all identity files with some listed exclusions. Alternative is to list all but excluded but is a cumbersome process.
