### PR TITLE
added false IsPackable for design tool.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PlatformTarget>AnyCpu</PlatformTarget>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>win-arm</RuntimeIdentifier>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
no need to pack the dotnet-aspnet-codegenerator-design tool for default or other runtimes. 
