### PR TITLE
Only adding _ViewStart to non blazor projects (identity)

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         private static readonly string _ViewImportFileName = "_ViewImports";
 
         // Note: "peer" is somewhat of a misnomer, not all of the "peer" files are in the same directory as the layout file.
-        internal static bool TryGetLayoutPeerFiles(IFileSystem fileSystem, string rootPath, IdentityGeneratorTemplateModel templateModel, out IReadOnlyList<IdentityGeneratorFile> layoutPeerFiles)
+        internal static bool TryGetLayoutPeerFiles(IFileSystem fileSystem, string rootPath, IdentityGeneratorTemplateModel templateModel, out IReadOnlyList<IdentityGeneratorFile> layoutPeerFiles, bool isBlazorProject)
         {
             string viewImportsFileNameWithExtension = string.Concat(_ViewImportFileName, ".cshtml");
 
@@ -273,8 +273,14 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 ShowInListFiles = false,
                 ShouldOverWrite = OverWriteCondition.Never
             };
-            peerFiles.Add(layoutPeerViewStart);
 
+            //don't need Layout for the start page of a Blazor Server application.
+            //Still adding Layout file for other added pages.
+            if (!isBlazorProject)
+            {
+                peerFiles.Add(layoutPeerViewStart);
+            }
+            
             layoutPeerFiles = peerFiles;
             return true;
         }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -273,7 +273,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 filesToGenerate.AddRange(IdentityGeneratorFilesConfig.GetViewImports(filesToGenerate, _fileSystem, _applicationInfo.ApplicationBasePath));
             }
 
-            if (IdentityGeneratorFilesConfig.TryGetLayoutPeerFiles(_fileSystem, _applicationInfo.ApplicationBasePath, templateModel, out IReadOnlyList<IdentityGeneratorFile> layoutPeerFiles))
+            if (IdentityGeneratorFilesConfig.TryGetLayoutPeerFiles(_fileSystem, _applicationInfo.ApplicationBasePath, templateModel, out IReadOnlyList<IdentityGeneratorFile> layoutPeerFiles, templateModel.IsBlazorProject))
             {
                 filesToGenerate.AddRange(layoutPeerFiles);
             }


### PR DESCRIPTION
Fixes - https://github.com/aspnet/AspNetCore-ManualTests/issues/1232
Only adding _ViewStart file for non blazor projects.
