### PR TITLE
updating install-msidentity.cmd to work from any folder

### DIFF
--- a/scripts/install-msidentity.cmd
+++ b/scripts/install-msidentity.cmd
@@ -1,6 +1,9 @@
 set VERSION=1.0.0-dev
+set NUPKG=artifacts\packages\Debug\Shipping\
+
+pushd %~dp0
+call cd ..
 set SRC_DIR=%cd%
-set NUPKG=artifacts/packages/Debug/Shipping/
 
 call taskkill /f /im dotnet.exe
 call rd /Q /S artifacts
@@ -8,7 +11,5 @@ call rd /Q /S artifacts
 call dotnet build MSIdentityScaffolding.slnf
 call dotnet pack MSIdentityScaffolding.slnf
 call dotnet tool uninstall -g Microsoft.dotnet-msidentity
-
-call cd  %SRC_DIR%/%NUPKG% 
 call dotnet tool install -g Microsoft.dotnet-msidentity --add-source %SRC_DIR%\%NUPKG% --version %VERSION%
-call cd %SRC_DIR%
+popd


### PR DESCRIPTION
I updated the `install-msidentity.cmd` to work from any folder. How it was written required the user to be in the `scaffolding` folder.