### PR TITLE
not adding/forcing Account.Logout.cshtml if blazor project already adding it

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModel2.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModel2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
@@ -11,5 +11,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         public string ContentVersion { get; set; }
 
         public bool IsRazorPagesProject { get; set; }
+
+        public bool IsBlazorProject { get; set; }
     }
 }


### PR DESCRIPTION
Fix for [#38640](https://github.com/dotnet/aspnetcore/issues/38640). 
If Blazor project w/ individual auth adds a custom Accout\Logout.cshtml file, don't try to add/suggest overwrite for that file.

