### PR TITLE
OnExecute: log inner exceptions

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
+++ b/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                 }
                 catch (Exception ex)
                 {
-                    throw new InvalidOperationException(string.Format(MessageStrings.ModelCreationFailed, ex.Message));
+                    throw new InvalidOperationException(string.Format(MessageStrings.ModelCreationFailed, ex.Message), ex);
                 }
 
                 foreach (var param in ActionDescriptor.Parameters)
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                         ex = ex.GetBaseException();
                     }
 
-                    throw new InvalidOperationException(ex.Message);
+                    throw new InvalidOperationException(ex.Message, ex);
                 }
 
                 return 0;

--- a/src/Scaffolding/VS.Web.CG.Design/Program.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/Program.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
                         }
                         ex = ex .InnerException;
                     }
-                    while (!(ex is null))
+                    while (!(ex is null));
                 }
                 return exitCode;
                 

--- a/src/Scaffolding/VS.Web.CG.Design/Program.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/Program.cs
@@ -90,14 +90,18 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
                 }
                 catch(Exception ex)
                 {
-                    logger.LogMessage(Resources.GenericErrorMessage, LogMessageLevel.Error);
-                    logger.LogMessage(ex.Message, LogMessageLevel.Error);
-                    logger.LogMessage(ex.StackTrace, LogMessageLevel.Trace);
-                    if (!logger.IsTracing)
+                    do
                     {
-                        logger.LogMessage(Resources.EnableTracingMessage);
+                        logger.LogMessage(Resources.GenericErrorMessage, LogMessageLevel.Error);
+                        logger.LogMessage(ex.Message, LogMessageLevel.Error);
+                        logger.LogMessage(ex.StackTrace, LogMessageLevel.Trace);
+                        if (!logger.IsTracing)
+                        {
+                            logger.LogMessage(Resources.EnableTracingMessage);
+                        }
+                        ex = ex .InnerException;
                     }
-
+                    while (!(ex is null))
                 }
                 return exitCode;
                 

--- a/src/Scaffolding/VS.Web.CG/CodeGenCommand.cs
+++ b/src/Scaffolding/VS.Web.CG/CodeGenCommand.cs
@@ -50,12 +50,17 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             }
             catch (Exception ex)
             {
-                while (ex is TargetInvocationException)
+                do
                 {
+                    while (ex is TargetInvocationException)
+                    {
+                        ex = ex.InnerException;
+                    }
+                    _logger.LogMessage(ex.Message, LogMessageLevel.Error);
+                    _logger.LogMessage(ex.StackTrace);
                     ex = ex.InnerException;
                 }
-                _logger.LogMessage(ex.Message, LogMessageLevel.Error);
-                _logger.LogMessage(ex.StackTrace);
+                while (ex is Exception);
             }
             return 0;
         }


### PR DESCRIPTION
Log the whole [exception chain](https://docs.microsoft.com/en-us/dotnet/api/system.exception.innerexception) when an [Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception) gets caught by a program.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


