### PR TITLE
Fixes for parameter updates and code modifier configs for web apps / …

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapi.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapi.json
@@ -18,7 +18,11 @@
           "Parameters": [ "IServiceCollection" ],
           "CodeChanges": [
             {
-              "Block": "IServiceCollection.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)"
+              "Block": "IServiceCollection.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)",
+              "LeadingTrivia": {
+                "NumberOfSpaces": 12, 
+                "Newline": true
+              }
             },
             {
               "Parent": "IServiceCollection.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)",
@@ -140,7 +144,11 @@
           "CodeChanges": [
             {
               "InsertAfter": "IApplicationBuilder.UseRouting",
-              "Block": "IApplicationBuilder.UseAuthentication()"
+              "Block": "IApplicationBuilder.UseAuthentication()",
+              "LeadingTrivia": {
+                "NumberOfSpaces": 12,
+                "Newline": true
+              }
             }
           ]
         },

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
@@ -10,10 +10,7 @@
           "CodeChanges": [
             {
               "InsertAfter": "IApplicationBuilder.UseRouting()",
-              "Block": "IApplicationBuilder.UseAuthentication()",
-              "LeadingTrivia": {
-                "NumberOfSpaces": 12
-              }
+              "Block": "IApplicationBuilder.UseAuthentication()"
             },
             {
               "Parent": "IApplicationBuilder.UseEndpoints",

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_webapp.json
@@ -10,12 +10,19 @@
           "CodeChanges": [
             {
               "InsertAfter": "IApplicationBuilder.UseRouting()",
-              "Block": "IApplicationBuilder.UseAuthentication()"
+              "Block": "IApplicationBuilder.UseAuthentication()",
+              "LeadingTrivia": {
+                "NumberOfSpaces": 12
+              }
             },
             {
               "Parent": "IApplicationBuilder.UseEndpoints",
+              "Parameter": "endpoints",
               "CodeChangeType": "Lambda",
-              "Block": "endpoints.MapControllers()"
+              "Block": "endpoints.MapControllers()",
+              "LeadingTrivia": {
+                "NumberOfSpaces": 16
+              }
             }
           ]
         },
@@ -174,11 +181,11 @@
       },
       "Usings": [
         "Microsoft.AspNetCore.Authentication",
-        "Microsoft.Identity.Web",
-        "Microsoft.Identity.Web.UI",
         "Microsoft.AspNetCore.Authentication.OpenIdConnect",
         "Microsoft.AspNetCore.Authorization",
-        "Microsoft.AspNetCore.Mvc.Authorization"
+        "Microsoft.AspNetCore.Mvc.Authorization",
+        "Microsoft.Identity.Web",
+        "Microsoft.Identity.Web.UI"
       ]
     },
     {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -291,8 +291,8 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 var namespaceNode = root?.Members.OfType<BaseNamespaceDeclarationSyntax>()?.FirstOrDefault();
 
                 string className = ProjectModifierHelper.GetClassName(file.FileName);
-                // get classNode. All class changes are done on the ClassDeclarationSyntax and then that node is replaced using documentEditor.
 
+                // get classNode. All class changes are done on the ClassDeclarationSyntax and then that node is replaced using documentEditor.
                 if (namespaceNode?.DescendantNodes().FirstOrDefault(node =>
                         node is ClassDeclarationSyntax cds &&
                         cds.Identifier.ValueText.Contains(className)) is ClassDeclarationSyntax classNode)
@@ -303,10 +303,8 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                     modifiedClassDeclarationSyntax = documentBuilder.AddProperties(modifiedClassDeclarationSyntax, options);
                     //add class attributes
                     modifiedClassDeclarationSyntax = documentBuilder.AddClassAttributes(modifiedClassDeclarationSyntax, options);
-
-                    modifiedClassDeclarationSyntax = ModifyMethods(modifiedClassDeclarationSyntax, documentBuilder, file.Methods, options);
-
                     //add code snippets/changes.
+                    modifiedClassDeclarationSyntax = ModifyMethods(modifiedClassDeclarationSyntax, documentBuilder, file.Methods, options);
 
                     //replace class node with all the updates.
 #pragma warning disable CS8631 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
@@ -331,6 +329,12 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 if (methodNode is null)
                 {
                     continue;
+                }
+
+                var parameters = ProjectModifierHelper.VerifyParameters(methodChanges.Parameters, methodNode.ParameterList.Parameters.ToList());
+                foreach ((string oldValue, string newValue) in parameters)
+                {
+                    methodChanges.CodeChanges = ProjectModifierHelper.UpdateVariables(methodChanges.CodeChanges, oldValue, newValue);
                 }
 
                 var updatedMethodNode = DocumentBuilder.GetModifiedMethod(methodNode, methodChanges, options);

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -76,7 +75,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 return;
             }
 
-            var isMinimalApp = await ProjectModifierHelper.IsMinimalApp(project.Documents.ToList()); // TODO can use "files" list of strings
+            var isMinimalApp = await ProjectModifierHelper.IsMinimalApp(project.Documents.ToList());
             var useTopLevelsStatements = await ProjectModifierHelper.IsUsingTopLevelStatements(project.Documents.ToList());
             CodeChangeOptions options = new CodeChangeOptions
             {
@@ -265,7 +264,6 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             var root = documentBuilder.AddUsings(options);
             if (file.FileName.Equals("Program.cs") && file.Methods.TryGetValue("Global", out var globalChanges))
             {
-                Debugger.Launch();
                 var filteredChanges = ProjectModifierHelper.FilterCodeSnippets(globalChanges.CodeChanges, options);
                 var updatedIdentifer = ProjectModifierHelper.GetBuilderVariableIdentifierTransformation(root.Members);
                 if (updatedIdentifer.HasValue)

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeChange/CodeSnippet.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeChange/CodeSnippet.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier.CodeChange
         public bool Replace { get; set; } = false;
         public string[] InsertBefore { get; set; }
         public string[] Options { get; set; }
-        public Formatting LeadingTrivia { get; set; }
+        public Formatting LeadingTrivia { get; set; } = new Formatting();
         public Formatting TrailingTrivia { get; set; } = new Formatting { Semicolon = true, Newline = true };
         public string Parameter { get; set; }
         public CodeChangeType CodeChangeType { get; set; } = CodeChangeType.Default;

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -166,12 +166,6 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 || node is ConstructorDeclarationSyntax cds && cds.Identifier.ValueText.Equals(methodName))
                  is BaseMethodDeclarationSyntax foundMethod)
             {
-                var parameters = VerifyParameters(methodChanges.Parameters, foundMethod.ParameterList.Parameters.ToList());
-                if (parameters == null)
-                {
-                    return null;
-                }
-
                 return foundMethod;
             }
 


### PR DESCRIPTION
Updates for "Do not use top-level statements" for adding code when the identity templates are not selected in VS

Fixes for parameter updates and code modifier configs for web apps / web apis that use startup.cs, specifically .Net5 projects
