### PR TITLE
disable nullable in identity templates

### DIFF
--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -4,8 +4,7 @@ set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/
 call taskkill /f /im dotnet.exe
 call rd /Q /S artifacts
-call dotnet build Scaffolding.slnf
-call dotnet pack Scaffolding.slnf
+call build
 call dotnet tool uninstall -g dotnet-aspnet-codegenerator 
 
 call cd %DEFAULT_NUPKG_PATH%

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.AccessDenied.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.AccessDenied.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace @(Model.Namespace).Areas.Identity.Pages.Account

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ConfirmEmail.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ConfirmEmail.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Linq;
 using System.Text;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ConfirmEmailChange.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ConfirmEmailChange.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ExternalLogin.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ExternalLogin.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ForgotPassword.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ForgotPassword.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ForgotPasswordConfirmation.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ForgotPasswordConfirmation.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Lockout.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Lockout.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Login.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Login.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.LoginWith2fa.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.LoginWith2fa.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.LoginWithRecoveryCode.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.LoginWithRecoveryCode.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Logout.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Logout.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Register.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Register.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -40,8 +42,6 @@ namespace @thisNamespace
     {
         private readonly SignInManager<@(Model.UserClass)> _signInManager;
         private readonly UserManager<@(Model.UserClass)> _userManager;
-        private readonly IUserStore<@(Model.UserClass)> _userStore;
-        private readonly IUserEmailStore<@(Model.UserClass)> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
 
@@ -53,8 +53,6 @@ namespace @thisNamespace
             IEmailSender emailSender)
         {
             _userManager = userManager;
-            _userStore = userStore;
-            _emailStore = GetEmailStore();
             _signInManager = signInManager;
             _logger = logger;
             _emailSender = emailSender;
@@ -114,7 +112,6 @@ namespace @thisNamespace
             public string ConfirmPassword { get; set; }
         }
 
-
         public async Task OnGetAsync(string returnUrl = null)
         {
             ReturnUrl = returnUrl;
@@ -127,23 +124,18 @@ namespace @thisNamespace
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)
             {
-                var user = CreateUser();
-
-                await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
-                await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+                var user = new @(Model.UserClass) { UserName = Input.Email, Email = Input.Email };
                 var result = await _userManager.CreateAsync(user, Input.Password);
-
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User created a new account with password.");
 
-                    var userId = await _userManager.GetUserIdAsync(user);
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
                     var callbackUrl = Url.Page(
                         "/Account/ConfirmEmail",
                         pageHandler: null,
-                        values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                        values: new { area = "Identity", userId = user.Id, code = code, returnUrl = returnUrl },
                         protocol: Request.Scheme);
 
                     await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
@@ -167,29 +159,6 @@ namespace @thisNamespace
 
             // If we got this far, something failed, redisplay form
             return Page();
-        }
-
-        private @(Model.UserClass) CreateUser()
-        {
-            try
-            {
-                return Activator.CreateInstance<@(Model.UserClass)>();
-            }
-            catch
-            {
-                throw new InvalidOperationException($"Can't create an instance of '{nameof(@(Model.UserClass))}'. " +
-                    $"Ensure that '{nameof(@(Model.UserClass))}' is not an abstract class and has a parameterless constructor, or alternatively " +
-                    $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
-            }
-        }
-
-        private IUserEmailStore<@(Model.UserClass)> GetEmailStore()
-        {
-            if (!_userManager.SupportsUserEmail)
-            {
-                throw new NotSupportedException("The default UI requires a user store with email support.");
-            }
-            return (IUserEmailStore<@(Model.UserClass)>)_userStore;
         }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Register.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.Register.cs.cshtml
@@ -42,6 +42,8 @@ namespace @thisNamespace
     {
         private readonly SignInManager<@(Model.UserClass)> _signInManager;
         private readonly UserManager<@(Model.UserClass)> _userManager;
+        private readonly IUserStore<@(Model.UserClass)> _userStore;
+        private readonly IUserEmailStore<@(Model.UserClass)> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
 
@@ -53,6 +55,8 @@ namespace @thisNamespace
             IEmailSender emailSender)
         {
             _userManager = userManager;
+            _userStore = userStore;
+            _emailStore = GetEmailStore();
             _signInManager = signInManager;
             _logger = logger;
             _emailSender = emailSender;
@@ -112,6 +116,7 @@ namespace @thisNamespace
             public string ConfirmPassword { get; set; }
         }
 
+
         public async Task OnGetAsync(string returnUrl = null)
         {
             ReturnUrl = returnUrl;
@@ -124,18 +129,23 @@ namespace @thisNamespace
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)
             {
-                var user = new @(Model.UserClass) { UserName = Input.Email, Email = Input.Email };
+                var user = CreateUser();
+
+                await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+                await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
                 var result = await _userManager.CreateAsync(user, Input.Password);
+
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User created a new account with password.");
 
+                    var userId = await _userManager.GetUserIdAsync(user);
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
                     var callbackUrl = Url.Page(
                         "/Account/ConfirmEmail",
                         pageHandler: null,
-                        values: new { area = "Identity", userId = user.Id, code = code, returnUrl = returnUrl },
+                        values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
                         protocol: Request.Scheme);
 
                     await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
@@ -159,6 +169,29 @@ namespace @thisNamespace
 
             // If we got this far, something failed, redisplay form
             return Page();
+        }
+
+        private @(Model.UserClass) CreateUser()
+        {
+            try
+            {
+                return Activator.CreateInstance<@(Model.UserClass)>();
+            }
+            catch
+            {
+                throw new InvalidOperationException($"Can't create an instance of '{nameof(@(Model.UserClass))}'. " +
+                    $"Ensure that '{nameof(@(Model.UserClass))}' is not an abstract class and has a parameterless constructor, or alternatively " +
+                    $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
+            }
+        }
+
+        private IUserEmailStore<@(Model.UserClass)> GetEmailStore()
+        {
+            if (!_userManager.SupportsUserEmail)
+            {
+                throw new NotSupportedException("The default UI requires a user store with email support.");
+            }
+            return (IUserEmailStore<@(Model.UserClass)>)_userStore;
         }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.RegisterConfirmation.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.RegisterConfirmation.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResendEmailConfirmation.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResendEmailConfirmation.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResetPassword.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResetPassword.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResetPasswordConfirmation.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Account.ResetPasswordConfirmation.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ChangePassword.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ChangePassword.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.DeletePersonalData.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.DeletePersonalData.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Disable2fa.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Disable2fa.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 @{

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.DownloadPersonalData.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.DownloadPersonalData.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Email.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Email.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.EnableAuthenticator.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.EnableAuthenticator.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ExternalLogins.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ExternalLogins.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.GenerateRecoveryCodes.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.GenerateRecoveryCodes.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Index.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.Index.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Encodings.Web;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ManageNavPages.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ManageNavPages.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ResetAuthenticator.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ResetAuthenticator.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 @{

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.SetPassword.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.SetPassword.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ShowRecoveryCodes.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.ShowRecoveryCodes.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 @{
     var namespaceSet = new System.Collections.Generic.SortedSet<string>(
         new string[]

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.TwoFactorAuthentication.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Account/Manage/Account.Manage.TwoFactorAuthentication.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 @{

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Error.cs.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/Pages/Error.cs.cshtml
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase;
+#nullable disable
+
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;


### PR DESCRIPTION
Adding #nullable disable tag to all identity bootstrap 5 templates.
- gets rids of warnings
- Model.State is valid instead of invalid.

Files/templates will be nullable compatible in the .NET 7 timeframe.