### PR TITLE
fix nullable warnings for new db context template.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.EFCore/Templates/DbContext/NewLocalDbContext.cshtml
+++ b/src/Scaffolding/VS.Web.CG.EFCore/Templates/DbContext/NewLocalDbContext.cshtml
@@ -45,7 +45,7 @@ using Microsoft.EntityFrameworkCore;
         {
         }
 
-        public DbSet<@Model.ModelTypeFullName>? @Model.ModelTypeName { get; set; }
+        public DbSet<@Model.ModelTypeFullName> @Model.ModelTypeName { get; set; } = default!;
     }
 @{
     if (!String.IsNullOrEmpty(Model.DbContextNamespace))


### PR DESCRIPTION
fixes nullable warnings
- don't use nullable entity set value, instead use default operator.
- fixes minimal api scaffolder, razor page and api scaffolder warnings.

