### PR TITLE
forcing version for System.Configuration.ConfigurationManager

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)"/>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManager)"/>
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,6 +120,7 @@
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityCryptographyX509CertificatesVersion>4.3.0</SystemSecurityCryptographyX509CertificatesVersion>
+    <SystemConfigurationConfigurationManager>6.0.0</SystemConfigurationConfigurationManager>
   </PropertyGroup>
   <!-- Package versions for MSIdentity projects-->
   <PropertyGroup>


### PR DESCRIPTION
forcing System.Configuration.ConfigurationManager v6.0.0 to fix missing system dlls error.