### PR TITLE
Do not intercept output from MSBuild

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/MsBuild/MsBuildProjectContextBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/MsBuild/MsBuildProjectContextBuilder.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Extensions.ProjectModel
         public IProjectContext Build()
         {
             var errors = new List<string>();
-            var output = new List<string>();
             var tmpFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var result = Command.CreateDotNet(
                 "msbuild",
@@ -47,7 +46,6 @@ namespace Microsoft.Extensions.ProjectModel
                     $"/p:OutputFile={tmpFile};CodeGenerationTargetLocation={_targetLocation};Configuration={_configuration}"
                 })
                 .OnErrorLine(e => errors.Add(e))
-                .OnOutputLine(o => output.Add(o))
                 .Execute();
 
             if (result.ExitCode != 0)


### PR DESCRIPTION
Do not intercept output from MSBuild
Fixes #1738

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

Class `MsBuildProjectContextBuilder` is not being tested.  Moreover, we have no control over what `MSBuild` writes to standard output, so there is nothing to assert.
