### PR TITLE
removing Nuget.Frameworks dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,6 @@
     <!-- Microsoft.Extensions.FileProviders.Physical -->
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>5.0.0-preview.7.20364.11</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
-    <NuGetFrameworksPackageVersion>5.7.0-preview.2.6618</NuGetFrameworksPackageVersion>
     <VisualStudio_NewtonsoftJsonPackageVersion>9.0.1</VisualStudio_NewtonsoftJsonPackageVersion>
     <SystemCollectionsImmutablePackageVersion>1.7.0</SystemCollectionsImmutablePackageVersion>
     <!-- Everything below here are Packages only used by test projects -->

--- a/src/Ext.ProjectModel.MsBuild.Sources/MsBuildProjectContextBuilder.cs
+++ b/src/Ext.ProjectModel.MsBuild.Sources/MsBuildProjectContextBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Shared/Cli.Utils/Command.cs
+++ b/src/Shared/Cli.Utils/Command.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using NuGet.Frameworks;
 
 namespace Microsoft.Extensions.Internal
 {
@@ -17,17 +16,17 @@ namespace Microsoft.Extensions.Internal
         private Action<string> _stdErrorHandler;
         private Action<string> _stdOutHandler;
 
-        internal static Command CreateDotNet(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration = "Debug")
+        internal static Command CreateDotNet(string commandName, IEnumerable<string> args)
         {
-            return Create(DotNetMuxer.MuxerPathOrDefault(), new[] { commandName }.Concat(args), framework, configuration);
+            return Create(DotNetMuxer.MuxerPathOrDefault(), new[] { commandName }.Concat(args));
         }
 
-        internal static Command Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration = "Debug")
+        internal static Command Create(string commandName, IEnumerable<string> args)
         {
-            return new Command(commandName, args, framework, configuration);
+            return new Command(commandName, args);
         }
 
-        private Command(string commandName, IEnumerable<string> args, NuGetFramework framework, string configuration)
+        private Command(string commandName, IEnumerable<string> args)
         {
             var psi = new ProcessStartInfo
             {

--- a/src/VS.Web.CG.Contracts/ProjectModel/CommonProjectContext.cs
+++ b/src/VS.Web.CG.Contracts/ProjectModel/CommonProjectContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -69,5 +69,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel
 
         /// <inheritdoc/>
         public string TargetFramework { get; set; }
+
+        public string TargetFrameworkMoniker { get; set; }
     }
 }

--- a/src/VS.Web.CG.Contracts/ProjectModel/IProjectContext.cs
+++ b/src/VS.Web.CG.Contracts/ProjectModel/IProjectContext.cs
@@ -50,6 +50,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel
         string TargetFramework { get; }
 
         /// <summary>
+        /// TargetFrameworkMoniker for the project.
+        /// If the project has multiple frameworks, all of the
+        /// information in the ProjectContext is specific to this
+        /// TargetFramework.
+        /// </summary>
+        string TargetFrameworkMoniker { get; }
+
+        /// <summary>
         /// Full path to config file for the assembly.
         /// Usually <see cref="AssemblyFullPath"/> + ".config"
         /// </summary>

--- a/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
+++ b/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
@@ -10,7 +10,6 @@ using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
-using NuGet.Frameworks;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 {
@@ -39,6 +38,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 
         [Build.Framework.Required]
         public string TargetFramework { get; set; }
+
+        [Build.Framework.Required]
+        public string TargetFrameworkMoniker { get; set; }
 
         [Build.Framework.Required]
         public string Name { get; set; }
@@ -97,7 +99,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
                 RootNamespace = this.RootNamespace,
                 RuntimeConfig = this.ProjectRuntimeConfigFileName,
                 TargetDirectory = this.TargetDirectory,
-                TargetFramework = this.TargetFramework
+                TargetFramework = this.TargetFramework,
+                TargetFrameworkMoniker = this.TargetFrameworkMoniker
             };
 
             var projectReferences = msBuildContext.ProjectReferences;
@@ -118,7 +121,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             if (!string.IsNullOrEmpty(projectAssetsFile) && File.Exists(projectAssetsFile) && !string.IsNullOrEmpty(TargetFramework))
             {
                 //target framework moniker for the current project. We use this to get all targets for said moniker.
-                var targetFrameworkMoniker = NuGetFramework.Parse(TargetFramework)?.DotNetFrameworkName;
+                var targetFrameworkMoniker = TargetFrameworkMoniker;
                 string json = File.ReadAllText(projectAssetsFile);
                 if (!string.IsNullOrEmpty(json) && !string.IsNullOrEmpty(targetFrameworkMoniker))
                 {

--- a/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -30,6 +30,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
   <Target Name="EvaluateProjectInfoForCodeGeneration" DependsOnTargets="$(EvaluateProjectInfoForCodeGenerationDependsOn)">
 
     <ProjectContextWriter TargetFramework ="$(TargetFramework)"
+                          TargetFrameworkMoniker ="$(TargetFrameworkMoniker)"
                           OutputFile ="$(OutputFile)"
                           Name ="$(ProjectName)"
                           ResolvedReferences ="@(ReferencePath)"

--- a/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
+++ b/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
@@ -24,6 +24,5 @@
       <!-- This version needs to line up with what is bundled in MSBuild and Visual Studio -->
       <NoWarn>KRB4002</NoWarn>
     </PackageReference>
-    <PackageReference Include="NuGet.Frameworks" PrivateAssets="All" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Contains utilities used by ASP.NET Core Code Generation packages.</Description>
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet-aspnet-codegenerator/DotNetBuildCommandHelper.cs
+++ b/src/dotnet-aspnet-codegenerator/DotNetBuildCommandHelper.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Internal;
-using NuGet.Frameworks;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
 {
@@ -14,14 +13,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
         internal static BuildResult Build(
             string project,
             string configuration,
-            NuGetFramework framework,
+            string shortFramework,
             string buildBasePath)
         {
             var args = new List<string>()
             {
                 project,
                 "--configuration", configuration,
-                "--framework", framework.GetShortFolderName(),
+                "--framework", shortFramework,
             };
 
             if (buildBasePath != null)
@@ -40,9 +39,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
 
             var command = Command.CreateDotNet(
                     "build",
-                    args,
-                    framework,
-                    configuration: configuration)
+                    args)
                     .OnErrorLine((str) => stdOutMsgs.Add(str))
                     .OnOutputLine((str) => stdErrorMsgs.Add(str));
 

--- a/src/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/src/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Code Generation tool for ASP.NET Core. Contains the dotnet-aspnet-codegenerator command used for generating controllers and views. </Description>
     <TargetFramework>net5.0</TargetFramework>
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/E2E_Test/E2E_Test.Tests.csproj
+++ b/test/E2E_Test/E2E_Test.Tests.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
     <!-- Restore this package as part of build so it's available for test projects -->
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" PrivateAssets="All" />
   </ItemGroup>

--- a/test/Shared/MSBuildProjectStrings.cs
+++ b/test/Shared/MSBuildProjectStrings.cs
@@ -671,6 +671,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
   <Target Name=""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
 
     <ProjectContextWriter TargetFramework =""$(TargetFramework)""
+                          TargetFrameworkMoniker=""$(TargetFrameworkMoniker)""
                           OutputFile =""$(OutputFile)""
                           Name =""$(ProjectName)""
                           ResolvedReferences =""@(ReferencePath)""
@@ -1058,6 +1059,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
   <Target Name = ""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
 
     <ProjectContextWriter TargetFramework = ""$(TargetFramework)""
+                          TargetFrameworkMoniker = ""$(TargetFrameworkMoniker)""
                           OutputFile =""$(OutputFile)""
                           Name =""$(ProjectName)""
                           ResolvedReferences =""@(ReferencePath)""

--- a/test/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating.Compilation;
 using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
 using Moq;
-using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 using IProjectContext = Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel.IProjectContext;

--- a/test/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating.Compilation;
 using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
 using Moq;
-using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 using IProjectContext = Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel.IProjectContext;

--- a/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
                 Assert.True(string.Equals(projectContext.DepsFile, "Test.deps.json", StringComparison.OrdinalIgnoreCase));
                 Assert.True(string.Equals(projectContext.RuntimeConfig, "Test.runtimeconfig.json", StringComparison.OrdinalIgnoreCase));
                 Assert.False(string.IsNullOrEmpty(projectContext.TargetFramework));
+                Assert.False(string.IsNullOrEmpty(projectContext.TargetFrameworkMoniker));
                 Assert.True(projectContext.PackageDependencies.Any());
                 Assert.True(projectContext.CompilationAssemblies.Any());
                 Assert.True(projectContext.PackageDependencies.Where(x => x.Name.Equals("Microsoft.VisualStudio.Web.CodeGeneration.Design")).Any());

--- a/test/VS.Web.CG.MSBuild.Test/TestBase.cs
+++ b/test/VS.Web.CG.MSBuild.Test/TestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
-using NuGet.Frameworks;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 {

--- a/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
+++ b/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
@@ -26,6 +26,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/test/VS.Web.CG.Sources.Test/TestBase.cs
+++ b/test/VS.Web.CG.Sources.Test/TestBase.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.Extensions.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
-using NuGet.Frameworks;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Sources.Test
 {

--- a/test/VS.Web.CG.Templating.Test/TestCompilationService.cs
+++ b/test/VS.Web.CG.Templating.Test/TestCompilationService.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating.Test
         private static ProjectContext CreateProjectContext(string projectPath)
         {
             projectPath = projectPath ?? Directory.GetCurrentDirectory();
-            var framework = NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName();
+            const string framework = "net1.0";
             if (!projectPath.EndsWith(Microsoft.DotNet.ProjectModel.Project.FileName))
             {
                 projectPath = Path.Combine(projectPath, Microsoft.DotNet.ProjectModel.Project.FileName);

--- a/test/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Tests.csproj
+++ b/test/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Tests.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
removing Nuget.Frameworks dependency.
- only use for to get TargetFrameworkMoniker from short folder name.
- can get both properties from design time build