### PR TITLE
Log exception for provisioning failures

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -231,12 +231,13 @@ namespace Microsoft.DotNet.MSIdentity
                         ConsoleLogger.LogMessage(failMessage, LogMessageType.Error);
                     }
                 }
-                catch (Exception ex)
+                catch (ServiceException ex)
                 {
+                    string jsonErrorContent = $"{ex.Error?.Code ?? string.Empty} {Environment.NewLine} {ex.Error?.Message ?? string.Empty}";
                     JsonResponse jsonResponse = new JsonResponse(CommandName)
                     {
                         State = State.Fail,
-                        Content = ex.Message
+                        Content = jsonErrorContent
                     };
 
                     ConsoleLogger.LogJsonMessage(jsonResponse);

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -218,15 +218,29 @@ namespace Microsoft.DotNet.MSIdentity
             ApplicationParameters? resultAppParameters = null;
             if (applicationParameters != null)
             {
-                resultAppParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewAppAsync(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
-                if (resultAppParameters != null && !string.IsNullOrEmpty(resultAppParameters.ClientId))
+                try
                 {
-                    ConsoleLogger.LogMessage(string.Format(Resources.CreatedAppRegistration, resultAppParameters.ApplicationDisplayName, resultAppParameters.ClientId));
+                    resultAppParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewAppAsync(tokenCredential, applicationParameters, ConsoleLogger, CommandName);
+                    if (resultAppParameters != null && !string.IsNullOrEmpty(resultAppParameters.ClientId))
+                    {
+                        ConsoleLogger.LogMessage(string.Format(Resources.CreatedAppRegistration, resultAppParameters.ApplicationDisplayName, resultAppParameters.ClientId));
+                    }
+                    else
+                    {
+                        string failMessage = Resources.FailedToCreateApp;
+                        ConsoleLogger.LogMessage(failMessage, LogMessageType.Error);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    string failMessage = Resources.FailedToCreateApp;
-                    ConsoleLogger.LogMessage(failMessage, LogMessageType.Error);
+                    JsonResponse jsonResponse = new JsonResponse(CommandName)
+                    {
+                        State = State.Fail,
+                        Content = ex.Message
+                    };
+
+                    ConsoleLogger.LogJsonMessage(jsonResponse);
+                    ConsoleLogger.LogMessage(ex.Message, LogMessageType.Error);
                 }
             }
             return resultAppParameters;


### PR DESCRIPTION
Adding logging for exceptions when Provisioning fails, for example due to exceeding the directory quota. 