### PR TITLE
[WiP] Make sure ActionInvoker throws with InnerException

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
+++ b/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                         ex = ex.GetBaseException();
                     }
 
-                    throw new InvalidOperationException(ex.Message);
+                    throw new InvalidOperationException(ex.Message, ex);
                 }
 
                 return 0;

--- a/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
@@ -50,6 +50,43 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Core.Test
             Assert.True(invokedModel.BoolProperty);
         }
 
+                [Fact]
+        public void ActionInvoker_Throws_With_Inner_Exception()
+        {
+            //Arrange
+            bool methodCalled = false;
+            CodeGeneratorModel invokedModel = null;
+
+            var codeGenInstance = new CodeGeneratorSample((model) =>
+            {
+                throw new NotImplementedException ("This action is intentionally not implemented.");
+            });
+            
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var generatorMock = new Mock<CodeGeneratorDescriptor>(typeof(CodeGeneratorSample).GetTypeInfo(),
+                serviceProviderMock.Object);
+
+            generatorMock
+                .SetupGet(cd => cd.CodeGeneratorInstance)
+                .Returns(codeGenInstance);
+            generatorMock
+                .SetupGet(cd => cd.Name)
+                .Returns(typeof(CodeGeneratorSample).Name);
+
+            var actionDescriptor = new ActionDescriptor(generatorMock.Object,
+                typeof(CodeGeneratorSample).GetMethod("GenerateCode")); //This is not a perfect unit test as the arrange is using actual instance rather than a mock
+
+            var actionInvoker = new ActionInvoker(actionDescriptor);
+
+            //Act
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(
+                () => actionInvoker.Execute("CodeGeneratorSample StringValuePassed --BoolProperty".Split(' ')));
+
+            //Assert
+            Assert.IsType<NotImplementedException>(ex.InnerException);
+         }
+
         private class CodeGeneratorSample
         {
             private Action<CodeGeneratorModel> _generateCodeImpl;

--- a/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
@@ -54,12 +54,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Core.Test
         public void ActionInvoker_Throws_With_Inner_Exception()
         {
             //Arrange
-            bool methodCalled = false;
-            CodeGeneratorModel invokedModel = null;
-
+            const string NOT_IMPLEMENTED_MESSAGE = "This action is intentionally not implemented.";
             var codeGenInstance = new CodeGeneratorSample((model) =>
             {
-                throw new NotImplementedException ("This action is intentionally not implemented.");
+                throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
             });
             
             var serviceProviderMock = new Mock<IServiceProvider>();
@@ -84,7 +82,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Core.Test
                 () => actionInvoker.Execute("CodeGeneratorSample StringValuePassed --BoolProperty".Split(' ')));
 
             //Assert
-            Assert.IsType<NotImplementedException>(ex.InnerException);
+            Assert.Equals(NOT_IMPLEMENTED_MESSAGE, ex.InnerException.Message);
          }
 
         private class CodeGeneratorSample

--- a/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Core.Test/ActionInvokerTests.cs
@@ -77,12 +77,12 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Core.Test
             var actionInvoker = new ActionInvoker(actionDescriptor);
 
             //Act
-            InvalidOperationException ex =
+            var ex =
                 Assert.Throws<InvalidOperationException>(
                 () => actionInvoker.Execute("CodeGeneratorSample StringValuePassed --BoolProperty".Split(' ')));
 
             //Assert
-            Assert.Equals(NOT_IMPLEMENTED_MESSAGE, ex.InnerException.Message);
+            Assert.Equal(NOT_IMPLEMENTED_MESSAGE, ex.InnerException.Message);
          }
 
         private class CodeGeneratorSample


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

1. `ActionInvoker` constructs its `InvalidOperationException` chained with the caught exception.
2. Add a test to check that this is the case.

Does not fix #1726.
