### PR TITLE
removing node type check, we shouldn't care what type of node.

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
@@ -535,7 +535,9 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
             
             if (!string.IsNullOrEmpty(insertAfterBlock) && !string.IsNullOrEmpty(change.Block))
             {
-                var insertAfterNode = modifiedBlockSyntaxNode.DescendantNodes().Where(node => node is ExpressionStatementSyntax && node.ToString().Contains(insertAfterBlock)).FirstOrDefault();
+                var insertAfterNode =
+                    modifiedBlockSyntaxNode.DescendantNodes().Where(node => node != null && node.ToString().Contains(insertAfterBlock)).FirstOrDefault() ??
+                    modifiedBlockSyntaxNode.DescendantNodes().Where(node => node != null && node.ToString().Contains(ProjectModifierHelper.TrimStatement(insertAfterBlock))).FirstOrDefault();
                 if (insertAfterNode != null)
                 {
                     var leadingTrivia = insertAfterNode.GetLeadingTrivia();


### PR DESCRIPTION
Shouldn't matter what type of node, ExpressionStatementSyntax or InvocationStatementSyntax etc.