### PR TITLE
added create-app-registration command

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/AuthenticationParameters/ApplicationParameters.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/AuthenticationParameters/ApplicationParameters.cs
@@ -107,17 +107,17 @@ namespace Microsoft.DotNet.MSIdentity.AuthenticationParameters
         /// <summary>
         /// The project is a web API.
         /// </summary>
-        public bool IsWebApi { get; set; }
+        public bool? IsWebApi { get; set; }
 
         /// <summary>
         /// The project is a web app.
         /// </summary>
-        public bool IsWebApp { get; set; }
+        public bool? IsWebApp { get; set; }
 
         /// <summary>
         /// The project is a blazor web assembly.
         /// </summary>
-        public bool IsBlazorWasm { get; set; }
+        public bool? IsBlazorWasm { get; set; }
 
         /// <summary>
         /// The app calls Microsoft Graph.

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
@@ -74,8 +74,10 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
         private static void PostProcessWebUris(ProjectAuthenticationSettings projectAuthenticationSettings)
         {
-            bool isBlazorWasm = projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.HasValue && projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.Value
-                && projectAuthenticationSettings.ApplicationParameters.IsWebApp.HasValue && !projectAuthenticationSettings.ApplicationParameters.IsWebApp.Value;
+            bool isBlazorWasm = projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.HasValue &&
+                                projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.Value &&
+                                projectAuthenticationSettings.ApplicationParameters.IsWebApp.HasValue &&
+                                !projectAuthenticationSettings.ApplicationParameters.IsWebApp.Value;
             string callbackPath = projectAuthenticationSettings.ApplicationParameters.CallbackPath ?? "/signin-oidc";
             if (isBlazorWasm)
             {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
@@ -74,8 +74,8 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
         private static void PostProcessWebUris(ProjectAuthenticationSettings projectAuthenticationSettings)
         {
-            bool isBlazorWasm = projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm
-                && !projectAuthenticationSettings.ApplicationParameters.IsWebApp;
+            bool isBlazorWasm = projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.HasValue && projectAuthenticationSettings.ApplicationParameters.IsBlazorWasm.Value
+                && projectAuthenticationSettings.ApplicationParameters.IsWebApp.HasValue && !projectAuthenticationSettings.ApplicationParameters.IsWebApp.Value;
             string callbackPath = projectAuthenticationSettings.ApplicationParameters.CallbackPath ?? "/signin-oidc";
             if (isBlazorWasm)
             {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
 
         GraphServiceClient? _graphServiceClient;
 
-        internal async Task<ApplicationParameters?> CreateNewApp(
+        internal async Task<ApplicationParameters?> CreateNewAppAsync(
             TokenCredential tokenCredential,
             ApplicationParameters applicationParameters,
             IConsoleLogger consoleLogger,
@@ -49,11 +49,11 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
                 };
             }
 
-            if (applicationParameters.IsWebApp.HasValue && applicationParameters.IsWebApp.Value)
+            if (applicationParameters.IsWebApp.GetValueOrDefault())
             {
                 AddWebAppPlatform(applicationParameters, application);
             }
-            else if (applicationParameters.IsBlazorWasm.HasValue && applicationParameters.IsBlazorWasm.Value)
+            else if (applicationParameters.IsBlazorWasm.GetValueOrDefault())
             {
                 // In .NET Core 3.1, Blazor uses MSAL.js 1.x (web redirect URIs)
                 // whereas in .NET 5.0, Blazor uses MSAL.js 2.x (SPA redirect URIs)
@@ -100,14 +100,14 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
 
             // For web API, we need to know the appId of the created app to compute the Identifier URI, 
             // and therefore we need to do it after the app is created (updating the app)
-            if (applicationParameters.IsWebApi.HasValue && applicationParameters.IsWebApi.Value
+            if (applicationParameters.IsWebApi.GetValueOrDefault()
                 && createdApplication.Api != null
                 && (createdApplication.IdentifierUris == null || !createdApplication.IdentifierUris.Any()))
             {
                 await ExposeScopes(graphServiceClient, createdApplication);
 
                 // Blazorwasm hosted: add permission to server web API from client SPA
-                if (applicationParameters.IsBlazorWasm.HasValue && applicationParameters.IsBlazorWasm.Value)
+                if (applicationParameters.IsBlazorWasm.GetValueOrDefault())
                 {
                     await AddApiPermissionFromBlazorwasmHostedSpaToServerApi(
                         graphServiceClient,
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
                 // Add password credentials
                 if (applicationParameters.CallsMicrosoftGraph || applicationParameters.CallsDownstreamApi)
                 {
-                    await AddPasswordCredentials(
+                    await AddPasswordCredentialsAsync(
                         graphServiceClient,
                         createdApplication.Id,
                         effectiveApplicationParameters,
@@ -332,7 +332,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
         /// <param name="createdApplication"></param>
         /// <param name="effectiveApplicationParameters"></param>
         /// <returns></returns>
-        internal static async Task<string> AddPasswordCredentials(
+        internal static async Task<string> AddPasswordCredentialsAsync(
             GraphServiceClient graphServiceClient,
             string applicatonId,
             ApplicationParameters effectiveApplicationParameters,
@@ -617,7 +617,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
             };
         }
 
-        internal async Task<bool> Unregister(TokenCredential tokenCredential, ApplicationParameters applicationParameters)
+        internal async Task<bool> UnregisterAsync(TokenCredential tokenCredential, ApplicationParameters applicationParameters)
         {
             bool unregisterSuccess = false;
             var graphServiceClient = GetGraphServiceClient(tokenCredential);

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -473,7 +473,14 @@ namespace Microsoft.DotNet.MSIdentity
             if (currentApplicationParameters == null && !ProvisioningToolOptions.Unregister)
             {
                 currentApplicationParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewApp(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
-                ConsoleLogger.LogMessage($"Created app {currentApplicationParameters.ApplicationDisplayName} - {currentApplicationParameters.ClientId}. ");
+                if (currentApplicationParameters != null)
+                {
+                    ConsoleLogger.LogMessage($"Created app {currentApplicationParameters.ApplicationDisplayName} - {currentApplicationParameters.ClientId}. ");
+                }
+                else
+                {
+                    ConsoleLogger.LogMessage("Failed to create Azure AD/AD B2C app registration", LogMessageType.Error);
+                }
             }
             return currentApplicationParameters;
         }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.MSIdentity
             ApplicationParameters? resultAppParameters = null;
             if (applicationParameters != null)
             {
-                resultAppParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewApp(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
+                resultAppParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewAppAsync(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
                 if (resultAppParameters != null && !string.IsNullOrEmpty(resultAppParameters.ClientId))
                 {
                     ConsoleLogger.LogMessage($"Created app {resultAppParameters.ApplicationDisplayName} - {resultAppParameters.ClientId}.");
@@ -472,7 +472,7 @@ namespace Microsoft.DotNet.MSIdentity
 
             if (currentApplicationParameters == null && !ProvisioningToolOptions.Unregister)
             {
-                currentApplicationParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewApp(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
+                currentApplicationParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewAppAsync(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
                 if (currentApplicationParameters != null)
                 {
                     ConsoleLogger.LogMessage($"Created app {currentApplicationParameters.ApplicationDisplayName} - {currentApplicationParameters.ClientId}. ");
@@ -540,7 +540,7 @@ namespace Microsoft.DotNet.MSIdentity
 
         private async Task UnregisterApplication(TokenCredential tokenCredential, ApplicationParameters applicationParameters)
         {
-            bool unregisterSuccess = await MicrosoftIdentityPlatformApplicationManager.Unregister(tokenCredential, applicationParameters);
+            bool unregisterSuccess = await MicrosoftIdentityPlatformApplicationManager.UnregisterAsync(tokenCredential, applicationParameters);
             JsonResponse jsonResponse = new JsonResponse(CommandName);
             if (unregisterSuccess)
             {
@@ -596,7 +596,7 @@ namespace Microsoft.DotNet.MSIdentity
             {
                 var graphServiceClient = MicrosoftIdentityPlatformApplicationManager.GetGraphServiceClient(tokenCredential);
 
-                string? password = await MicrosoftIdentityPlatformApplicationManager.AddPasswordCredentials(
+                string? password = await MicrosoftIdentityPlatformApplicationManager.AddPasswordCredentialsAsync(
                         graphServiceClient,
                         applicationParameters.GraphEntityId,
                         applicationParameters,
@@ -650,7 +650,7 @@ namespace Microsoft.DotNet.MSIdentity
                     //need ClientId and Microsoft.Graph.Application.Id(GraphEntityId)
                     if (graphServiceClient != null && !string.IsNullOrEmpty(applicationParameters.ClientId) && !string.IsNullOrEmpty(applicationParameters.GraphEntityId))
                     {
-                        await MicrosoftIdentityPlatformApplicationManager.AddPasswordCredentials(
+                        await MicrosoftIdentityPlatformApplicationManager.AddPasswordCredentialsAsync(
                             graphServiceClient,
                             applicationParameters.GraphEntityId,
                             applicationParameters,

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/Commands.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/Commands.cs
@@ -5,11 +5,11 @@ namespace Microsoft.DotNet.MSIdentity.Tool
         public const string LIST_AAD_APPS_COMMAND = "--list-aad-apps";
         public const string LIST_SERVICE_PRINCIPALS_COMMAND = "--list-service-principals";
         public const string LIST_TENANTS_COMMAND = "--list-tenants";
-        public const string ADD_CLIENT_SECRET = "--add-client-secret";
         public const string REGISTER_APPLICATIION_COMMAND = "--register-app";
-        public const string UPDATE_APPLICATION_COMMAND = "--update-app-registration";
-        public const string UPDATE_PROJECT_COMMAND = "--update-project";
         public const string UNREGISTER_APPLICATION_COMMAND = "--unregister-app";
-        public const string VALIDATE_APP_PARAMS_COMMAND = "--validate-app-params";
+        public const string ADD_CLIENT_SECRET = "--create-client-secret";
+        public const string CREATE_APP_REGISTRATION_COMMAND = "--create-app-registration";
+        public const string UPDATE_APP_REGISTRATION_COMMAND = "--update-app-registration";
+        public const string UPDATE_PROJECT_COMMAND = "--update-project";
     }
 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/ConsoleLogger.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/ConsoleLogger.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.MSIdentity.Tool
+{
+    internal class ConsoleLogger : IConsoleLogger
+    {
+        private bool _jsonOutput;
+
+        public ConsoleLogger(bool jsonOutput = false)
+        {
+            _jsonOutput = jsonOutput;
+            Console.OutputEncoding = Encoding.UTF8;
+        }
+
+        public void LogMessage(string? message, LogMessageType level, bool removeNewLine = false)
+        {
+            //if json output is enabled, don't write to console at all.
+            if (!_jsonOutput)
+            {
+                switch (level)
+                {
+                    case LogMessageType.Error:
+                        if (removeNewLine)
+                        {
+                            Console.Error.Write(message);
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine(message);
+                        }
+                        break;
+                    case LogMessageType.Information:
+                        if (removeNewLine)
+                        {
+                            Console.Write(message);
+                        }
+                        else
+                        {
+                            Console.WriteLine(message);
+                        }
+                        break;
+                }
+            }
+        }
+
+        public void LogJsonMessage(JsonResponse jsonMessage)
+        {
+            if (_jsonOutput)
+            {
+                Console.WriteLine(jsonMessage.ToJsonString());
+            }
+        }
+
+        public void LogMessage(string? message, bool removeNewLine = false)
+        {
+            LogMessage(message, LogMessageType.Information, removeNewLine);
+        }
+    }
+}

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/IConsoleLogger.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/IConsoleLogger.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.MSIdentity.Tool
+{
+    public interface IConsoleLogger
+    {
+        void LogMessage(string? message, LogMessageType level, bool removeNewLine = false);
+        void LogMessage(string? message, bool removeNewLine = false);
+        void LogJsonMessage(JsonResponse jsonMessage);
+    }
+
+    public enum LogMessageType
+    {
+        Error,
+        Information
+    }
+}

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/JsonResponse.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/JsonResponse.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace Microsoft.DotNet.MSIdentity.Tool
 {
-    internal class JsonResponse
+    public class JsonResponse
     {
         public string Command { get; }
         public string? State { get; set; }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 {
     internal class MsAADTool : IMsAADTool
     {
+        internal IConsoleLogger ConsoleLogger { get; }
         private ProvisioningToolOptions ProvisioningToolOptions { get; set; }
         private string CommandName { get; }
         public IGraphServiceClient GraphServiceClient { get; set; }
@@ -27,6 +28,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             TokenCredential = new MsalTokenCredential(ProvisioningToolOptions.TenantId, ProvisioningToolOptions.Username);
             GraphServiceClient = new GraphServiceClient(new TokenCredentialAuthenticationProvider(TokenCredential));
             AzureManagementAPI = new AzureManagementAuthenticationProvider(TokenCredential);
+            ConsoleLogger = new ConsoleLogger(ProvisioningToolOptions.Json);
         }
 
         public async Task<ApplicationParameters?> Run()

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/ProvisioningToolOptions.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/ProvisioningToolOptions.cs
@@ -21,6 +21,11 @@ namespace Microsoft.DotNet.MSIdentity.Tool
         public string? AppSettingsFilePath { get; set; }
 
         ///<summary>
+        /// Display name for Azure AD/AD B2C app registration
+        ///</summary>
+        public string? AppDisplayName { get; set; }
+
+        ///<summary>
         /// Web redirect URIs.
         ///</summary>
         public IList<string> RedirectUris { get; set; } = new List<string>();
@@ -168,7 +173,8 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 AppSettingsFilePath = AppSettingsFilePath,
                 WebApiClientId = WebApiClientId,
                 AppIdUri = AppIdUri,
-                Json = Json
+                Json = Json,
+                AppDisplayName = AppDisplayName
             };
         }
     }

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
@@ -179,7 +179,10 @@ namespace Tests
 
         private void AssertAuthSettings(ProjectAuthenticationSettings authenticationSettings, bool isB2C = false)
         {
-            Assert.True(authenticationSettings.ApplicationParameters.IsWebApi || authenticationSettings.ApplicationParameters.IsWebApp || authenticationSettings.ApplicationParameters.IsBlazorWasm);
+            bool IsWebApi = authenticationSettings.ApplicationParameters.IsWebApi.HasValue && authenticationSettings.ApplicationParameters.IsWebApi.Value;
+            bool IsWebApp = authenticationSettings.ApplicationParameters.IsWebApp.HasValue && authenticationSettings.ApplicationParameters.IsWebApp.Value;
+            bool IsBlazorWasm = authenticationSettings.ApplicationParameters.IsBlazorWasm.HasValue && authenticationSettings.ApplicationParameters.IsBlazorWasm.Value;
+            Assert.True(IsWebApi || IsWebApp || IsBlazorWasm);
             
             if (isB2C)
             {

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.UnitTests.Tests/MicrosoftIdentityPlatformApplicationManagerTests.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.UnitTests.Tests/MicrosoftIdentityPlatformApplicationManagerTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.MSIdentity.UnitTests.Tests
+{
+    public class MicrosoftIdentityPlatformApplicationManagerTests
+    {
+        [Theory]
+        [MemberData(nameof(UriList))]
+        public void ValidateUrisTests(List<string> urisToValidate, List<string> validUris)
+        {
+            var validatedUris = MicrosoftIdentityPlatformApplicationManager.ValidateUris(urisToValidate);
+            var areEquivalent = (validUris.Count == validatedUris.Count) && !validatedUris.Except(validUris).Any();
+            Assert.True(areEquivalent);
+        }
+
+        public static IEnumerable<object[]> UriList =>
+            new List<object[]>
+            {
+                new object[] {
+                    new List<string> {
+                                        "https://localhost:5001/",
+                                        "https://localhost:5002/get",
+                                        "http://localhost:5001/",
+                                        "https://www.microsoft.com/",
+                                        "http://www.azure.com",
+                                        "https://www.testapi.com/get/{id}",
+                                        "http://www.skype.com",
+                                        "http://127.0.0.1/get",
+                                        "http://loopback/post",
+                                        "badstring",
+                                        null,
+                                        string.Empty,
+                                        ""
+                                     },
+
+                    new List<string> {
+                                        "https://localhost:5001/",
+                                        "https://localhost:5002/get",
+                                        "http://localhost:5001/",
+                                        "https://www.microsoft.com/",
+                                        "https://www.testapi.com/get/{id}",
+                                        "http://127.0.0.1/get",
+                                        "http://loopback/post",
+                                     }
+                }
+            };
+    }
+}

--- a/tools/dotnet-msidentity/MsAADToolFactory.cs
+++ b/tools/dotnet-msidentity/MsAADToolFactory.cs
@@ -4,7 +4,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
     {
         internal static IMsAADTool CreateTool(string commandName, ProvisioningToolOptions provisioningToolOptions)
         {
-            switch(commandName)
+            switch (commandName)
             {
                 case Commands.LIST_AAD_APPS_COMMAND:
                 case Commands.LIST_SERVICE_PRINCIPALS_COMMAND:


### PR DESCRIPTION
Initial Draft

- added --create-app-registration
  - allows to create Azure AD/AD B2C app registrations. 
  - TODO : change object being passed back?
- renamed --add-client-secret --> --create-client-secret
- added ConsoleLogger to simplify outputting to console when --json is enabled
- changed --project-path to have path to the .csproj file instead of folder with the .csproj file.
- added ValidateUrisTest unit test
