### PR TITLE
Include projectReferenceString in exception

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
+using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
 {

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
@@ -64,6 +64,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             if (projectReferenceStrings != null && projectReferenceStrings.Any())
             {
                 foreach (string projectReferenceString in projectReferenceStrings)
+                try
                 {
                     var currentProject = new Project(Path.GetFullPath(projectReferenceString));
                     if (currentProject != null)
@@ -71,7 +72,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
                         projectReferenceInformation.Add(GetProjectInformation(currentProject));
                     }
                 }
-            }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Could not load information for project { projectReferenceString }", ex);
+                }
+            } 
             return projectReferenceInformation;
         }
 


### PR DESCRIPTION
`RoslynWorkspaceHelper.GetProjectReferenceInformation`: when `new Project` throws an [Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception), wrap it with an [InvalidOperationException](https://docs.microsoft.com/en-us/dotnet/api/system.invalidoperationexception) holding the value of `projectReferenceString`.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


