### PR TITLE
Code updates for blazor server Downstream API option

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeFiles/Blazor/Server/CallWebApi.razor
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeFiles/Blazor/Server/CallWebApi.razor
@@ -1,0 +1,48 @@
+@page "/callwebapi"
+
+@using Microsoft.Identity.Web
+
+@inject IDownstreamWebApi downstreamAPI
+@inject MicrosoftIdentityConsentAndConditionalAccessHandler ConsentHandler
+
+<h1>Call an API</h1>
+
+<p>This component demonstrates fetching data from a Web API.</p>
+
+@if (apiResult == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <h2>API Result</h2>
+    @apiResult
+}
+
+@code {
+    private HttpResponseMessage response;
+    private string apiResult;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            response = await downstreamAPI.CallWebApiForUserAsync(
+                    "DownstreamApi",
+                    options => options.RelativePath = "");
+
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                apiResult = await response.Content.ReadAsStringAsync();
+            }
+            else
+            {
+                apiResult = "Failed to call the web API";
+            }
+        }
+        catch (Exception ex)
+        {
+            ConsentHandler.HandleException(ex);
+        }
+    }
+}

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_blazorserver.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_blazorserver.json
@@ -3,6 +3,7 @@
   "Files": [
     {
       "FileName": "Program.cs",
+      "Options": [ "MinimalApp" ],
       "Methods": {
         "Global": {
           "CodeChanges": [
@@ -153,6 +154,13 @@
           "Options": [
             "MicrosoftGraph"
           ]
+        },
+        {
+          "Block": "</NavLink>\r\n        </div>\r\n        <div class=\"nav-item px-3\">\r\n            <NavLink class=\"nav-link\" href=\"callwebapi\">\r\n                <span class=\"oi oi-list-rich\" aria-hidden=\"true\"></span> Call Web API\r\n            </NavLink>\r\n        </div>\r\n    </nav>\r\n</div>",
+          "ReplaceSnippet": "</NavLink>\r\n        </div>\r\n    </nav>\r\n</div>",
+          "Options": [
+            "DownstreamApi"
+          ]
         }
       ]
     },
@@ -161,6 +169,13 @@
       "AddFilePath": "Pages/ShowProfile.razor",
       "Options": [
         "MicrosoftGraph"
+      ]
+    },
+    {
+      "FileName": "CallWebApi.razor",
+      "AddFilePath": "Pages/CallWebApi.razor",
+      "Options": [
+        "DownstreamApi"
       ]
     }
   ]

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapi.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapi.json
@@ -3,6 +3,7 @@
   "Files": [
     {
       "FileName": "Startup.cs",
+      "Options": [ "NonMinimalApp" ],
       "Methods": {
         "Configure": {
           "Parameters": [ "IApplicationBuilder", "IWebHostEnvironment" ],
@@ -36,6 +37,7 @@
     },
     {
       "FileName": "Program.cs",
+      "Options": [ "MinimalApp" ],
       "Methods": {
         "Global": {
           "CodeChanges": [

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
@@ -3,6 +3,7 @@
   "Files": [
     {
       "FileName": "Startup.cs",
+      "Options": [ "NonMinimalApp" ],
       "Methods": {
         "Configure": {
           "Parameters": [ "IApplicationBuilder", "IWebHostEnvironment" ],
@@ -70,6 +71,7 @@
     },
     {
       "FileName": "Program.cs",
+      "Options": [ "MinimalApp" ],
       "Methods": {
         "Global": {
           "CodeChanges": [

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
             var razorChanges = file?.RazorChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, toolOptions));
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, razorChanges);
-            await ProjectModifierHelper.UpdateDocument(fileName, editedDocument, _consoleLogger);
+            await ProjectModifierHelper.UpdateDocument(editedDocument, _consoleLogger);
         }
 
         internal async Task ModifyCshtmlFile(string fileName, CodeFile cshtmlFile, CodeAnalysis.Project project, CodeChangeOptions options)
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                             var filteredCodeFiles = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
                             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeFiles);
                             //replace the document
-                            await ProjectModifierHelper.UpdateDocument(fileName, editedDocument, _consoleLogger);
+                            await ProjectModifierHelper.UpdateDocument(editedDocument, _consoleLogger);
                         }
                     }
                 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
             var razorChanges = file?.RazorChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, toolOptions));
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, razorChanges);
-            await ProjectModifierHelper.UpdateDocument(editedDocument, fileName, _consoleLogger);
+            await ProjectModifierHelper.UpdateDocument(fileName, editedDocument, _consoleLogger);
         }
 
         internal async Task ModifyCshtmlFile(string fileName, CodeFile cshtmlFile, CodeAnalysis.Project project, CodeChangeOptions options)
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                             var filteredCodeFiles = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
                             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeFiles);
                             //replace the document
-                            await ProjectModifierHelper.UpdateDocument(editedDocument, fileName, _consoleLogger);
+                            await ProjectModifierHelper.UpdateDocument(fileName, editedDocument, _consoleLogger);
                         }
                     }
                 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -79,40 +79,17 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
         private async Task HandleCodeFileAsync(CodeFile file, CodeAnalysis.Project project, CodeChangeOptions options)
         {
-            if (string.IsNullOrEmpty(file.FileName))
+            if (file.FileName.EndsWith(".cs"))
             {
-                return;
+                await ModifyCsFile(file, project, options);
             }
-
-            if (!string.IsNullOrEmpty(file.AddFilePath))
+            else if (file.FileName.EndsWith(".cshtml"))
             {
-                AddFile(file);
-                return;
+                await ModifyCshtmlFile(file, project, options);
             }
-
-            var fileName = file.FileName.Equals("Startup.cs", StringComparison.OrdinalIgnoreCase)
-                    ? await ProjectModifierHelper.GetStartupClass(_toolOptions.ProjectPath, project)
-                    : file.FileName;
-
-            if (fileName.Equals("Program.cs"))
+            else if (file.FileName.EndsWith(".razor"))
             {
-                // only modify Program.cs file if it's a minimal hosting app (as we made changes to the Startup.cs file).
-                if (options.IsMinimalApp)
-                {
-                    await ModifyProgramCs(file, project, options);
-                }
-            }
-            else if (fileName.EndsWith(".cs"))
-            {
-                await ModifyCsFile(fileName, file, project, options);
-            }
-            else if (fileName.EndsWith(".cshtml"))
-            {
-                await ModifyCshtmlFile(fileName, file, project, options);
-            }
-            else if (fileName.EndsWith(".razor"))
-            {
-                await ModifyRazorFile(fileName, file, project, options);
+                await ModifyRazorFile(file, project, options);
             }
         }
 
@@ -155,11 +132,135 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 Directory.CreateDirectory(fileDir);
                 File.WriteAllText(filePath, codeFileString);
             }
+            return;
         }
 
-        internal async Task ModifyRazorFile(string fileName, CodeFile file, CodeAnalysis.Project project, CodeChangeOptions toolOptions)
+        internal async Task ModifyCsFile(CodeFile file, CodeAnalysis.Project project, CodeChangeOptions options)
         {
-            var document = project.Documents.Where(d => d.Name.EndsWith(fileName)).FirstOrDefault();
+            if (file.FileName.Equals("Startup.cs"))
+            {
+                // Startup class file name may be different
+                file.FileName = await ProjectModifierHelper.GetStartupClass(project) ?? file.FileName;
+            }
+
+            var fileDoc = project.Documents.Where(d => d.Name.Equals(file.FileName)).FirstOrDefault();
+            if (fileDoc is null)
+            {
+                return;
+            }
+
+            //get the file document to get the document root for editing.
+            DocumentEditor documentEditor = await DocumentEditor.CreateAsync(fileDoc);
+            if (documentEditor is null)
+            {
+                return;
+            }
+
+            DocumentBuilder documentBuilder = new DocumentBuilder(documentEditor, file, _consoleLogger);
+            var modifiedRoot = file.FileName.Equals("Program.cs")
+                ? ModifyProgramCsRoot(documentBuilder, options, file)
+                : ModifyRoot(documentBuilder, options, file);
+
+            if (documentEditor.OriginalRoot != null && modifiedRoot != null)
+            {
+                documentEditor.ReplaceNode(documentEditor.OriginalRoot, modifiedRoot);
+            }
+
+            await documentBuilder.WriteToClassFileAsync(fileDoc.FilePath);
+        }
+
+        private static CompilationUnitSyntax? ModifyProgramCsRoot(DocumentBuilder documentBuilder, CodeChangeOptions options, CodeFile file)
+        {
+            var newRoot = documentBuilder.AddUsings(options);
+            var variableDict = ProjectModifierHelper.GetBuilderVariableIdentifier(newRoot.Members);
+            var globalChanges = file.Methods.TryGetValue("Global", out var globalMethod);
+            if (globalMethod != null)
+            {
+                var filteredCodeChanges = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
+                foreach (var change in filteredCodeChanges)
+                {
+                    //Modify CodeSnippet to have correct variable identifiers present.
+                    var formattedChange = ProjectModifierHelper.FormatCodeSnippet(change, variableDict);
+                    newRoot = DocumentBuilder.AddGlobalStatements(formattedChange, newRoot);
+                }
+            }
+
+            return newRoot;
+        }
+
+        private static CompilationUnitSyntax? ModifyRoot(DocumentBuilder documentBuilder, CodeChangeOptions options, CodeFile file)
+        {
+            var newRoot = documentBuilder.AddUsings(options);
+            var namespaceNode = newRoot?.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
+            FileScopedNamespaceDeclarationSyntax? fileScopedNamespace = null;
+            if (namespaceNode is null)
+            {
+                fileScopedNamespace = newRoot?.Members.OfType<FileScopedNamespaceDeclarationSyntax>()?.FirstOrDefault();
+            }
+
+            string className = ProjectModifierHelper.GetClassName(file.FileName);
+            //get classNode. All class changes are done on the ClassDeclarationSyntax and then that node is replaced using documentEditor.
+            var classNode =
+                namespaceNode?.DescendantNodes()?.Where(node =>
+                    node is ClassDeclarationSyntax cds &&
+                    cds.Identifier.ValueText.Contains(className)).FirstOrDefault() ??
+                fileScopedNamespace?.DescendantNodes()?.Where(node =>
+                    node is ClassDeclarationSyntax cds &&
+                    cds.Identifier.ValueText.Contains(className)).FirstOrDefault();
+
+            if (classNode is ClassDeclarationSyntax classDeclarationSyntax)
+            {
+                var modifiedClassDeclarationSyntax = classDeclarationSyntax;
+
+                //add class properties
+                modifiedClassDeclarationSyntax = documentBuilder.AddProperties(modifiedClassDeclarationSyntax, options);
+                //add class attributes
+                modifiedClassDeclarationSyntax = documentBuilder.AddClassAttributes(modifiedClassDeclarationSyntax, options);
+
+                //add code snippets/changes.
+                if (file.Methods != null && file.Methods.Any())
+                {
+                    modifiedClassDeclarationSyntax = documentBuilder.AddCodeSnippets(modifiedClassDeclarationSyntax, options);
+                    modifiedClassDeclarationSyntax = documentBuilder.EditMethodTypes(modifiedClassDeclarationSyntax, options);
+                    modifiedClassDeclarationSyntax = documentBuilder.AddMethodParameters(modifiedClassDeclarationSyntax, options);
+                }
+                //replace class node with all the updates.
+#pragma warning disable CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
+                newRoot = newRoot.ReplaceNode(classDeclarationSyntax, modifiedClassDeclarationSyntax);
+#pragma warning restore CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
+            }
+
+            return newRoot;
+        }
+
+        internal async Task ModifyCshtmlFile(CodeFile file, CodeAnalysis.Project project, CodeChangeOptions options)
+        {
+            var fileDoc = project.Documents.Where(d => d.Name.Equals(file.FileName)).FirstOrDefault();
+            if (fileDoc is null || file.Methods is null || !file.Methods.Any())
+            {
+                return;
+            }
+
+            //add code snippets/changes.
+            var globalChanges = file.Methods.TryGetValue("Global", out var globalMethod);
+            if (globalMethod != null)
+            {
+                var filteredCodeChanges = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
+                var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeChanges);
+                //replace the document
+                await ProjectModifierHelper.UpdateDocument(fileDoc, editedDocument, _consoleLogger);
+            }
+        }
+
+        internal async Task ModifyRazorFile(CodeFile file, CodeAnalysis.Project project, CodeChangeOptions toolOptions)
+        {
+            if (!string.IsNullOrEmpty(file.AddFilePath))
+            {
+                AddFile(file);
+                return;
+            }
+
+            var document = project.Documents.Where(d => d.Name.EndsWith(file.FileName)).FirstOrDefault();
             if (document is null)
             {
                 return;
@@ -168,134 +269,6 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             var razorChanges = file?.RazorChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, toolOptions));
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, razorChanges);
             await ProjectModifierHelper.UpdateDocument(document, editedDocument, _consoleLogger);
-        }
-
-        internal async Task ModifyCshtmlFile(string fileName, CodeFile cshtmlFile, CodeAnalysis.Project project, CodeChangeOptions options)
-        {
-            string? filePath = Directory.EnumerateFiles(_toolOptions.ProjectPath, fileName, SearchOption.AllDirectories).FirstOrDefault();
-
-            if (!string.IsNullOrEmpty(filePath))
-            {
-                var fileDoc = project.Documents.Where(d => d.Name.Equals(filePath)).FirstOrDefault();
-                if (fileDoc != null)
-                {
-                    //add code snippets/changes.
-                    if (cshtmlFile.Methods != null && cshtmlFile.Methods.Any())
-                    {
-                        var globalChanges = cshtmlFile.Methods.TryGetValue("Global", out var globalMethod);
-                        if (globalMethod != null)
-                        {
-                            var filteredCodeFiles = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
-                            var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeFiles);
-                            //replace the document
-                            await ProjectModifierHelper.UpdateDocument(fileDoc, editedDocument, _consoleLogger);
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Modify Program.cs file to add changes specified in the CodeFile.
-        /// </summary>
-        /// <param name="programCsFile"></param>
-        /// <param name="project"></param>
-        /// <returns></returns>
-        internal async Task ModifyProgramCs(CodeFile programCsFile, CodeAnalysis.Project project, CodeChangeOptions toolOptions)
-        {
-            string? programCsFilePath = Directory.EnumerateFiles(_toolOptions.ProjectPath, "Program.cs", SearchOption.AllDirectories).FirstOrDefault();
-            if (!string.IsNullOrEmpty(programCsFilePath))
-            {
-                var programDocument = project.Documents.Where(d => d.Name.Equals(programCsFilePath)).FirstOrDefault();
-                DocumentEditor documentEditor = await DocumentEditor.CreateAsync(programDocument);
-                DocumentBuilder documentBuilder = new DocumentBuilder(documentEditor, programCsFile, _consoleLogger);
-                if (documentEditor.OriginalRoot is CompilationUnitSyntax docRoot && programDocument != null)
-                {
-                    //get builder variable
-                    var variableDict = ProjectModifierHelper.GetBuilderVariableIdentifier(docRoot.Members);
-                    //add usings
-                    var newRoot = documentBuilder.AddUsings(toolOptions);
-                    //add code snippets/changes.
-                    if (programCsFile.Methods != null && programCsFile.Methods.Any())
-                    {
-                        var globalChanges = programCsFile.Methods.TryGetValue("Global", out var globalMethod);
-                        if (globalMethod != null)
-                        {
-                            var filteredCodeFiles = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, toolOptions));
-                            foreach (var change in filteredCodeFiles)
-                            {
-                                //Modify CodeSnippet to have correct variable identifiers present.
-                                var formattedChange = ProjectModifierHelper.FormatCodeSnippet(change, variableDict);
-                                newRoot = DocumentBuilder.AddGlobalStatements(formattedChange, newRoot);
-                            }
-                        }
-                    }
-                    //replace root node with all the updates.
-                    documentEditor.ReplaceNode(docRoot, newRoot);
-                    //write to Program.cs file
-                    await documentBuilder.WriteToClassFileAsync(programCsFilePath);
-                }
-            }
-        }
-
-        internal async Task ModifyCsFile(string fileName, CodeFile file, CodeAnalysis.Project project, CodeChangeOptions options)
-        {
-            string className = ProjectModifierHelper.GetClassName(fileName);
-            string? filePath = Directory.EnumerateFiles(_toolOptions.ProjectPath, fileName, SearchOption.AllDirectories).FirstOrDefault();
-            //get the file document to get the document root for editing.
-
-            if (!string.IsNullOrEmpty(filePath))
-            {
-                var fileDoc = project.Documents.Where(d => d.Name.Equals(filePath)).FirstOrDefault();
-                DocumentEditor documentEditor = await DocumentEditor.CreateAsync(fileDoc);
-                DocumentBuilder documentBuilder = new DocumentBuilder(documentEditor, file, _consoleLogger);
-                var newRoot = documentBuilder.AddUsings(options);
-                //adding usings
-                var namespaceNode = newRoot?.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
-                FileScopedNamespaceDeclarationSyntax? fileScopedNamespace = null;
-                if (namespaceNode == null)
-                {
-                    fileScopedNamespace = newRoot?.Members.OfType<FileScopedNamespaceDeclarationSyntax>()?.FirstOrDefault();
-                }
-
-                //get classNode. All class changes are done on the ClassDeclarationSyntax and then that node is replaced using documentEditor.
-                var classNode =
-                    namespaceNode?.DescendantNodes()?.Where(node =>
-                        node is ClassDeclarationSyntax cds &&
-                        cds.Identifier.ValueText.Contains(className)).FirstOrDefault() ??
-                    fileScopedNamespace?.DescendantNodes()?.Where(node =>
-                        node is ClassDeclarationSyntax cds &&
-                        cds.Identifier.ValueText.Contains(className)).FirstOrDefault();
-
-                if (classNode is ClassDeclarationSyntax classDeclarationSyntax)
-                {
-                    var modifiedClassDeclarationSyntax = classDeclarationSyntax;
-
-                    //add class properties
-                    modifiedClassDeclarationSyntax = documentBuilder.AddProperties(modifiedClassDeclarationSyntax, options);
-                    //add class attributes
-                    modifiedClassDeclarationSyntax = documentBuilder.AddClassAttributes(modifiedClassDeclarationSyntax, options);
-
-                    //add code snippets/changes.
-                    if (file.Methods != null && file.Methods.Any())
-                    {
-                        modifiedClassDeclarationSyntax = documentBuilder.AddCodeSnippets(modifiedClassDeclarationSyntax, options);
-                        modifiedClassDeclarationSyntax = documentBuilder.EditMethodTypes(modifiedClassDeclarationSyntax, options);
-                        modifiedClassDeclarationSyntax = documentBuilder.AddMethodParameters(modifiedClassDeclarationSyntax, options);
-                    }
-                    //replace class node with all the updates.
-#pragma warning disable CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
-                    newRoot = newRoot.ReplaceNode(classDeclarationSyntax, modifiedClassDeclarationSyntax);
-#pragma warning restore CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
-                }
-
-                if (documentEditor.OriginalRoot is CompilationUnitSyntax docRoot && newRoot != null)
-                {
-                    documentEditor.ReplaceNode(docRoot, newRoot);
-                }
-
-                await documentBuilder.WriteToClassFileAsync(filePath);
-            }
         }
 
         private CodeModifierConfig? GetCodeModifierConfig()

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             }
 
             var fileName = file.FileName.Equals("Startup.cs", StringComparison.OrdinalIgnoreCase)
-                    ? await ProjectModifierHelper.GetStartupClass(_toolOptions.ProjectPath, project)
+                    ? await ProjectModifierHelper.GetStartupClass(project)
                     : file.FileName;
 
             if (fileName.Equals("Program.cs"))

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             }
 
             var fileName = file.FileName.Equals("Startup.cs", StringComparison.OrdinalIgnoreCase)
-                    ? await ProjectModifierHelper.GetStartupClass(project)
+                    ? await ProjectModifierHelper.GetStartupClass(_toolOptions.ProjectPath, project)
                     : file.FileName;
 
             if (fileName.Equals("Program.cs"))

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
             var razorChanges = file?.RazorChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, toolOptions));
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, razorChanges);
-            await ProjectModifierHelper.UpdateDocument(document, editedDocument, _consoleLogger);
+            await ProjectModifierHelper.UpdateDocument(editedDocument, fileName, _consoleLogger);
         }
 
         internal async Task ModifyCshtmlFile(string fileName, CodeFile cshtmlFile, CodeAnalysis.Project project, CodeChangeOptions options)
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                             var filteredCodeFiles = globalMethod.CodeChanges.Where(cc => ProjectModifierHelper.FilterOptions(cc.Options, options));
                             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeFiles);
                             //replace the document
-                            await ProjectModifierHelper.UpdateDocument(fileDoc, editedDocument, _consoleLogger);
+                            await ProjectModifierHelper.UpdateDocument(editedDocument, fileName, _consoleLogger);
                         }
                     }
                 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -63,6 +63,16 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        internal static byte[] add_CallWebApi_razor {
+            get {
+                object obj = ResourceManager.GetObject("add_CallWebApi_razor", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         internal static byte[] add_ShowProfile_razor {
             get {
                 object obj = ResourceManager.GetObject("add_ShowProfile_razor", resourceCulture);

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -124,6 +124,9 @@
     <value>Adding package {0} . . .</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="add_CallWebApi_razor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\CodeReaderWriter\CodeFiles\Blazor\Server\CallWebApi.razor;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="add_ShowProfile_razor" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\CodeReaderWriter\CodeFiles\Blazor\Server\ShowProfile.razor;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeChange/CodeChangeHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeChange/CodeChangeHelper.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier.CodeChange
         public const string DownstreamApi = nameof(DownstreamApi);
         public const string Skip = nameof(Skip);
         public const string NonMinimalApp = nameof(NonMinimalApp);
+        public const string MinimalApp = nameof(MinimalApp);
     }
 
     public class CodeChangeOptions

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return startupType == null;
         }
 
+        // Returns true when there is no Startup.cs or equivalent
         internal static async Task<bool> IsMinimalApp(CodeAnalysis.Project project)
         {
             if (project != null)
@@ -60,23 +61,14 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return false;
         }
 
-        //Get Startup class name from CreateHostBuilder in Program.cs. If Program.cs is not being used, method
-        //will bail out.
-        internal static async Task<string> GetStartupClass(string projectPath, CodeAnalysis.Project project)
+        // Get Startup class name from CreateHostBuilder in Program.cs. If Program.cs is not being used, method
+        // will return null.
+        internal static async Task<string> GetStartupClass(CodeAnalysis.Project project)
         {
-            var programFilePath = Directory.EnumerateFiles(projectPath, "Program.cs").FirstOrDefault();
-            if (!string.IsNullOrEmpty(programFilePath))
-            {
-                var programDoc = project.Documents.Where(d => d.Name.Equals(programFilePath)).FirstOrDefault();
-                var startupClassName = await GetStartupClassName(programDoc);
-                string className = startupClassName;
-                var startupFilePath = string.Empty;
-                if (!string.IsNullOrEmpty(startupClassName))
-                {
-                    return string.Concat(startupClassName, ".cs");
-                }
-            }
-            return string.Empty;
+            var programCsDocument = project.Documents.Where(d => d.Name.Equals("Program.cs")).FirstOrDefault();
+            var startupClassName = await GetStartupClassName(programCsDocument);
+
+            return string.IsNullOrEmpty(startupClassName) ? null : string.Concat(startupClassName, ".cs");
         }
 
         internal static async Task<string> GetStartupClassName(Document programDoc)
@@ -110,6 +102,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                     }
                 }
             }
+
             return string.Empty;
         }
 
@@ -343,6 +336,11 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             {
                 return false;
             }
+            // for example, program.cs is only modified when codeChangeOptions.IsMinimalApp is true
+            if (options.Contains(CodeChangeOptionStrings.MinimalApp) && !codeChangeOptions.IsMinimalApp)
+            {
+                return false;
+            }
             //if its a minimal app and options have a "NonMinimalApp", don't add the CodeBlock
             if (options.Contains(CodeChangeOptionStrings.NonMinimalApp) && codeChangeOptions.IsMinimalApp)
             {
@@ -375,6 +373,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -420,14 +419,14 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 return null; // TODO generate README
             }
 
-            var sourceTextToAdd = SourceText.From(sourceFileString);
-            return fileDoc.WithText(sourceTextToAdd);
+            var updatedSourceText = SourceText.From(sourceFileString);
+            return fileDoc.WithText(updatedSourceText);
         }
 
         internal static async Task UpdateDocument(Document fileDoc, Document editedDocument, IConsoleLogger consoleLogger)
         {
             var classFileTxt = await editedDocument.GetTextAsync();
-            File.WriteAllText(fileDoc.Name, classFileTxt.ToString());
+            File.WriteAllText(fileDoc.FilePath, classFileTxt.ToString());
             consoleLogger.LogMessage($"Modified {fileDoc.Name}.\n");
         }
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -432,11 +432,11 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return fileDoc.WithText(updatedSourceText);
         }
 
-        internal static async Task UpdateDocument(string fileName, Document editedDocument, IConsoleLogger consoleLogger)
+        internal static async Task UpdateDocument(Document editedDocument, IConsoleLogger consoleLogger)
         {
             var classFileTxt = await editedDocument.GetTextAsync();
             File.WriteAllText(editedDocument.Name, classFileTxt.ToString());
-            consoleLogger.LogMessage($"Modified {fileName}.\n");
+            consoleLogger.LogMessage($"Modified {editedDocument.Name}.\n");
         }
 
         // Filter out CodeBlocks that are invalid using FilterOptions

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -61,14 +61,23 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return false;
         }
 
-        // Get Startup class name from CreateHostBuilder in Program.cs. If Program.cs is not being used, method
-        // will return null.
-        internal static async Task<string> GetStartupClass(CodeAnalysis.Project project)
+        //Get Startup class name from CreateHostBuilder in Program.cs. If Program.cs is not being used, method
+        //will bail out.
+        internal static async Task<string> GetStartupClass(string projectPath, CodeAnalysis.Project project)
         {
-            var programCsDocument = project.Documents.Where(d => d.Name.Equals("Program.cs")).FirstOrDefault();
-            var startupClassName = await GetStartupClassName(programCsDocument);
-
-            return string.IsNullOrEmpty(startupClassName) ? null : string.Concat(startupClassName, ".cs");
+            var programFilePath = Directory.EnumerateFiles(projectPath, "Program.cs").FirstOrDefault();
+            if (!string.IsNullOrEmpty(programFilePath))
+            {
+                var programDoc = project.Documents.Where(d => d.Name.Equals(programFilePath)).FirstOrDefault();
+                var startupClassName = await GetStartupClassName(programDoc);
+                string className = startupClassName;
+                var startupFilePath = string.Empty;
+                if (!string.IsNullOrEmpty(startupClassName))
+                {
+                    return string.Concat(startupClassName, ".cs");
+                }
+            }
+            return string.Empty;
         }
 
         internal static async Task<string> GetStartupClassName(Document programDoc)

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -432,7 +432,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return fileDoc.WithText(updatedSourceText);
         }
 
-        internal static async Task UpdateDocument(Document editedDocument, string fileName, IConsoleLogger consoleLogger)
+        internal static async Task UpdateDocument(string fileName, Document editedDocument, IConsoleLogger consoleLogger)
         {
             var classFileTxt = await editedDocument.GetTextAsync();
             File.WriteAllText(editedDocument.Name, classFileTxt.ToString());

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -432,11 +432,11 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return fileDoc.WithText(updatedSourceText);
         }
 
-        internal static async Task UpdateDocument(Document fileDoc, Document editedDocument, IConsoleLogger consoleLogger)
+        internal static async Task UpdateDocument(Document editedDocument, string fileName, IConsoleLogger consoleLogger)
         {
             var classFileTxt = await editedDocument.GetTextAsync();
-            File.WriteAllText(fileDoc.FilePath, classFileTxt.ToString());
-            consoleLogger.LogMessage($"Modified {fileDoc.Name}.\n");
+            File.WriteAllText(editedDocument.Name, classFileTxt.ToString());
+            consoleLogger.LogMessage($"Modified {fileName}.\n");
         }
 
         // Filter out CodeBlocks that are invalid using FilterOptions

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -432,11 +432,13 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return fileDoc.WithText(updatedSourceText);
         }
 
-        internal static async Task UpdateDocument(Document editedDocument, IConsoleLogger consoleLogger)
+        internal static async Task UpdateDocument(Document document, IConsoleLogger consoleLogger)
         {
-            var classFileTxt = await editedDocument.GetTextAsync();
-            File.WriteAllText(editedDocument.Name, classFileTxt.ToString());
-            consoleLogger.LogMessage($"Modified {editedDocument.Name}.\n");
+            var classFileTxt = await document.GetTextAsync();
+
+            // Note: Here, document.Name is the full filepath
+            File.WriteAllText(document.Name, classFileTxt.ToString());
+            consoleLogger.LogMessage($"Modified {document.Name}.\n");
         }
 
         // Filter out CodeBlocks that are invalid using FilterOptions


### PR DESCRIPTION
1. Adds code updates for blazor server "calls downstream API" option including CallWebApi.razor
2. Adds more code file filtering -> Startup.cs will be ignored when "NonMinimalApp" is false, Program.cs will be ignored when "MinimalApp" is false
3. Fix bug in ProjectModifierHelper. UpdateDocument where code files are added by FileName rather than by FilePath