### PR TITLE
Fix comment wording

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
@@ -56,8 +56,8 @@ namespace @Model.ControllerNamespace
         }
 
         // PUT: @routePrefix/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
         [HttpPut("{id}")]
         public async Task<IActionResult> Put@(Model.ModelTypeName)(@primaryKeyShortTypeName id, @Model.ModelTypeName @Model.ModelVariable)
         {
@@ -88,8 +88,8 @@ namespace @Model.ControllerNamespace
         }
 
         // POST: @routePrefix
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
         [HttpPost]
         public async Task<ActionResult<@(Model.ModelTypeName)>> Post@(Model.ModelTypeName)(@Model.ModelTypeName @Model.ModelVariable)
         {

--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
@@ -56,8 +56,7 @@ namespace @Model.ControllerNamespace
         }
 
         // PUT: @routePrefix/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPut("{id}")]
         public async Task<IActionResult> Put@(Model.ModelTypeName)(@primaryKeyShortTypeName id, @Model.ModelTypeName @Model.ModelVariable)
         {
@@ -88,8 +87,7 @@ namespace @Model.ControllerNamespace
         }
 
         // POST: @routePrefix
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see https://go.microsoft.com/fwlink/?linkid=2123754.
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]
         public async Task<ActionResult<@(Model.ModelTypeName)>> Post@(Model.ModelTypeName)(@Model.ModelTypeName @Model.ModelVariable)
         {

--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -123,8 +123,8 @@ namespace @Model.ControllerNamespace
         }
 
         // POST: @routePrefix/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for 
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("@bindString")] @Model.ModelTypeName @Model.ModelVariable)
@@ -172,8 +172,8 @@ namespace @Model.ControllerNamespace
         }
 
         // POST: @routePrefix/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for 
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(@primaryKeyShortTypeName id, [Bind("@bindString")] @Model.ModelTypeName @Model.ModelVariable)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
@@ -52,8 +52,8 @@ namespace @Model.NamespaceName
         [BindProperty]
         public @Model.ViewDataTypeShortName @Model.ViewDataTypeShortName { get; set; }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://aka.ms/RazorPagesCRUD.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
@@ -52,8 +52,7 @@ namespace @Model.NamespaceName
         [BindProperty]
         public @Model.ViewDataTypeShortName @Model.ViewDataTypeShortName { get; set; }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see https://aka.ms/RazorPagesCRUD.
+        // To protect from overposting attacks, see https://aka.ms/RazorPagesCRUD
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
@@ -52,8 +52,8 @@ namespace @Model.NamespaceName
         [BindProperty]
         public @Model.ViewDataTypeShortName @Model.ViewDataTypeShortName { get; set; }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://aka.ms/RazorPagesCRUD.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
@@ -52,8 +52,7 @@ namespace @Model.NamespaceName
         [BindProperty]
         public @Model.ViewDataTypeShortName @Model.ViewDataTypeShortName { get; set; }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see https://aka.ms/RazorPagesCRUD.
+        // To protect from overposting attacks, see https://aka.ms/RazorPagesCRUD
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/EditPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/EditPageModel.cshtml
@@ -70,8 +70,8 @@ namespace @Model.NamespaceName
             return Page();
         }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://aka.ms/RazorPagesCRUD.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/test/E2E_Test/Compiler/Resources/CarsController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsController.txt
@@ -53,8 +53,8 @@ namespace TestProject
         }
 
         // POST: Cars/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
@@ -87,8 +87,8 @@ namespace TestProject
         }
 
         // POST: Cars/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)

--- a/test/E2E_Test/Compiler/Resources/CarsControllerWithDAL.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsControllerWithDAL.txt
@@ -54,8 +54,8 @@ namespace TestProject.Areas.Test.Controllers
         }
 
         // POST: Test/CarsWithView/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
@@ -88,8 +88,8 @@ namespace TestProject.Areas.Test.Controllers
         }
 
         // POST: Test/CarsWithView/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)

--- a/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
@@ -54,8 +54,8 @@ namespace TestProject.Areas.Test.Controllers
         }
 
         // POST: Test/CarsWithView/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
@@ -88,8 +88,8 @@ namespace TestProject.Areas.Test.Controllers
         }
 
         // POST: Test/CarsWithView/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)

--- a/test/E2E_Test/Compiler/Resources/ProductsController.txt
+++ b/test/E2E_Test/Compiler/Resources/ProductsController.txt
@@ -52,8 +52,8 @@ namespace TestProject
         }
 
         // POST: Products/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ProductID,Name,Price,ManufacturerID")] Product product)
@@ -86,8 +86,8 @@ namespace TestProject
         }
 
         // POST: Products/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("ProductID,Name,Price,ManufacturerID")] Product product)


### PR DESCRIPTION
Changes comments in 9 files from the form:

```
// POST: Movies/Edit/5
// To protect from overposting attacks, enable the specific properties you want to bind to, for 
// more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
```
to:
```
// POST: Movies/Edit/5
// To protect from overposting attacks, enable the specific properties you want to bind to.
// For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
```