### PR TITLE
fixed missing NullableEnabled property in the RazorPageModel

### DIFF
--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=5.0.0
+VERSION=6.0.3
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public IModelMetadata ModelMetadata { get; set; }
 
         public string JQueryVersion { get; set; }
+        public bool NullableEnabled { get; set; } = false;
 
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -239,7 +239,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             {
                 razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
             }
-            System.Diagnostics.Debugger.Launch();
             RazorPageGeneratorTemplateModel2 templateModel = new RazorPageGeneratorTemplateModel2()
             {
                 NamespaceName = namespaceName,

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             {
                 razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
             }
-
+            System.Diagnostics.Debugger.Launch();
             RazorPageGeneratorTemplateModel2 templateModel = new RazorPageGeneratorTemplateModel2()
             {
                 NamespaceName = namespaceName,
@@ -252,7 +252,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 ReferenceScriptLibraries = razorGeneratorModel.ReferenceScriptLibraries,
                 JQueryVersion = "1.10.2", //Todo
                 BootstrapVersion = razorGeneratorModel.BootstrapVersion,
-                ContentVersion = DetermineContentVersion(razorGeneratorModel)
+                ContentVersion = DetermineContentVersion(razorGeneratorModel),
+                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
             };
 
             return templateModel;

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageWithContextTemplateModel.cs
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public string DbContextNamespace { get; private set; }
 
         public ModelType ModelType { get; private set; }
-        public bool NullableEnabled { get; set; }
 
         public string ModelTypeName
         {


### PR DESCRIPTION
Fixing issue on macOS and Linux running the following command:
`dotnet aspnet-codegenerator razorpage Empty Empty -udl` with error:
![image](https://user-images.githubusercontent.com/54324771/158907378-bdcc3626-ccd6-407b-8c32-2a3ace7995fd.png)
