### PR TITLE
Razor page namespace fix

### DIFF
--- a/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
 
         private string GetDefaultPageModelNamespaceName(string relativeFolderPath)
         {
-            return NameSpaceUtilities.GetSafeNameSpaceFromPath(relativeFolderPath, ApplicationInfo.ApplicationName);
+            return _projectContext.RootNamespace ?? NameSpaceUtilities.GetSafeNameSpaceFromPath(relativeFolderPath, ApplicationInfo.ApplicationName);
         }
 
         private static string DetermineContentVersion(RazorPageGeneratorModel razorGeneratorModel)

--- a/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
 
         private string GetDefaultPageModelNamespaceName(string relativeFolderPath)
         {
-            return _projectContext.RootNamespace ?? NameSpaceUtilities.GetSafeNameSpaceFromPath(relativeFolderPath, ApplicationInfo.ApplicationName);
+            return NameSpaceUtilities.GetSafeNameSpaceFromPath(relativeFolderPath, _projectContext.RootNamespace);
         }
 
         private static string DetermineContentVersion(RazorPageGeneratorModel razorGeneratorModel)


### PR DESCRIPTION
Cli tool was still using application name over root namespace as namespace prefix when not provided a namespace. VS provides one. 