### PR TITLE
Fix position of the Logout button near the profile link

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/_LoginPartial.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/_LoginPartial.cshtml
@@ -30,7 +30,7 @@
       {
 @:        <form id="logoutForm" class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@@Url.Action("Index", "Home", new { area = "" })">
       }
-@:            <button id="logout" type="submit" class="nav-link btn btn-link text-dark">Logout</button>
+@:            <button id="logout" type="submit" class="nav-link btn btn-link text-dark border-0">Logout</button>
 @:        </form>
 @:    </li>
 @:}


### PR DESCRIPTION
The "btn-link" class has 1px border and, as a result, a button looks misplaced.

Before:
<img width="306" alt="Снимок экрана 2022-06-04 в 21 25 36" src="https://user-images.githubusercontent.com/812052/172045495-8102731a-a7f9-42a6-8249-139310763091.png">

After:
<img width="282" alt="Снимок экрана 2022-06-05 в 15 51 54" src="https://user-images.githubusercontent.com/812052/172045506-a69f3f89-7aaf-449b-8012-ba4742335981.png">




