### PR TITLE
removed class atrribute from closing dd tag

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap4/Delete.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap4/Delete.cshtml
@@ -67,7 +67,7 @@
         </dt>
         <dd class = "col-sm-10">
             @@Html.DisplayFor(model => model.@GetValueExpression(navigation).@navigation.DisplayPropertyName)
-        </dd class>
+        </dd>
         }
     }
     @:</dl>


### PR DESCRIPTION
Was causing issues in the Delete page when scaffolded a model. User would have to manually edit the erroneous tag.
Removing it from the template should fix the issue. 
