### PR TITLE
Fix code update config for blazor wasm

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_blazorwasm.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeModifierConfigs/cm_dotnet_blazorwasm.json
@@ -281,6 +281,9 @@
     },
     {
       "FileName": "FetchData.razor",
+      "Options": [
+        "DownstreamApi"
+      ],
       "Replacements": [
         {
           "MultiLineBlock": [


### PR DESCRIPTION
The "DownstreamApi" option needs to be specified for modifying the "FetchData" page for blazor wasm projects, otherwise the file gets modified even if there is not a downstream API configured.

See bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1553434