### PR TITLE
Adding #nullable disable to scaffolding templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ stages:
           
       - job: Linux
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: macOS-11
         container: LinuxContainer
         strategy:
           matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
 
       - job: OSX
         pool:
-          name: Hosted macOS
+          vmImage: macOS-11
         strategy:
           matrix:
             release_configuration:
@@ -130,7 +130,7 @@ stages:
           
       - job: Linux
         pool:
-          vmImage: macOS-11
+          vmImage: ubuntu-18.04
         container: LinuxContainer
         strategy:
           matrix:

--- a/src/Scaffolding/VS.Web.CG.Design/CodeGenCommandExecutor.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/CodeGenCommandExecutor.cs
@@ -74,7 +74,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
         {
             var applicationInfo = new ApplicationInfo(
                 projectInformation.ProjectName,
-                Path.GetDirectoryName(projectInformation.ProjectFullPath));
+                Path.GetDirectoryName(projectInformation.ProjectFullPath),
+                new RoslynWorkspaceHelper(projectInformation.ProjectFullPath));
             serviceProvider.Add<IProjectContext>(projectInformation);
             serviceProvider.Add<IApplicationInfo>(applicationInfo);
             serviceProvider.Add<ICodeGenAssemblyLoadContext>(new DefaultAssemblyLoadContext());

--- a/src/Scaffolding/VS.Web.CG.EFCore/NewDbContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/NewDbContextTemplateModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 {
     public class NewDbContextTemplateModel
     {
-        public NewDbContextTemplateModel(string dbContextName, ModelType modelType, ModelType programType)
+        public NewDbContextTemplateModel(string dbContextName, ModelType modelType, ModelType programType, bool nullableEnabled)
         {
             if (dbContextName == null)
             {
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             ProgramTypeName = programType.Name;
             ProgramNamespace = programType.Namespace;
             RequiredNamespaces = new HashSet<string>();
-
+            NullableEnabled = nullableEnabled;
             var classNameModel = new ClassNameModel(dbContextName);
 
             DbContextTypeName = classNameModel.ClassName;
@@ -58,5 +58,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         public string ProgramNamespace { get; private set; }
 
         public HashSet<string> RequiredNamespaces { get; private set; }
+        public bool NullableEnabled { get; set; }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.EFCore/Templates/DbContext/NewLocalDbContext.cshtml
+++ b/src/Scaffolding/VS.Web.CG.EFCore/Templates/DbContext/NewLocalDbContext.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic;
 using System;
 using System.Collections.Generic;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.Project;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
@@ -79,6 +80,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                 //Todo: Pluralize model name
                 controllerGeneratorModel.ControllerName = modelTypeAndContextModel.ModelType.Name + Constants.ControllerSuffix;
             }
+
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
             var namespaceName = string.IsNullOrEmpty(controllerGeneratorModel.ControllerNamespace)
                 ? GetDefaultControllerNamespace(controllerGeneratorModel.RelativeFolderPath)
                 : controllerGeneratorModel.ControllerNamespace;
@@ -88,7 +94,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                 AreaName = _areaName,
                 UseAsync = controllerGeneratorModel.UseAsync, // This is no longer used for controllers with context.
                 ControllerNamespace = namespaceName,
-                ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata
+                ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata,
+                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
             };
 
             await CodeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, GetTemplateName(controllerGeneratorModel), TemplateFolders, templateModel);

--- a/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextTemplateModel.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
         public string AreaName { get; set; }
 
         public bool UseAsync { get; set; }
+        public bool NullableEnabled { get; set; }
 
         public string ControllerNamespace { get; set; }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration;
@@ -272,6 +273,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
             }
 
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+
             RazorPageWithContextTemplateModel2 templateModel = new RazorPageWithContextTemplateModel2(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName)
             {
                 NamespaceName = namespaceName,
@@ -289,7 +295,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 JQueryVersion = "1.10.2", //Todo
                 BootstrapVersion = razorGeneratorModel.BootstrapVersion,
                 ContentVersion = DetermineContentVersion(razorGeneratorModel),
-                UseSqlite = razorGeneratorModel.UseSqlite
+                UseSqlite = razorGeneratorModel.UseSqlite,
+                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
             };
 
             return templateModel;

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public string DbContextNamespace { get; private set; }
 
         public ModelType ModelType { get; private set; }
+        public bool NullableEnabled { get; set; }
 
         public string ModelTypeName
         {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic;
 @using System.Linq;
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/CreatePageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/CreatePageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DeletePageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DeletePageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DetailsPageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DetailsPageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/EditPageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/EditPageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/EmptyPageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/EmptyPageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/ListPageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/ListPageModel.cshtml
@@ -1,4 +1,11 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+if (@Model.NullableEnabled)
+{
+@:#nullable disable
+
+}
+}
 @using System.Collections.Generic
 @using System.Linq
 using System;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap5/Details.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/ViewGenerator/Bootstrap5/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
 @using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 @using System.Collections.Generic
 @using System.Linq
@@ -76,7 +76,7 @@
     string pkName = GetPrimaryKeyName();
     if (pkName != null)
     {
-    @:<a asp-action="Edit" asp-route-id="@@Model.@pkName">Edit</a> |
+    @:<a asp-action="Edit" asp-route-id="@@Model?.@pkName">Edit</a> |
     @:<a asp-action="Index">Back to List</a>
     }
     else

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGeneratorTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGeneratorTemplateModel.cs
@@ -25,5 +25,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
         public IModelMetadata ModelMetadata { get; set; }
 
         public string JQueryVersion { get; set; }
+        public bool NullableEnabled { get; set; }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration;
-using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 {
@@ -174,6 +174,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             bool isLayoutSelected = !viewGeneratorModel.PartialView &&
                 (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
 
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
             ViewGeneratorTemplateModel templateModel = new ViewGeneratorTemplateModel()
             {
                 ViewDataTypeName = modelTypeAndContextModel?.ModelType?.FullName,
@@ -184,7 +188,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 IsPartialView = viewGeneratorModel.PartialView,
                 ReferenceScriptLibraries = viewGeneratorModel.ReferenceScriptLibraries,
                 ModelMetadata = modelTypeAndContextModel?.ContextProcessingResult?.ModelMetadata,
-                JQueryVersion = "1.10.2" //Todo
+                JQueryVersion = "1.10.2", //Todo,
+                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
             };
 
             return templateModel;

--- a/src/Scaffolding/VS.Web.CG.Utils/DotNet/ApplicationInfo.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/DotNet/ApplicationInfo.cs
@@ -1,19 +1,20 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
 {
     public class ApplicationInfo : IApplicationInfo
     {
-        public ApplicationInfo(string appName, string appBasePath)
-            : this(appName, appBasePath, "Debug")
+        public ApplicationInfo(string appName, string appBasePath, RoslynWorkspaceHelper workspaceHelper)
+            : this(appName, appBasePath, "Debug", workspaceHelper)
         {
 
         }
 
-        public ApplicationInfo(string appName, string appBasePath, string appConfiguration)
+        public ApplicationInfo(string appName, string appBasePath, string appConfiguration, RoslynWorkspaceHelper workspaceHelper)
         {
             if (appName == null)
             {
@@ -30,7 +31,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
             ApplicationName = appName;
             ApplicationBasePath = appBasePath;
             ApplicationConfiguration = appConfiguration;
+            WorkspaceHelper = workspaceHelper;
         }
+
         public string ApplicationBasePath
         {
             get; private set;
@@ -42,6 +45,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
         }
 
         public string ApplicationConfiguration
+        {
+            get; private set;
+        }
+
+        public RoslynWorkspaceHelper WorkspaceHelper
         {
             get; private set;
         }

--- a/src/Scaffolding/VS.Web.CG.Utils/DotNet/IApplicationInfo.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/DotNet/IApplicationInfo.cs
@@ -1,8 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using System;
-using System.Collections.Generic;
+using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
 {
@@ -11,5 +9,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
         string ApplicationBasePath { get; }
         string ApplicationName { get; }
         string ApplicationConfiguration { get; }
+        RoslynWorkspaceHelper WorkspaceHelper { get;  }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
-using Microsoft.VisualStudio.Web.CodeGeneration.Utils.Workspaces;
 using PInfo = Microsoft.CodeAnalysis.ProjectInfo;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
@@ -39,7 +38,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             {
                 MSBuildLocator.RegisterDefaults();
             }
-            var projReferenceInformation = RoslynWorkspaceHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
+            RoslynWorkspaceHelper roslynHelper = new RoslynWorkspaceHelper(projectInformation.ProjectFullPath);
+            var projReferenceInformation = roslynHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
 
             if (projReferenceInformation != null && projReferenceInformation.Any())
             {

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
@@ -1,23 +1,71 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 
-namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils.Workspaces
+namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
 {
-    internal static class RoslynWorkspaceHelper
+    public class RoslynWorkspaceHelper
     {
-        internal static IEnumerable<ProjectReferenceInformation> GetProjectReferenceInformation(IEnumerable<string> projectReferenceStrings)
+        private string _projectPath;
+        private Project _project;
+        public Project MsBuildProject
+        {
+            get
+            {
+                if (_project == null)
+                {
+                    _project = new Project(_projectPath);
+                }
+                return _project;
+            }
+        }
+
+        public RoslynWorkspaceHelper(string projectPath)
+        {
+            _projectPath = projectPath;
+        }
+
+        public Dictionary<string, string> GetMsBuildProperties(IEnumerable<string> properties)
+        {
+            Dictionary<string, string> msbuildProperties = new Dictionary<string, string>();
+            if (properties != null && properties.Any())
+            {
+                foreach (string property in properties)
+                {
+                    string value = GetMsBuildProperty(property);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        msbuildProperties.Add(property, value);
+                    }
+                }
+            }
+            return msbuildProperties;
+        }
+
+        public string GetMsBuildProperty(string property)
+        {
+            if (!string.IsNullOrEmpty(property))
+            {
+                string value = MsBuildProject?.GetProperty(property)?.EvaluatedValue;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        internal IEnumerable<ProjectReferenceInformation> GetProjectReferenceInformation(IEnumerable<string> projectReferenceStrings)
         {
             List<ProjectReferenceInformation> projectReferenceInformation = new List<ProjectReferenceInformation>();
             if (projectReferenceStrings != null && projectReferenceStrings.Any())
-            {   
+            {
                 foreach (string projectReferenceString in projectReferenceStrings)
                 {
-                    var currentProject = GetMsBuildProject(Path.GetFullPath(projectReferenceString));
+                    var currentProject = new Project(Path.GetFullPath(projectReferenceString));
                     if (currentProject != null)
                     {
                         projectReferenceInformation.Add(GetProjectInformation(currentProject));
@@ -27,12 +75,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils.Workspaces
             return projectReferenceInformation;
         }
 
-        private static Project GetMsBuildProject(string projectPath)
-        {
-            return new Project(projectPath);
-        }
-
-        private static ProjectReferenceInformation GetProjectInformation(Project project)
+        private ProjectReferenceInformation GetProjectInformation(Project project)
         {
             var compileItems = project.GetItems("Compile").Select(i => i.EvaluatedInclude);
             var fullPath = project.FullPath;

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
 
         private CodeModelService GetCodeModelService(string path, string applicationName)
         {
-            _appInfo = new ApplicationInfo(applicationName, Path.GetDirectoryName(path), "Debug");
+            _appInfo = new ApplicationInfo(applicationName, Path.GetDirectoryName(path), null);
             _logger = new ConsoleLogger();
             _projectContext = GetProjectInformation(path);
             _workspace = new RoslynWorkspace(_projectContext);

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
 
         private EntityFrameworkServices GetEfServices(string path, string applicationName, bool useSqlite)
         {
-            _appInfo = new ApplicationInfo(applicationName, Path.GetDirectoryName(path), "Debug");
+            _appInfo = new ApplicationInfo(applicationName, Path.GetDirectoryName(path), null);
             _logger = new ConsoleLogger();
             _packageInstaller = new Mock<IPackageInstaller>();
             _serviceProvider = new Mock<IServiceProvider>();

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/ControllerGeneratorBaseTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/ControllerGeneratorBaseTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
             _codeGenActionService = new Mock<ICodeGeneratorActionsService>();
             _serviceProvider = new Mock<IServiceProvider>();
             _logger = new ConsoleLogger();
-            _applicationInfo = new ApplicationInfo("TestApp", "..", "Debug");
+            _applicationInfo = new ApplicationInfo("TestApp", "..", null);
         }
 
         [Fact]

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                     UseSqlite = false
                 };
 
-                var applicationInfo = new ApplicationInfo("TestApp", "Sample");
+                var applicationInfo = new ApplicationInfo("TestApp", "Sample", null);
 
                 var builder = new IdentityGeneratorTemplateModelBuilder(
                     commandLineModel,
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             IdentityGeneratorCommandLineModel commandLineModel = new IdentityGeneratorCommandLineModel();
             commandLineModel.Layout = existingLayoutFile;
 
-            IApplicationInfo applicationInfo = new ApplicationInfo("test", LayoutFileLocationTestProjectBasePath);
+            IApplicationInfo applicationInfo = new ApplicationInfo("test", LayoutFileLocationTestProjectBasePath, null);
             CommonProjectContext context = new CommonProjectContext();
             context.ProjectFullPath = LayoutFileLocationTestProjectBasePath;
             context.ProjectName = "TestProject";

--- a/test/Scaffolding/VS.Web.CG.Sources.Test/ApplicationInfoTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Sources.Test/ApplicationInfoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -14,7 +14,7 @@ namespace ConsoleApplication
         [Fact]
         public void ApplicationEnvironment_Test()
         {
-            _applicationInfo = new ApplicationInfo("TestApplication", Directory.GetCurrentDirectory());
+            _applicationInfo = new ApplicationInfo("TestApplication", Directory.GetCurrentDirectory(), null);
             Assert.Equal(Directory.GetCurrentDirectory(), _applicationInfo.ApplicationBasePath);
             Assert.Equal("TestApplication", _applicationInfo.ApplicationName);
         }


### PR DESCRIPTION
- Checking for `<Nullable>enable/disable</Nullable>` MsBuild property.
- Adding `#nullable disable` to EF Scaffolding templates if nullable is enabled for the project.
- Helps with current warnings.
- Will be handled with newer templates in .NET 7 timeline likely.