### PR TITLE
RunTemplateAsync: generate template class name

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Templating/RazorTemplating.cs
+++ b/src/Scaffolding/VS.Web.CG.Templating/RazorTemplating.cs
@@ -12,6 +12,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating.Compilation;
 
+// ClassDeclarationIntermediateNode
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
 {
     //Todo: Make this internal and expose as a sevice
@@ -41,10 +44,15 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
 
                 SectionDirective.Register(builder);
 
-                builder.AddTargetExtension(new TemplateTargetExtension()
+                builder
+                .AddTargetExtension(new TemplateTargetExtension()
                 {
                     TemplateTypeName = "global::Microsoft.AspNetCore.Mvc.Razor.HelperResult",
-                });
+                })
+                .ConfigureClass(
+                    (RazorCodeDocument doc, ClassDeclarationIntermediateNode cl)
+                    => cl.ClassName = string.Join('_',
+                        fileSystem.GetItem(doc.Source.FilePath).FilePathWithoutExtension.Substring(0X1).Split('/'));
 
                 builder.AddDefaultImports(@"
 @using System


### PR DESCRIPTION
Use the same template class name as `{ dotnet build; }` does.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


