### PR TITLE
replaced check for referencing assemblies

### DIFF
--- a/src/VS.Web.CG.Core/DefaultCodeGeneratorAssemblyProvider.cs
+++ b/src/VS.Web.CG.Core/DefaultCodeGeneratorAssemblyProvider.cs
@@ -13,17 +13,13 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 {
     public class DefaultCodeGeneratorAssemblyProvider : ICodeGeneratorAssemblyProvider
     {
+        //we need this assembly to get the ICodeGenerators and templates. 
+        //instead of looking assemblies referencing "Microsoft,VisualStudio.Web.CodeGeneration",
+        //we just try to find "Microsoft.VisualStudio.Web.CodeGenerators.Mvc."
         private static readonly HashSet<string> _codeGenerationFrameworkAssemblies =
             new HashSet<string>(StringComparer.Ordinal)
             {
-                "Microsoft.VisualStudio.Web.CodeGeneration",
-            };
-        private static readonly HashSet<string> _exclusions =
-            new HashSet<string>(StringComparer.Ordinal)
-            {
-                "Microsoft.VisualStudio.Web.CodeGeneration.Tools",
-                "Microsoft.VisualStudio.Web.CodeGeneration",
-                "Microsoft.VisualStudio.Web.CodeGeneration.Design"
+                "Microsoft.VisualStudio.Web.CodeGenerators.Mvc",
             };
 
         private readonly ICodeGenAssemblyLoadContext _assemblyLoadContext;
@@ -49,16 +45,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             get
             {
                 var list = _codeGenerationFrameworkAssemblies
-                    .SelectMany(_projectContext.GetReferencingPackages)
-                    .Distinct()
-                    .Where(IsCandidateLibrary);
-                return list.Select(lib => _assemblyLoadContext.LoadFromName(new AssemblyName(lib.Name)));
+                    .Where(assembly => _projectContext.GetAssembly(assembly) != null);
+                    
+                return list.Select(lib => _assemblyLoadContext.LoadFromName(new AssemblyName(lib)));
             }
-        }
-
-        private bool IsCandidateLibrary(DependencyDescription library)
-        {
-            return !_exclusions.Contains(library.Name);
         }
     }
 }

--- a/src/VS.Web.CG.Utils/ProjectContextExtensions.cs
+++ b/src/VS.Web.CG.Utils/ProjectContextExtensions.cs
@@ -4,30 +4,28 @@
 using System;
 using System.Linq;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
-using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
 {
     public static class ProjectContextExtensions
     {
+        public const string DllExtension = ".dll";
         public static DependencyDescription GetPackage(this IProjectContext context, string name)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
             Requires.NotNull(context, nameof(context));
-
             return context.PackageDependencies.FirstOrDefault(package => package.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
 
-        public static IEnumerable<DependencyDescription> GetReferencingPackages(this IProjectContext context, string name)
+        public static ResolvedReference GetAssembly(this IProjectContext context, string name)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
             Requires.NotNull(context, nameof(context));
-
+            string assemblyWithExtension = string.Concat(name, ProjectContextExtensions.DllExtension);
             return context
-                .PackageDependencies
-                .Where(package => package
-                    .Dependencies
-                    .Any(dep => dep.Name.Equals(name, StringComparison.OrdinalIgnoreCase)));
+                .CompilationAssemblies
+                .Where(assembly => assembly.Name.Equals(assemblyWithExtension, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault();
         }
     }
 }

--- a/src/VS.Web.CG.Utils/TemplateFoldersUtilities.cs
+++ b/src/VS.Web.CG.Utils/TemplateFoldersUtilities.cs
@@ -67,6 +67,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                     rootFolders.Add(containingProjectPath);
                 }
             }
+            else 
+            {
+                var assembly = projectContext.GetAssembly(containingProject);
+                if (assembly != null)
+                {
+                    rootFolders.Add(GetPackagePathFromAssembly(containingProject, assembly.ResolvedPath));
+                }
+            }
 
             foreach (var rootFolder in rootFolders)
             {
@@ -81,6 +89,19 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                 }
             }
             return templateFolders;
+        }
+
+        public static string GetPackagePathFromAssembly(string assemblyName, string resolvedPath)
+        {
+            if (!string.IsNullOrEmpty(resolvedPath) && !string.IsNullOrEmpty(assemblyName))
+            {
+                string path = Path.GetFullPath(Path.Combine(resolvedPath, @"..\..\..\"));
+                if (Directory.Exists(path))
+                {
+                    return path;
+                }
+            }
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
Tested against VS and CLI projects. 
- allows us to remove some unnecessary dependency code on VS. 