### PR TITLE
Fix formatting

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
@@ -41,7 +41,8 @@ namespace @(thisNamespace)
         public void Configure(IWebHostBuilder builder)
         {
 @{
-@:            builder.ConfigureServices((context, services) => {
+@:            builder.ConfigureServices((context, services) =>
+              {
 
     if (!Model.IsUsingExistingDbContext)
     {

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/Pages/Account/Account.Login.cs.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/Pages/Account/Account.Login.cs.cshtml
@@ -40,7 +40,7 @@ namespace @thisNamespace
         private readonly SignInManager<@(Model.UserClass)> _signInManager;
         private readonly ILogger<LoginModel> _logger;
 
-        public LoginModel(SignInManager<@(Model.UserClass)> signInManager, 
+        public LoginModel(SignInManager<@(Model.UserClass)> signInManager,
             ILogger<LoginModel> logger,
             UserManager<@(Model.UserClass)> userManager)
         {

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
@@ -41,7 +41,8 @@ namespace @(thisNamespace)
         public void Configure(IWebHostBuilder builder)
         {
 @{
-@:            builder.ConfigureServices((context, services) => {
+@:            builder.ConfigureServices((context, services) =>
+              {
 
     if (!Model.IsUsingExistingDbContext)
     {

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/Pages/Account/Account.Login.cs.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/Pages/Account/Account.Login.cs.cshtml
@@ -40,7 +40,7 @@ namespace @thisNamespace
         private readonly SignInManager<@(Model.UserClass)> _signInManager;
         private readonly ILogger<LoginModel> _logger;
 
-        public LoginModel(SignInManager<@(Model.UserClass)> signInManager, 
+        public LoginModel(SignInManager<@(Model.UserClass)> signInManager,
             ILogger<LoginModel> logger,
             UserManager<@(Model.UserClass)> userManager)
         {


### PR DESCRIPTION
I'm working on an ASP.NET Core project, and after I've added scaffolding for register and login pages, the default code inside `IdentityHostingStartup` gives IDE0055 warning. I hope this is the correct place to fix this.

![image](https://user-images.githubusercontent.com/31348972/88178080-1cacc980-cc2a-11ea-9fa2-cd1a3086bdd9.png)

I've also a question: in my case, the `IdentityHostingStartup` doesn't seem to be doing anything, why it was generated in the first place? I think it should only be generated if there is no existing db context?