### PR TITLE
add more AddDbContext in Program.cs if one exists

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
@@ -12,7 +12,6 @@
             },
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
-              "CheckBlock": "builder.Services.AddDbContext",
               "Block": "builder.Services.AddDbContext<{0}>(options =>\r\n    options.{0}(connectionString));\""
             },
             {


### PR DESCRIPTION
Now we can add multiple .AddDbContext for SqlServer and Sqlite in Program.cs in identity scenarios.
