### PR TITLE
added global_install.sh

### DIFF
--- a/global_install.sh
+++ b/global_install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+VERSION=5.0.0
+DEFAULT_NUPKG_PATH=~/.nuget/packages
+SRC_DIR=$(pwd)
+echo $SRC_DIR
+NUPKG=artifacts/packages/Debug/Shipping/
+
+#kill all dotnet procs
+pkill -f dotnet
+git clean -xdf
+./build.sh 
+dotnet tool uninstall -g dotnet-aspnet-codegenerator 
+cd $DEFAULT_NUPKG_PATH
+rm -rf microsoft.visualstudio.web.codegeneration
+rm -rf microsoft.visualstudio.web.codegeneration.contracts
+rm -rf microsoft.visualstudio.web.codegeneration.core
+rm -rf microsoft.visualstudio.web.codegeneration.design
+rm -rf microsoft.visualstudio.web.codegeneration.entityframeworkcore
+rm -rf microsoft.visualstudio.web.codegeneration.templating
+rm -rf microsoft.visualstudio.web.codegeneration.utils
+rm -rf microsoft.visualstudio.web.codegenerators.mvc
+cd "$OLDPWD"/$NUPKG 
+dotnet tool install -g dotnet-aspnet-codegenerator --add-source $SRC_DIR/$NUPKG  --version $VERSION
+cd "$OLDPWD"


### PR DESCRIPTION
cleans older packages, builds and installs the dotnet-aspnet-codegenerator tool on linux and mac systems. 