### PR TITLE
using projects.assets.json to get project dependencies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,8 +26,8 @@
     <MicrosoftAspNetCoreRazorLanguagePackageVersion>5.0.0-preview.6.20312.15</MicrosoftAspNetCoreRazorLanguagePackageVersion>
     <!-- Microsoft.AspNetCore.Razor.Runtime -->
     <MicrosoftAspNetCoreRazorRuntimePackageVersion>2.2.0</MicrosoftAspNetCoreRazorRuntimePackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.82</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>15.6.82</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildPackageVersion>16.6.0 </MicrosoftBuildPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>16.6.0 </MicrosoftBuildUtilitiesCorePackageVersion>
     <!-- Microsoft.CodeAnalysis.CSharp -->
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.6.0-1.final</MicrosoftCodeAnalysisCSharpPackageVersion>
     <!-- Microsoft.CodeAnalysis.Razor -->
@@ -66,7 +66,7 @@
     <!-- Microsoft.AspNetCore -->
     <!-- this is from aspnetcore-dev (test project only) -->
     <MicrosoftAspNetCorePackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftBuildRuntimePackageVersion>15.6.82</MicrosoftBuildRuntimePackageVersion>
+    <MicrosoftBuildRuntimePackageVersion>16.6.0</MicrosoftBuildRuntimePackageVersion>
     <!-- Microsoft.AspNetCore.Mvc -->
     <!-- this is from aspnetcore-dev (test only) -->
     <MicrosoftAspNetCoreMvcPackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCoreMvcPackageVersion>

--- a/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
+++ b/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
@@ -1,19 +1,25 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
-using Newtonsoft.Json;
+using NuGet.Frameworks;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 {
     public class ProjectContextWriter : Build.Utilities.Task
     {
+        private const string TargetsProperty = "targets";
+        private const string PackageFoldersProperty = "packageFolders";
+        private const string DependencyProperty = "dependencies";
+        private const string TypeProperty = "type";
         #region Inputs
         [Build.Framework.Required]
         public string OutputFile { get; set; }
@@ -21,8 +27,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
         [Build.Framework.Required]
         public ITaskItem[] ResolvedReferences { get; set; }
 
-        [Build.Framework.Required]
-        public ITaskItem[] PackageDependencies { get; set; }
 
         [Build.Framework.Required]
         public ITaskItem[] ProjectReferences { get; set; }
@@ -67,22 +71,26 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 
         [Build.Framework.Required]
         public string ProjectDepsFileName { get; set; }
+
+        [Build.Framework.Required]
+        public string ProjectAssetsFile { get; set; }
         #endregion
 
         public override bool Execute()
         {
+            Debugger.Launch();
             var msBuildContext = new CommonProjectContext()
             {
                 AssemblyFullPath = this.AssemblyFullPath,
                 AssemblyName = string.IsNullOrEmpty(this.AssemblyName) ? Path.GetFileName(this.AssemblyFullPath) : this.AssemblyName,
                 CompilationAssemblies = GetCompilationAssemblies(this.ResolvedReferences),
                 CompilationItems = this.CompilationItems.Select(i => i.ItemSpec),
+                PackageDependencies = GetPackageDependencies(this.ProjectAssetsFile),
                 Config = this.AssemblyFullPath + ".config",
                 Configuration = this.Configuration,
                 DepsFile = this.ProjectDepsFileName,
                 EmbededItems = this.EmbeddedItems.Select(i => i.ItemSpec),
                 IsClassLibrary = "Library".Equals(this.OutputType, StringComparison.OrdinalIgnoreCase),
-                PackageDependencies = this.GetPackageDependencies(PackageDependencies),
                 Platform = this.Platform,
                 ProjectFullPath = this.ProjectFullPath,
                 ProjectName = this.Name,
@@ -98,11 +106,118 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             msBuildContext.ProjectReferenceInformation = projReferenceInformation;
             using(var streamWriter = new StreamWriter(File.Create(OutputFile)))
             {
-                var json = JsonConvert.SerializeObject(msBuildContext);
+                var json = JsonSerializer.Serialize(msBuildContext);
                 streamWriter.Write(json);
             }
 
             return true;
+        }
+
+        internal IEnumerable<DependencyDescription> GetPackageDependencies(string projectAssetsFile)
+        {
+            IList<DependencyDescription> packageDependencies = new List<DependencyDescription>();
+            if (!string.IsNullOrEmpty(projectAssetsFile) && File.Exists(projectAssetsFile) && !string.IsNullOrEmpty(TargetFramework))
+            {
+                //target framework moniker for the current project. We use this to get all targets for said moniker.
+                var targetFrameworkMoniker = NuGetFramework.Parse(TargetFramework)?.DotNetFrameworkName;
+                string json = File.ReadAllText(projectAssetsFile);
+                if (!string.IsNullOrEmpty(json) && !string.IsNullOrEmpty(targetFrameworkMoniker))
+                {
+                    try
+                    {
+                        JsonDocument baseDocument = JsonDocument.Parse(json);
+                        if (baseDocument != null)
+                        {
+                            JsonElement root = baseDocument.RootElement;
+                            //"targets" gives us all top-level and transitive dependencies. "packageFolders" gives us the path where the dependencies are on disk.
+                            if (root.TryGetProperty(TargetsProperty, out var targets) && root.TryGetProperty(PackageFoldersProperty, out var packageFolderPath))
+                            {
+                                if (targets.TryGetProperty(targetFrameworkMoniker, out var packages))
+                                {
+                                    var packagesEnumerator = packages.EnumerateObject();
+                                    //populate are our own List<DependencyDescription> of all the dependencies we find.
+                                    foreach (var package in packagesEnumerator)
+                                    {
+                                        var fullName = package.Name;
+                                        //get default nuget package path.
+                                        var path = packageFolderPath.EnumerateObject().Any() ? packageFolderPath.EnumerateObject().First().Name : string.Empty;
+                                        if (!string.IsNullOrEmpty(fullName) && !string.IsNullOrEmpty(path) && package.Value.TryGetProperty(TypeProperty, out var type))
+                                        {
+                                            //fullName is in the format {Package Name}/{Version} for example "System.Text.MoreText/2.1.1" Split into tuple. 
+                                            Tuple<string, string> nameAndVersion = GetName(fullName);
+                                            if (nameAndVersion != null)
+                                            {
+                                                var dependencyTypeValue = type.ToString();
+                                                var DependencyTypeEnum = DependencyType.Unknown;
+                                                if (Enum.TryParse(typeof(DependencyType), dependencyTypeValue, true, out var dependencyType))
+                                                {
+                                                    DependencyTypeEnum = (DependencyType)dependencyType;
+                                                }
+                                                
+                                                DependencyDescription dependency = new DependencyDescription(nameAndVersion.Item1,
+                                                                                                             nameAndVersion.Item2,
+                                                                                                             GetPath(path, nameAndVersion),
+                                                                                                             targetFrameworkMoniker,
+                                                                                                             DependencyTypeEnum,
+                                                                                                             true);
+                                                if (package.Value.TryGetProperty(DependencyProperty, out var dependencies))
+                                                {
+                                                    var dependenciesList = dependencies.EnumerateObject();
+                                                    //Add all transitive dependencies
+                                                    foreach (var dep in dependenciesList)
+                                                    {
+                                                        if (!string.IsNullOrEmpty(dep.Name))
+                                                        {
+                                                            Dependency transitiveDependency = new Dependency(dep.Name, dep.Value.ToString());
+                                                            dependency.AddDependency(transitiveDependency);
+                                                        }
+                                                    }
+                                                }
+                                                packageDependencies.Add(dependency);
+                                            } 
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        Debug.Assert(false, "Completely empty json.");
+                    }
+                }
+            }
+
+            return packageDependencies;
+        }
+
+
+        internal string GetPath(string nugetPath, Tuple<string, string> nameAndVersion)
+        {
+            if (!string.IsNullOrEmpty(nugetPath))
+            {
+                string path = Path.Combine(nugetPath, nameAndVersion.Item1, nameAndVersion.Item2);
+                if (Directory.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private Tuple<string, string> GetName(string fullName)
+        {
+            Tuple<string, string> nameAndVersion = null;
+            if (!string.IsNullOrEmpty(fullName))
+            {
+                string[] splitName = fullName.Split("/");
+                if (splitName.Length  > 1)
+                {
+                    nameAndVersion = new Tuple<string, string>(splitName[0], splitName[1]);
+                }
+            }
+            return nameAndVersion;
         }
 
         private IEnumerable<ProjectReferenceInformation> GetProjectDependency(
@@ -112,77 +227,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             return ProjectReferenceInformationProvider.GetProjectReferenceInformation(
                 rootProjectFullpath,
                 projectReferences);
-        }
-
-        private IEnumerable<DependencyDescription> GetPackageDependencies(ITaskItem[] packageDependecyItems)
-        {
-            Requires.NotNull(packageDependecyItems, nameof(packageDependecyItems));
-            var packages = packageDependecyItems.Select(item => new { key = item.ItemSpec, value = GetPackageDependency(item) })
-                .Where(package => package != null && package.value != null);
-            var packageMap = new Dictionary<string, DependencyDescription>(StringComparer.OrdinalIgnoreCase);
-            foreach(var package in packages)
-            {
-                packageMap.Add(package.key, package.value);
-            }
-
-            PopulateDependencies(packageMap, packageDependecyItems);
-
-            return packageMap.Values;
-        }
-
-        private void PopulateDependencies(Dictionary<string, DependencyDescription> packageMap, ITaskItem[] packageDependecyItems)
-        {
-            Requires.NotNull(packageMap, nameof(packageMap));
-            Requires.NotNull(packageDependecyItems, nameof(packageDependecyItems));
-            foreach (var item in packageDependecyItems)
-            {
-                var depSpecs = item.GetMetadata("Dependencies")
-                    ?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                DependencyDescription current = null;
-                if (depSpecs == null || !packageMap.TryGetValue(item.ItemSpec, out current))
-                {
-                    return;
-                }
-
-                foreach (var depSpec in depSpecs)
-                {
-                    var spec = item.ItemSpec.Split('/').FirstOrDefault() +"/"+ depSpec;
-                    DependencyDescription d = null;
-                    if (packageMap.TryGetValue(spec, out d))
-                    {
-                        current.AddDependency(new Dependency(d.Name, d.Version));
-                    }
-                }
-            }
-        }
-
-        private DependencyDescription GetPackageDependency(ITaskItem item)
-        {
-            Requires.NotNull(item, nameof(item));
-
-            var type = item.GetMetadata("Type");
-            var name = ("Target".Equals(type, StringComparison.OrdinalIgnoreCase))
-                ? item.ItemSpec
-                : item.GetMetadata("Name");
-
-            if (string.IsNullOrEmpty(name))
-            {
-                return null;
-            }
-            var version = item.GetMetadata("Version");
-            var path = item.GetMetadata("Path");
-            var resolved = item.GetMetadata("Resolved");
-
-            var isResolved = false;
-            bool.TryParse(resolved, out isResolved);
-
-            var framework = item.ItemSpec.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).First();
-            DependencyType dt;
-            dt = Enum.TryParse(type, out dt)
-                ? dt
-                : DependencyType.Unknown;
-
-            return new DependencyDescription(name, version, path, framework, dt, isResolved);
         }
 
         private IEnumerable<ResolvedReference> GetCompilationAssemblies(ITaskItem[] resolvedReferences)

--- a/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
+++ b/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
@@ -78,7 +78,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 
         public override bool Execute()
         {
-            Debugger.Launch();
             var msBuildContext = new CommonProjectContext()
             {
                 AssemblyFullPath = this.AssemblyFullPath,
@@ -113,7 +112,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             return true;
         }
 
-        internal IEnumerable<DependencyDescription> GetPackageDependencies(string projectAssetsFile)
+        private IEnumerable<DependencyDescription> GetPackageDependencies(string projectAssetsFile)
         {
             IList<DependencyDescription> packageDependencies = new List<DependencyDescription>();
             if (!string.IsNullOrEmpty(projectAssetsFile) && File.Exists(projectAssetsFile) && !string.IsNullOrEmpty(TargetFramework))
@@ -153,10 +152,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
                                                 {
                                                     DependencyTypeEnum = (DependencyType)dependencyType;
                                                 }
-                                                
+
+                                                string packagePath = GetPath(path, nameAndVersion);
                                                 DependencyDescription dependency = new DependencyDescription(nameAndVersion.Item1,
                                                                                                              nameAndVersion.Item2,
-                                                                                                             GetPath(path, nameAndVersion),
+                                                                                                             Directory.Exists(path) ? path : string.Empty,
                                                                                                              targetFrameworkMoniker,
                                                                                                              DependencyTypeEnum,
                                                                                                              true);
@@ -194,16 +194,13 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 
         internal string GetPath(string nugetPath, Tuple<string, string> nameAndVersion)
         {
-            if (!string.IsNullOrEmpty(nugetPath))
+            string path = string.Empty;
+            if (!string.IsNullOrEmpty(nugetPath) && !string.IsNullOrEmpty(nameAndVersion.Item1) && !string.IsNullOrEmpty(nameAndVersion.Item2))
             {
-                string path = Path.Combine(nugetPath, nameAndVersion.Item1, nameAndVersion.Item2);
-                if (Directory.Exists(path))
-                {
-                    return path;
-                }
+                path = Path.Combine(nugetPath, nameAndVersion.Item1, nameAndVersion.Item2);
             }
 
-            return string.Empty;
+            return path;
         }
 
         private Tuple<string, string> GetName(string fullName)

--- a/src/VS.Web.CG.Msbuild/Properties/AssemblyInfo.cs
+++ b/src/VS.Web.CG.Msbuild/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.VisualStudio.Web.CodeGeneration.MSBuild.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
  Copyright (c) .NET Foundation. All rights reserved.
  Licensed under the Apache License, Version 2.0.
 -->
@@ -17,7 +17,6 @@ Outputs the Project Information needed for CodeGeneration to a file.
     <EvaluateProjectInfoForCodeGenerationDependsOn>
       $(EvaluateProjectInfoForCodeGenerationDependsOn);
       ResolveReferences;
-      ResolvePackageDependenciesDesignTime;
     </EvaluateProjectInfoForCodeGenerationDependsOn>
   </PropertyGroup>
 
@@ -34,7 +33,6 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           OutputFile ="$(OutputFile)"
                           Name ="$(ProjectName)"
                           ResolvedReferences ="@(ReferencePath)"
-                          PackageDependencies ="@(_DependenciesDesignTime)"
                           ProjectReferences ="@(ProjectReference)"
                           AssemblyFullPath ="$(TargetPath)"
                           OutputType="$(OutputType)"
@@ -46,7 +44,8 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           Configuration="$(Configuration)"
                           ProjectFullPath="$(MSBuildProjectFullPath)"
                           ProjectDepsFileName="$(ProjectDepsFileName)"
-                          ProjectRuntimeConfigFileName="$(ProjectRuntimeConfigFileName)"/>
+                          ProjectRuntimeConfigFileName="$(ProjectRuntimeConfigFileName)"
+                          ProjectAssetsFile="$(ProjectAssetsFile)"/>
 
   </Target>
 </Project>

--- a/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -46,6 +46,5 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           ProjectDepsFileName="$(ProjectDepsFileName)"
                           ProjectRuntimeConfigFileName="$(ProjectRuntimeConfigFileName)"
                           ProjectAssetsFile="$(ProjectAssetsFile)"/>
-
   </Target>
 </Project>

--- a/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
+++ b/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>MSBuild task (EvaluateProjectInfoForCodeGeneration) used by Microsoft.VisualStudio.Web.CodeGeneration.Tools</Description>

--- a/src/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
+++ b/src/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Code Generators for ASP.NET Core MVC. Contains code generators for MVC Controllers and Views.</Description>

--- a/src/dotnet-aspnet-codegenerator/Program.cs
+++ b/src/dotnet-aspnet-codegenerator/Program.cs
@@ -231,7 +231,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
             var depsFile = Path.Combine(targetDir, context.DepsFile);
 
             string dotnetCodeGenInsideManPath = string.Empty;
-            
             if (IsNetCoreAppFramework(frameworkToUse))
             {
                 dotnetCodeGenInsideManPath = context.CompilationAssemblies

--- a/test/Shared/MSBuildProjectStrings.cs
+++ b/test/Shared/MSBuildProjectStrings.cs
@@ -832,6 +832,25 @@ namespace Test
 </Project>
 ";
 
+        public const string SimpleNet50ProjectText = @"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" />
+  <PropertyGroup>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      C:\scaffolding\artifacts\packages\Debug\Shipping;
+    </RestoreSources>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>Microsoft.Test</RootNamespace>
+    <ProjectName>Test</ProjectName>
+    <NoWarn>NU1605</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""5.0.0-preview.6.20323.1"" />
+  </ItemGroup>
+</Project>
+";
         public const string BaseDbContextText = @"
 using Microsoft.EntityFrameworkCore;
 using Test.Models;
@@ -912,6 +931,39 @@ namespace Test
 }
 ";
 
+        public const string EmptyTestStartupText = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Test
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseStaticFiles();
+        }
+    }
+}
+";
         public const string BlogModelText = @"
 namespace Test.Models
 {
@@ -976,6 +1028,64 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           ProjectFullPath=""$(MSBuildProjectFullPath)""
                           ProjectDepsFileName=""$(ProjectDepsFileName)""
                           ProjectRuntimeConfigFileName=""$(ProjectRuntimeConfigFileName)""/>
+
+  </Target>
+</Project>
+";
+
+ public const string ProjectContextWriterMsbuildHelperText = @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<!--
+**********************************************************************************
+Target: EvaluateProjectInfoForCodeGeneration
+
+Outputs the Project Information needed for CodeGeneration to a file.
+
+**********************************************************************************
+-->
+
+  <PropertyGroup>
+    <EvaluateProjectInfoForCodeGenerationDependsOn>
+      $(EvaluateProjectInfoForCodeGenerationDependsOn);
+      ResolveReferences;
+    </EvaluateProjectInfoForCodeGenerationDependsOn>
+  </PropertyGroup>
+  <Choose>
+    <!-- For Portable Msbuild, MSBuildRuntimeType = 'Core'. For Desktop MsBuild, MSBuildRuntimeType = 'Full'-->
+    <When Condition=""'$(MSBuildRuntimeType)' == 'Core'"">
+      <PropertyGroup>
+        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net5.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup >
+        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net5.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <UsingTask TaskName=""ProjectContextWriter""
+             AssemblyFile=""$(EvaluateProjectInfoForCodeGenerationAssemblyPath)"" />
+
+  <Target Name=""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
+
+    <ProjectContextWriter TargetFramework =""$(TargetFramework)""
+                          OutputFile =""$(OutputFile)""
+                          Name =""$(ProjectName)""
+                          ResolvedReferences =""@(ReferencePath)""
+                          PackageDependencies =""@(_DependenciesDesignTime)""
+                          ProjectReferences =""@(ProjectReference)""
+                          AssemblyFullPath =""$(TargetPath)""
+                          OutputType=""$(OutputType)""
+                          Platform=""$(Platform)""
+                          RootNameSpace =""$(RootNamespace)""
+                          CompilationItems =""@(Compile)""
+                          TargetDirectory=""$(TargetDir)""
+                          EmbeddedItems=""@(EmbeddedResource)""
+                          Configuration=""$(Configuration)""
+                          ProjectFullPath=""$(MSBuildProjectFullPath)""
+                          ProjectDepsFileName=""$(ProjectDepsFileName)""
+                          ProjectRuntimeConfigFileName=""$(ProjectRuntimeConfigFileName)""
+                          ProjectAssetsFile=""$(ProjectAssetsFile)""/>
 
   </Target>
 </Project>

--- a/test/Shared/MSBuildProjectStrings.cs
+++ b/test/Shared/MSBuildProjectStrings.cs
@@ -838,7 +838,6 @@ namespace Test
   <PropertyGroup>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
-      C:\scaffolding\artifacts\packages\Debug\Shipping;
     </RestoreSources>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.Test</RootNamespace>
@@ -1049,30 +1048,19 @@ Outputs the Project Information needed for CodeGeneration to a file.
       ResolveReferences;
     </EvaluateProjectInfoForCodeGenerationDependsOn>
   </PropertyGroup>
-  <Choose>
-    <!-- For Portable Msbuild, MSBuildRuntimeType = 'Core'. For Desktop MsBuild, MSBuildRuntimeType = 'Full'-->
-    <When Condition=""'$(MSBuildRuntimeType)' == 'Core'"">
-      <PropertyGroup>
-        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net5.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup >
-        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net5.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup>
+    <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net5.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+  </PropertyGroup>
 
   <UsingTask TaskName=""ProjectContextWriter""
              AssemblyFile=""$(EvaluateProjectInfoForCodeGenerationAssemblyPath)"" />
 
-  <Target Name=""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
+  <Target Name = ""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
 
-    <ProjectContextWriter TargetFramework =""$(TargetFramework)""
+    <ProjectContextWriter TargetFramework = ""$(TargetFramework)""
                           OutputFile =""$(OutputFile)""
                           Name =""$(ProjectName)""
                           ResolvedReferences =""@(ReferencePath)""
-                          PackageDependencies =""@(_DependenciesDesignTime)""
                           ProjectReferences =""@(ProjectReference)""
                           AssemblyFullPath =""$(TargetPath)""
                           OutputType=""$(OutputType)""
@@ -1086,7 +1074,6 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           ProjectDepsFileName=""$(ProjectDepsFileName)""
                           ProjectRuntimeConfigFileName=""$(ProjectRuntimeConfigFileName)""
                           ProjectAssetsFile=""$(ProjectAssetsFile)""/>
-
   </Target>
 </Project>
 ";

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -54,6 +54,25 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             }
         }
 
+        internal void SetupEmptyCodeGenerationProject(TemporaryFileProvider fileProvider, ITestOutputHelper outputHelper)
+        {
+            fileProvider.Add("global.json", GlobalJsonText);
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "net5.0"));
+
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.ProjectContextWriterMsbuildHelperText);
+
+            var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+            fileProvider.Copy(msbuildTaskDllPath, "toolAssets/net5.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+
+            var rootProjectTxt = MsBuildProjectStrings.SimpleNet50ProjectText;
+            fileProvider.Add(MsBuildProjectStrings.RootProjectName, rootProjectTxt);
+            fileProvider.Add("Startup.cs", MsBuildProjectStrings.EmptyTestStartupText);
+            fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
+            fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
+
+            RestoreAndBuild(fileProvider.Root, outputHelper);
+        }
+
         public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));

--- a/test/Shared/TemporaryFileProvider.cs
+++ b/test/Shared/TemporaryFileProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -1,0 +1,39 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Microsoft.VisualStudio.Web.CodeGeneration.Sources.Test;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
+{
+    public class ProjectContextWriterTests : TestBase
+    {
+        static string testAppPath = Path.Combine("..", "TestApps", "ModelTypesLocatorTestClassLibrary");
+        ICodeGenAssemblyLoadContext loadContext;
+        private ITestOutputHelper _outputHelper;
+
+        public ProjectContextWriterTests(ITestOutputHelper outputHelper)
+        {
+            loadContext = new DefaultAssemblyLoadContext();
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public void CommonUtilities_TestGetAssemblyFromCompilation_MsBuild()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+
+                new MsBuildProjectSetupHelper().SetupEmptyCodeGenerationProject(fileProvider, _outputHelper);
+                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName);
+
+                var projectContext = GetProjectContext(path, true);
+
+            }
+        }
+    }
+}

--- a/test/VS.Web.CG.MSBuild.Test/TestBase.cs
+++ b/test/VS.Web.CG.MSBuild.Test/TestBase.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.ProjectModel;
+using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
+using NuGet.Frameworks;
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
+{
+    public class TestBase
+    {
+        protected IProjectContext GetProjectContext(string path, bool isMsBuild)
+        {
+            if (isMsBuild)
+            {
+                /**
+                 * To Make this work, the test project needs to take a dependency on
+                 * 'Microsoft.VisualStudio.Web.CodeGeneration.Tools' package. That way when NuGet restores 
+                 * the project, it will include the targets in the project automatically.
+                 */
+                var codeGenerationTargetLocation = "Dummy";
+                // TODO: Need to include the build task and target
+                return new MsBuildProjectContextBuilder(path, codeGenerationTargetLocation)
+                    .Build();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
+++ b/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\VS.Web.CG.Msbuild\VS.Web.CG.Msbuild.csproj" />
+    <ProjectReference Include="..\VS.Web.CG.Sources.Test\VS.Web.CG.Sources.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
+++ b/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <Import Project="$(RepoRoot)test\TestPackage.props" />
 
@@ -18,13 +18,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\VS.Web.CG.Msbuild\VS.Web.CG.Msbuild.csproj" />
-    <ProjectReference Include="..\VS.Web.CG.Sources.Test\VS.Web.CG.Sources.Tests.csproj" />
+    <Compile Include="..\..\src\Ext.ProjectModel.MsBuild.Sources\**\*.cs;">
+      <Link>MsBuildSources\%(RecursiveDir)%(FileName)</Link>
+    </Compile>
   </ItemGroup>
-
+ 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
since the project system changes in the sdk 3.1.4+ and 5.0.0-preview7+, we need to populate dependencies using the projects.assets.json file.

- Using msbuild property to get the assets file location and then parsing the json.

- added unit tests and one to test dependencies using a bare net 5.0 project with the CodeGeneration.Design dependency.

Will port over VS fairly soon as well (until we are ready to use the Nuget API).