### PR TITLE
throwing exception if GetConnectionString returns null.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
@@ -375,7 +375,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             if (stringToModify.Contains(GetConnectionString))
             {
                 modifiedString = modifiedString.Replace("GetConnectionString(\"{0}\")", $"GetConnectionString(\"{dbContextClassName}Connection\")");
+                modifiedString = modifiedString.Replace("Connection string '{0}'", $"Connection string '{dbContextClassName}Connection'");
             }
+
             return modifiedString;
         }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
@@ -8,7 +8,7 @@
             {
               "InsertAfter": "WebApplication.CreateBuilder",
               "CheckBlock": "builder.Configuration.GetConnectionString",
-              "Block": "\nvar connectionString = builder.Configuration.GetConnectionString(\"{0}\");"
+              "Block": "\nvar connectionString = builder.Configuration.GetConnectionString(\"{0}\") ?? throw new InvalidOperationException(\"Connection string '{0}' not found.\")));"
             },
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",


### PR DESCRIPTION
throwing exception if GetConnectionString returns null, adding to identity config for when adding a new DbContext and DbContextConnectionString. 
[Context ](https://github.com/dotnet/Scaffolding/pull/1830)



