### PR TITLE
Revert "OnExecute: log inner exceptions (#1751)"

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
+++ b/src/Scaffolding/VS.Web.CG.Core/ActionInvoker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                 }
                 catch (Exception ex)
                 {
-                    throw new InvalidOperationException(string.Format(MessageStrings.ModelCreationFailed, ex.Message), ex);
+                    throw new InvalidOperationException(string.Format(MessageStrings.ModelCreationFailed, ex.Message));
                 }
 
                 foreach (var param in ActionDescriptor.Parameters)

--- a/src/Scaffolding/VS.Web.CG.Design/Program.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/Program.cs
@@ -90,18 +90,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
                 }
                 catch(Exception ex)
                 {
-                    do
+                    logger.LogMessage(Resources.GenericErrorMessage, LogMessageLevel.Error);
+                    logger.LogMessage(ex.Message, LogMessageLevel.Error);
+                    logger.LogMessage(ex.StackTrace, LogMessageLevel.Trace);
+                    if (!logger.IsTracing)
                     {
-                        logger.LogMessage(Resources.GenericErrorMessage, LogMessageLevel.Error);
-                        logger.LogMessage(ex.Message, LogMessageLevel.Error);
-                        logger.LogMessage(ex.StackTrace, LogMessageLevel.Trace);
-                        if (!logger.IsTracing)
-                        {
-                            logger.LogMessage(Resources.EnableTracingMessage);
-                        }
-                        ex = ex .InnerException;
+                        logger.LogMessage(Resources.EnableTracingMessage);
                     }
-                    while (!(ex is null));
+
                 }
                 return exitCode;
                 

--- a/src/Scaffolding/VS.Web.CG/CodeGenCommand.cs
+++ b/src/Scaffolding/VS.Web.CG/CodeGenCommand.cs
@@ -50,17 +50,12 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             }
             catch (Exception ex)
             {
-                do
+                while (ex is TargetInvocationException)
                 {
-                    while (ex is TargetInvocationException)
-                    {
-                        ex = ex.InnerException;
-                    }
-                    _logger.LogMessage(ex.Message, LogMessageLevel.Error);
-                    _logger.LogMessage(ex.StackTrace);
                     ex = ex.InnerException;
                 }
-                while (ex is Exception);
+                _logger.LogMessage(ex.Message, LogMessageLevel.Error);
+                _logger.LogMessage(ex.StackTrace);
             }
             return 0;
         }


### PR DESCRIPTION
reverting #1751.

After extensive debugging and looking at error messages in VS and on the command-line, have decided to revert this merge. 
- Error messages are significantly verbose, sometimes repeating themselves since top-level exceptions can be minor modifications of inner exceptions and since everything is logged, its quite messy looking.
- The issue remains but we need a better fix that to concatenate all the exception messages. Maybe that would be ok on command line experience but not for VS that is consuming the this tool as well.

@yecril71pl I have opened this [issue](https://github.com/dotnet/Scaffolding/issues/1820) to track it.
