### PR TITLE
adding if conditions for debug and release jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,41 +77,26 @@ stages:
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
         strategy:
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              Build_Release:
-                _BuildConfig: Release
-                # PRs or external builds are not signed.
-                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                  _PublishType: none
-                  _SignType: test
-                  _DotNetPublishToBlobFeed : false
-                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                  _PublishType: blob
-                  _SignType: real
-                  _DotNetPublishToBlobFeed : true
-                  # _Script: eng\validate-sdk.cmd
-                  # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            matrix:
+          matrix:
+            Build_Release:
+              _BuildConfig: Release
+              # PRs or external builds are not signed.
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                _PublishType: none
+                _SignType: test
+                _DotNetPublishToBlobFeed : false
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                _PublishType: blob
+                _SignType: real
+                _DotNetPublishToBlobFeed : true
+                # _Script: eng\validate-sdk.cmd
+                # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
               Build_Debug:
                 _BuildConfig: Debug
                 _PublishType: none
                 _SignType: test
                 _DotNetPublishToBlobFeed : false
-              Build_Release:
-                _BuildConfig: Release
-                # PRs or external builds are not signed.
-                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                  _PublishType: none
-                  _SignType: test
-                  _DotNetPublishToBlobFeed : false
-                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                  _PublishType: blob
-                  _SignType: real
-                  _DotNetPublishToBlobFeed : true
-                  # _Script: eng\validate-sdk.cmd
-                  # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
         steps:
         - checkout: self
           clean: true
@@ -127,16 +112,12 @@ stages:
         pool:
           name: Hosted macOS
         strategy:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            matrix:
+          matrix:
+            release_configuration:
+              _BuildConfig: Release
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
               debug_configuration:
                 _BuildConfig: Debug
-              release_configuration:
-                _BuildConfig: Release
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              release_configuration:
-                _BuildConfig: Release
         steps:
         - checkout: self
           clean: true
@@ -153,15 +134,12 @@ stages:
         container: LinuxContainer
         strategy:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            matrix:
+          matrix:
+            release_configuration:
+              _BuildConfig: Release
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
               debug_configuration:
                 _BuildConfig: Debug
-              release_configuration:
-                _BuildConfig: Release
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              release_configuration:
-                _BuildConfig: Release
         steps:
         - checkout: self
           clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,25 +77,41 @@ stages:
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
         strategy:
-          matrix:
-            Build_Debug:
-              _BuildConfig: Debug
-              _PublishType: none
-              _SignType: test
-              _DotNetPublishToBlobFeed : false
-            Build_Release:
-              _BuildConfig: Release
-              # PRs or external builds are not signed.
-              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              Build_Release:
+                _BuildConfig: Release
+                # PRs or external builds are not signed.
+                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                  _PublishType: none
+                  _SignType: test
+                  _DotNetPublishToBlobFeed : false
+                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                  _PublishType: blob
+                  _SignType: real
+                  _DotNetPublishToBlobFeed : true
+                  # _Script: eng\validate-sdk.cmd
+                  # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
                 _PublishType: none
                 _SignType: test
                 _DotNetPublishToBlobFeed : false
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                _PublishType: blob
-                _SignType: real
-                _DotNetPublishToBlobFeed : true
-                # _Script: eng\validate-sdk.cmd
-                # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
+              Build_Release:
+                _BuildConfig: Release
+                # PRs or external builds are not signed.
+                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                  _PublishType: none
+                  _SignType: test
+                  _DotNetPublishToBlobFeed : false
+                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                  _PublishType: blob
+                  _SignType: real
+                  _DotNetPublishToBlobFeed : true
+                  # _Script: eng\validate-sdk.cmd
+                  # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
         steps:
         - checkout: self
           clean: true
@@ -111,11 +127,16 @@ stages:
         pool:
           name: Hosted macOS
         strategy:
-          matrix:
-            debug_configuration:
-              _BuildConfig: Debug
-            release_configuration:
-              _BuildConfig: Release
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              debug_configuration:
+                _BuildConfig: Debug
+              release_configuration:
+                _BuildConfig: Release
+          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
         steps:
         - checkout: self
           clean: true
@@ -131,11 +152,16 @@ stages:
           name: Hosted Ubuntu 1604
         container: LinuxContainer
         strategy:
-          matrix:
-            debug_configuration:
-              _BuildConfig: Debug
-            release_configuration:
-              _BuildConfig: Release
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              debug_configuration:
+                _BuildConfig: Debug
+              release_configuration:
+                _BuildConfig: Release
+          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
         steps:
         - checkout: self
           clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,7 +133,6 @@ stages:
           name: Hosted Ubuntu 1604
         container: LinuxContainer
         strategy:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
           matrix:
             release_configuration:
               _BuildConfig: Release


### PR DESCRIPTION
Added if statements for Windows, macOS, and Linux build jobs.
- on public pipelines, build both Debug and Release configurations.
- on internal (signed) pipelines, build only Release configurations.
