### PR TITLE
added lower case check for package paths

### DIFF
--- a/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
+++ b/src/VS.Web.CG.Msbuild/ProjectContextWriter.cs
@@ -212,6 +212,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             if (!string.IsNullOrEmpty(nugetPath) && !string.IsNullOrEmpty(nameAndVersion.Item1) && !string.IsNullOrEmpty(nameAndVersion.Item2))
             {
                 path = Path.Combine(nugetPath, nameAndVersion.Item1, nameAndVersion.Item2);
+                path =  Directory.Exists(path) ? path : Path.Combine(nugetPath, nameAndVersion.Item1.ToLower(), nameAndVersion.Item2);
             }
 
             return path;

--- a/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
         }
 
         [SkippableTheory]
-        [InlineData("C:\\Users\\User\\.nuget\\packages\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\packages\\X.Y.Z\\1.2.3")]
-        [InlineData("C:\\Users\\User\\.nuget\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\X.Y.Z\\1.2.3")]
+        [InlineData("C:\\Users\\User\\.nuget\\packages\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\packages\\x.y.z\\1.2.3")]
+        [InlineData("C:\\Users\\User\\.nuget\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\x.y.z\\1.2.3")]
         [InlineData("C:\\Users\\User\\.nuget\\packages\\", null, null, "")]
         [InlineData("C:\\Users\\User\\.nuget\\packages\\", "X.Y.Z", null, "")]
         [InlineData("C:\\Users\\User\\.nuget\\packages\\", null, "1.2.3", "")]
@@ -60,8 +60,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
         }
 
         [SkippableTheory]
-        [InlineData("C://Users//User//.nuget//packages//", "X.Y.Z", "1.2.3", "C://Users//User//.nuget//packages//X.Y.Z//1.2.3")]
-        [InlineData("C://Users//User//.nuget//", "X.Y.Z", "1.2.3", "C://Users//User//.nuget//X.Y.Z//1.2.3")]
+        [InlineData("C://Users//User//.nuget//packages//", "X.Y.Z", "1.2.3", "C://Users//User//.nuget//packages//x.y.z//1.2.3")]
+        [InlineData("C://Users//User//.nuget//", "X.Y.Z", "1.2.3", "C://Users//User//.nuget//x.y.z//1.2.3")]
         [InlineData("C://Users//User//.nuget//packages//", null, null, "")]
         [InlineData("C://Users//User//.nuget//packages//", "X.Y.Z", null, "")]
         [InlineData("C://Users//User//.nuget//packages//", null, "1.2.3", "")]


### PR DESCRIPTION
- for linux and mac users, if capitalized path ala "Microsoft.VisualStudio..." cannot be found in the nuget folder due to the case-sensitive file system, it will also try to look for "microsoft.visualstudio..."
- going to get ported for 3.1, 5.0 and 6.0-preview1. 