### PR TITLE
added check for bootstrap 4

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -310,6 +310,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             {
                 return ContentVersionBootstrap3;
             }
+            else if (string.Equals(razorGeneratorModel.BootstrapVersion, "4", StringComparison.Ordinal))
+            {
+                return ContentVersionBootstrap4;
+            }
             else
             {
                 throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, razorGeneratorModel.BootstrapVersion, string.Join(", ", ValidBootstrapVersions)));


### PR DESCRIPTION
Fixing error when upgrading a .NET Core 3.1/5 app to .NET 6.
- Bootstrap 4 is not upgraded to Bootstrap 5, kept at 4 and no errors are thrown. 
- If users wants to upgrade to Bootstrap 5, we expect it to do it themselves or create a new .NET 6 app. 
