### PR TITLE
Avoid building OSX/Linux in official

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,46 +108,47 @@ stages:
             $(_ValidateSdkArgs)
           displayName: Windows Build / Publish
 
-      - job: OSX
-        pool:
-          vmImage: macOS-11
-        strategy:
-          matrix:
-            release_configuration:
-              _BuildConfig: Release
-            ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              debug_configuration:
-                _BuildConfig: Debug
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-          name: Build
-          displayName: Build
-          condition: succeeded()
-          
-      - job: Linux
-        pool:
-          vmImage: ubuntu-18.04
-        container: LinuxContainer
-        strategy:
-          matrix:
-            release_configuration:
-              _BuildConfig: Release
-            ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              debug_configuration:
-                _BuildConfig: Debug
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-          name: Build
-          displayName: Build
-          condition: succeeded()
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        - job: OSX
+          pool:
+            vmImage: macOS-11
+          strategy:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                debug_configuration:
+                  _BuildConfig: Debug
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+            name: Build
+            displayName: Build
+            condition: succeeded()
+
+        - job: Linux
+          pool:
+            vmImage: ubuntu-18.04
+          container: LinuxContainer
+          strategy:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                debug_configuration:
+                  _BuildConfig: Debug
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+            name: Build
+            displayName: Build
+            condition: succeeded()
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml


### PR DESCRIPTION
- These builds do not contribute to the official build outputs
- These jobs are still run in PRs and rolling public CI
- This avoids having to use 1ES pools in these cases

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


