### PR TITLE
not throwing exception on invalid bootstrap versions.

### DIFF
--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=6.0.1
+set VERSION=6.0.2
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
@@ -117,10 +117,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                     _projectContext);
             }
 
-            // This should get caught by IdentityGeneratorTemplateModelBuilder.ValidateCommandLine() and emit the same error. 
-            // But best to be safe here.
-            // Note: If we start pivoting content on things other than bootstrap version, this error message will need to be reworked.
-            throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, templateModel2.BootstrapVersion, string.Join(", ", ValidBootstrapVersions)));
+            //return default template path if ContentVersion == DefaultVersion and if we can't figure out/invalid versions of bootstrap.
+            //better than throwing an invalid bootstrap version exception.
+            return TemplateFolders;
         }
 
         // Returns the root directory of the template folders appropriate for templateModel.ContentVersion
@@ -142,10 +141,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
                 if (string.IsNullOrEmpty(relativePath))
                 {
-                    // This should get caught by IdentityGeneratorTemplateModelBuilder.ValidateCommandLine() and emit the same error. 
-                    // But best to be safe here.
-                    // Note: If we start pivoting content on things other than bootstrap version, this error message will need to be reworked.
-                    throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, templateModel2.BootstrapVersion, string.Join(", ", ValidBootstrapVersions)));
+                    //set to defaultPath if invalid ContentVersion for Identity scaffolding. Not throwing an InvalidOpException anymore.
+                    relativePath = DefaultContentRelativeBaseDir;
                 }
             }
             else

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -314,17 +314,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 {
                     return IdentityGenerator.ContentVersionBootstrap4;
                 }
-                else
-                {
-                    // This should get caught by ValidateCommandLine() and emit the same error.
-                    // But best to be safe here.
-                    throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, templateModel2.BootstrapVersion, string.Join(", ", IdentityGenerator.ValidBootstrapVersions)));
-                }
             }
-            else
-            {
-                return IdentityGenerator.ContentVersionDefault;
-            }
+            //return default bootstrap version if no specific one can be determined. Better than to throw an exception here.
+            return IdentityGenerator.ContentVersionDefault;
         }
 
         private static readonly IReadOnlyList<string> _ExistingLayoutFileCheckLocations = new List<string>()
@@ -743,7 +735,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--layout", "--generateLayout"));
             }
 
-            if (!string.IsNullOrEmpty(model.BootstrapVersion) && !IdentityGenerator.ValidBootstrapVersions.Contains(model.BootstrapVersion))
+            if (!string.IsNullOrEmpty(model.BootstrapVersion) && !IdentityGenerator.ValidBootstrapVersions.Contains(model.BootstrapVersion.Trim(' ', '\n'))
             {
                 errorStrings.Add(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, model.BootstrapVersion, string.Join(", ", IdentityGenerator.ValidBootstrapVersions)));
             }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -735,7 +735,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--layout", "--generateLayout"));
             }
 
-            if (!string.IsNullOrEmpty(model.BootstrapVersion) && !IdentityGenerator.ValidBootstrapVersions.Contains(model.BootstrapVersion.Trim(' ', '\n'))
+            if (!string.IsNullOrEmpty(model.BootstrapVersion) && !IdentityGenerator.ValidBootstrapVersions.Contains(model.BootstrapVersion.Trim(' ', '\n')))
             {
                 errorStrings.Add(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, model.BootstrapVersion, string.Join(", ", IdentityGenerator.ValidBootstrapVersions)));
             }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
@@ -31,8 +31,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public IModelMetadata ModelMetadata { get; set; }
 
         public string JQueryVersion { get; set; }
-        
-        public bool NullableEnabled { get; set; }
 
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -157,9 +157,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                     },
                     projectContext: _projectContext);
             }
-
-            // Note: If we start pivoting content on things other than bootstrap version, this error message will need to be reworked.
-            throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, bootstrapVersion, string.Join(", ", ValidBootstrapVersions)));
+            //If no bootstrap version could be decided/invalid, return default bootstrap 5 templates.
+            return TemplateFolders;
         }
 
         protected async Task AddRequiredFiles(RazorPageGeneratorModel razorGeneratorModel)
@@ -321,10 +320,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             {
                 return ContentVersionBootstrap4;
             }
-            else
-            {
-                throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, razorGeneratorModel.BootstrapVersion, string.Join(", ", ValidBootstrapVersions)));
-            }
+            return ContentVersionDefault;
         }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
@@ -37,7 +37,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public string DbContextNamespace { get; private set; }
 
         public ModelType ModelType { get; private set; }
- 
+        public bool NullableEnabled { get; set; }
+
         public string ModelTypeName
         {
             get

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGenerator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 throw new InvalidOperationException(string.Format(MessageStrings.ModelClassRequiredForTemplate, templateName));
             }
 
-            if (!string.IsNullOrEmpty(viewGeneratorModel.BootstrapVersion) && !ValidBootstrapVersions.Contains(viewGeneratorModel.BootstrapVersion))
+            if (!string.IsNullOrEmpty(viewGeneratorModel.BootstrapVersion) && !ValidBootstrapVersions.Contains(viewGeneratorModel.BootstrapVersion.Trim(' ', '\n')))
             {
                 throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, viewGeneratorModel.BootstrapVersion, string.Join(", ", ValidBootstrapVersions)));
             }

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
@@ -87,11 +87,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             {
                 return ViewGenerator.ContentVersionBootstrap4;
             }
-            else
-            {
-                // this should be caught by ViewGenerator.ValidateViewGeneratorModel(), but best to be safe.
-                throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, model.BootstrapVersion, string.Join(", ", ViewGenerator.ValidBootstrapVersions)));
-            }
+            return ViewGenerator.ContentVersionDefault;
         }
 
         protected IEnumerable<string> GetTemplateFoldersForContentVersion(ViewGeneratorModel model)
@@ -125,9 +121,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                     baseFolders: new[] { Path.Combine(ViewGenerator.VersionedContentRelativeBaseDir, ViewGenerator.ContentVersionBootstrap4) },
                     projectContext: _projectContext);
             }
-
-            // this should be caught by ViewGenerator.ValidateViewGeneratorModel(), but best to be safe.
-            throw new InvalidOperationException(string.Format(MessageStrings.InvalidBootstrapVersionForScaffolding, model.BootstrapVersion, string.Join(", ", ViewGenerator.ValidBootstrapVersions)));
+            return TemplateFolders;
         }
 
         protected async Task AddRequiredFiles(ViewGeneratorModel viewGeneratorModel)


### PR DESCRIPTION
- improved string check for commandline passed bootstrap versions.
- not throwing InvalidOperation exception if bootstrap version not found, just returning default.

Tested .net6 projects with bootstrap 3, 4, 5 and invalid versions. All work well.