### PR TITLE
Propagate correct tenant ID from command line args

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.MSIdentity
             // Get developer credentials
             TokenCredential tokenCredential = GetTokenCredential(
                 ProvisioningToolOptions,
-                projectSettings.ApplicationParameters.EffectiveTenantId ?? projectSettings.ApplicationParameters.EffectiveDomain);
+                ProvisioningToolOptions.TenantId ?? projectSettings.ApplicationParameters.EffectiveTenantId ?? projectSettings.ApplicationParameters.EffectiveDomain);
 
             //for now, update project command is handlded seperately.
             //TODO: switch case to handle all the different commands.


### PR DESCRIPTION
When calling the CLI tool from VS, the tenant ID parameter sent in was not being used for creating app registrations, updating app registrations, etc. So in certain cases the CLI tool will infer the wrong tenant ID from the VS project rather than using the tenant that the VS user has currently selected. This change makes it so the CLI tool uses the tenant ID parameter sent in from VS for these operations.