### PR TITLE
supporting os version tfm for "-windows"

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/MsBuild/MsBuildProjectContextBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/MsBuild/MsBuildProjectContextBuilder.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Extensions.ProjectModel
                 {
                     _projectPath,
                     $"/t:EvaluateProjectInfoForCodeGeneration",
-                    $"/p:OutputFile={tmpFile};CodeGenerationTargetLocation={_targetLocation};Configuration={_configuration}"
+                    $"/p:OutputFile={tmpFile};CodeGenerationTargetLocation={_targetLocation};Configuration={_configuration}",
+                    "-restore"
                 })
                 .OnErrorLine(e => errors.Add(e))
                 .OnOutputLine(o => output.Add(o))

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
@@ -48,6 +48,12 @@ namespace Microsoft.DotNet.Scaffolding.Shared
                             //"targets" gives us all top-level and transitive dependencies. "packageFolders" gives us the path where the dependencies are on disk.
                             if (root.TryGetProperty(TargetsProperty, out var targets) && root.TryGetProperty(PackageFoldersProperty, out var packageFolderPath))
                             {
+                                if (targetFramework.EndsWith("-windows"))
+                                {
+                                    //tfm in project.assets.json is netX-windows7.0 instead of netX-windows
+                                    targetFramework = $"{targetFramework}7.0";
+                                }
+
                                 if (targets.TryGetProperty(targetFramework, out var packages))
                                 {
                                     packageDependencies = DeserializePackages(packages, packageFolderPath, targetFrameworkMoniker);


### PR DESCRIPTION
adding support for tfm "net7.0-windows" 
- tfm was not supported, parsing projects.assets.json was failing. 
- fixed parsing, rest of the flow just works.