### PR TITLE
added support for sqlite for minimal api scaffolding.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
 
             if (!string.IsNullOrEmpty(modelTypeAndContextModel.DbContextFullName) && CalledFromCommandline)
             {
-                EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, useSqlite: false);
+                EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, useSqlite: model.UseSqlite);
             }
 
             var templateModel = new MinimalApiModel(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName, model.EndpintsClassName)
@@ -92,7 +92,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 ModelMetadata = modelTypeAndContextModel.ContextProcessingResult?.ModelMetadata,
                 NullableEnabled = "enable".Equals(AppInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase),
                 OpenAPI = model.OpenApi,
-                MethodName = $"Map{modelTypeAndContextModel.ModelType.Name}Endpoints"
+                MethodName = $"Map{modelTypeAndContextModel.ModelType.Name}Endpoints",
+                UseSqlite = model.UseSqlite
             };
 
             var endpointsModel = ModelTypesLocator.GetAllTypes().FirstOrDefault(t => t.Name.Equals(model.EndpintsClassName));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -22,6 +22,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         [Option(Name = "endpointsNamespace", ShortName = "namespace", Description = "Specify the name of the namespace to use for the generated controller")]
         public string EndpointsNamespace { get; set; }
 
+        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        public bool UseSqlite { get; set; }
+
         public MinimalApiGeneratorCommandLineModel()
         {
         }
@@ -33,6 +36,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             RelativeFolderPath = copyFrom.RelativeFolderPath;
             OpenApi = copyFrom.OpenApi;
             EndpointsNamespace = copyFrom.EndpointsNamespace;
+            UseSqlite = copyFrom.UseSqlite;
         }
 
         public MinimalApiGeneratorCommandLineModel Clone()

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
@@ -42,6 +42,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         //If CRUD endpoints support Open API
         public bool OpenAPI { get; set; }
 
+        //Sqlite for sqlite and mac/linux scenarios.
+        public bool UseSqlite { get; set; }
+
         //Generated namespace for a Endpoints class/file. If using an existing file, does not apply.
         public string EndpointsNamespace { get; set; }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/ModelMetadataUtilities.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ModelMetadataUtilities.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                     dbContextFullName,
                     model,
                     areaName,
-                    useSqlite: false);
+                    useSqlite: commandLineModel.UseSqlite);
             }
 
             return new ModelTypeAndContextModel()


### PR DESCRIPTION
Addresses #1897 
- support for mac/linux minimal api scaffolders with support for sqlite.
- use `-sqlite/--useSqlite` with the `minimalapi` scaffolder.
