### PR TITLE
throwing new mysql exception mssg with no sensitive information.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
     internal class EntityFrameworkModelProcessor
     {
         private const string EFSqlServerPackageName = "Microsoft.EntityFrameworkCore.SqlServer";
+        private const string MySqlException = nameof(MySqlException);
         private const string NewDbContextFolderName = "Data";
         private bool _useSqlite;
         private string _dbContextFullTypeName;
@@ -554,8 +556,60 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             }
             catch (Exception ex)
             {
+                System.Diagnostics.Debugger.Launch();
+                var exceptionType = ex.GetType();
+                // if MySQL exception with error code 1045, discard error message since it contains sensitive dev information
+                if (exceptionType.Name.Equals(MySqlException, StringComparison.OrdinalIgnoreCase) || exceptionType.FullName.Contains(MySqlException, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (ex.Data.Keys.Count > 0 &&
+                        ex.Data["Server Error Code"] != null &&
+                        //based on error code 1045 from here https://dev.mysql.com/doc/
+                        ex.Data["Server Error Code"].ToString().Equals("1045", StringComparison.OrdinalIgnoreCase))
+                    {
+                        //userName will have some value, or will be empty. We're ok with both.
+                        string userName = GetUsername(ex.Message);
+                        ex = new Exception($"{string.Format(MessageStrings.MySQLDbContextExceptionMssg, userName)}\n");
+                        throw ex;
+                    }
+                }
                 throw ex.Unwrap(_logger);
             }
+        }
+
+        /// <summary>
+        /// return the username/user id from exception messages including sensitive information.
+        /// Currently accounting for exception messages using MySQL scenarios.
+        /// </summary>
+        /// <returns>username from connection strings found in exception messages.</returns>
+        internal static string GetUsername(string exceptionMssg)
+        {
+            string username = string.Empty;
+            if (!string.IsNullOrEmpty(exceptionMssg))
+            {
+                //if the exception message is in the format `Access denied for user 'admin'@'localhost',
+                //discard the entire message since username and machine name could be both sensitive based on
+                //our collected telemetry.
+                if (exceptionMssg.Contains("Access denied for user", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Empty;
+                }
+                //exception messages could also contain entire SqlServer or MySQL connection strings
+                //format connection strings
+                exceptionMssg = exceptionMssg.Replace(" ", string.Empty);
+                exceptionMssg = exceptionMssg.Replace("\n", string.Empty);
+                exceptionMssg = exceptionMssg.Replace("\r", string.Empty);
+
+                var userIdMatch = Regex.Match(exceptionMssg, "[.]*uid=.*;", RegexOptions.IgnoreCase).Value;
+                userIdMatch = string.IsNullOrEmpty(userIdMatch) ? Regex.Match(exceptionMssg, "[.]*userid=.*;", RegexOptions.IgnoreCase).Value : userIdMatch;
+
+                var equalsIndex = userIdMatch.IndexOf('=');
+                var semiColonIndex = userIdMatch.IndexOf(';');
+                if (equalsIndex >= 0 && equalsIndex < semiColonIndex)
+                {
+                    username = $" '{userIdMatch.Substring(equalsIndex+1, semiColonIndex-equalsIndex-1)}'";
+                }
+            }
+            return username;
         }
 
         private void ValidateEFSqlServerDependency()

--- a/src/Scaffolding/VS.Web.CG.EFCore/MessageStrings.Designer.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/MessageStrings.Designer.cs
@@ -213,7 +213,18 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore {
                 return ResourceManager.GetString("ModelTypeNotFound", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get DbContext Instance. Access denied for user{0} (MySQL db).
+        /// </summary>
+        internal static string MySQLDbContextExceptionMssg
+        {
+            get
+            {
+                return ResourceManager.GetString("MySQLDbContextExceptionMssg", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to There is no entity type {0} on DbContext {1}.
         /// </summary>

--- a/src/Scaffolding/VS.Web.CG.EFCore/MessageStrings.resx
+++ b/src/Scaffolding/VS.Web.CG.EFCore/MessageStrings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -167,6 +167,9 @@
   </data>
   <data name="ModelTypeNotFound" xml:space="preserve">
     <value>Could not get the reflection type for Model : {0}</value>
+  </data>
+  <data name="MySQLDbContextExceptionMssg" xml:space="preserve">
+    <value>Unable to get DbContext Instance. Access denied for user{0} (MySQL db).</value>
   </data>
   <data name="NoEntityOfTypeInDbContext" xml:space="preserve">
     <value>There is no entity type {0} on DbContext {1}</value>

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkModelProcessorTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkModelProcessorTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
+{
+    
+    public class EntityFrameworkModelProcessorTests
+    {
+        [InlineData("Server= myServerAddress; Database=myDataBase ; uid   = myUsername; Pwd=myPassword;", " 'myUsername'")]
+        [InlineData("Server  =  myServerAddress ; Database=myDataBase;  User Id=myUsername ; Password=myPassword;", " 'myUsername'")]
+        [InlineData("Server=myServerAddress;Database=myDataBase;uid=myUsername;Pwd=myPassword;", " 'myUsername'")]
+        [InlineData("Server=myServerAddress;Database=myDataBase;uid=myUsername;", " 'myUsername'")]
+        [InlineData("uid=myUsername;Server=myServerAddress;Database=myDataBase;Pwd=myPassword;", " 'myUsername'")]
+        [InlineData("uid=myUsername;Pwd=myPassword;", " 'myUsername'")]
+        [InlineData("uid=myUsername;", " 'myUsername'")]
+        [InlineData("Server=myServerAddress;Database=myDataBase;UserId=myUsername;Password=myPassword;", " 'myUsername'")]
+        [InlineData("Access denied for user 'admin'@'localhost' (using password: YES)", "")]
+        [Theory]
+        public void GetUsernameTest(string connectionString, string usernameValue)
+        {
+            Assert.Equal(usernameValue, EntityFrameworkModelProcessor.GetUsername(connectionString));
+        }
+    }
+}


### PR DESCRIPTION
In the scenario when using a MySQL db with dotnet webapp/webapi, scaffolding will 
- try to register and activate the DbContext. 
- If the current user/dev does not have the correct MySQL db credentials set/access, MySQL will throw an AccessDenied exception with error code 1045. 
- This exception can contain sensitive information about the server being connected to and passwords in connection strings. 
- Will discard the entire exception message and keep the user id from the MySQL connection string if possible. 

Two possible exception messages:
1. Unable to get DbContext Instance. Access denied for user 'USER' (MySQL db).
2. Unable to get DbContext Instance. Access denied for user (MySQL db).

