### PR TITLE
Add service principal when exposing API scopes

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/AuthenticationParameters/AzureAdProperties.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/AuthenticationParameters/AzureAdProperties.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.MSIdentity.AuthenticationParameters
         public const bool ValidateAuthority = true;
 
         public const string MicrosoftGraphBaseUrl = "https://graph.microsoft.com/v1.0";
-        public const string DefaultScopes = "user.read";
+        public const string MicrosoftGraphScopes = "user.read";
+        public const string ApiScopes = "access_as_user";
     }
 
     public class AzureAdBlock
@@ -77,15 +78,15 @@ namespace Microsoft.DotNet.MSIdentity.AuthenticationParameters
         {
             JObject azureAdObj = JObject.FromObject(azureAdToken);
 
-            ClientId ??= azureAdObj.Value<string>(PropertyNames.ClientId); // here, if the applicationparameters value is null, we use the existing app settings value
-            Instance ??= azureAdObj.Value<string>(PropertyNames.Instance);
-            Domain ??= azureAdObj.Value<string>(PropertyNames.Domain);
-            TenantId ??= azureAdObj.Value<string>(PropertyNames.TenantId);
-            Authority ??= azureAdObj.Value<string>(PropertyNames.Authority);
-            CallbackPath ??= azureAdObj.Value<string>(PropertyNames.CallbackPath);
-            Scopes ??= azureAdObj.Value<string>(PropertyNames.Scopes);
-            ClientSecret ??= azureAdObj.Value<string>(PropertyNames.ClientSecret);
-            ClientCertificates ??= azureAdObj.Value<string[]>(PropertyNames.ClientCertificates);
+            ClientId ??= azureAdObj.GetValue(PropertyNames.ClientId)?.ToString(); // here, if the applicationparameters value is null, we use the existing app settings value
+            Instance ??= azureAdObj.GetValue(PropertyNames.Instance)?.ToString();
+            Domain ??= azureAdObj.GetValue(PropertyNames.Domain)?.ToString();
+            TenantId ??= azureAdObj.GetValue(PropertyNames.TenantId)?.ToString();
+            Authority ??= azureAdObj.GetValue(PropertyNames.Authority)?.ToString();
+            CallbackPath ??= azureAdObj.GetValue(PropertyNames.CallbackPath)?.ToString();
+            Scopes ??= azureAdObj.GetValue(PropertyNames.Scopes)?.ToString();
+            ClientSecret ??= azureAdObj.GetValue(PropertyNames.ClientSecret)?.ToString();
+            ClientCertificates ??= azureAdObj.GetValue(PropertyNames.ClientCertificates)?.ToObject<string[]>();
 
             return this;
         }
@@ -113,7 +114,7 @@ namespace Microsoft.DotNet.MSIdentity.AuthenticationParameters
             TenantId = TenantId ?? DefaultProperties.TenantId,
             ClientId = ClientId ?? DefaultProperties.ClientId,
             CallbackPath = CallbackPath ?? DefaultProperties.CallbackPath,
-            Scopes = Scopes ?? DefaultProperties.DefaultScopes,
+            Scopes = Scopes ?? DefaultProperties.MicrosoftGraphScopes,
             ClientSecret = ClientSecret ?? DefaultProperties.ClientSecret,
             ClientCertificates = ClientCertificates ?? Array.Empty<string>()
         };

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/AppSettingsModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/AppSettingsModifier.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatform
             if (_provisioningToolOptions.CallsGraph)
             {
                 // update MicrosoftGraph Block
-                var microsoftGraphBlock = GetApiBlock(appSettings, MicrosoftGraph, DefaultProperties.DefaultScopes, DefaultProperties.MicrosoftGraphBaseUrl);
+                var microsoftGraphBlock = GetApiBlock(appSettings, MicrosoftGraph, DefaultProperties.MicrosoftGraphScopes, DefaultProperties.MicrosoftGraphBaseUrl);
                 if (microsoftGraphBlock != null)
                 {
                     changesMade = true;
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatform
             if (_provisioningToolOptions.CallsDownstreamApi)
             {
                 // update DownstreamAPI Block
-                var updatedDownstreamApiBlock = GetApiBlock(appSettings, DownstreamApi, DefaultProperties.DefaultScopes, DefaultProperties.MicrosoftGraphBaseUrl);
+                var updatedDownstreamApiBlock = GetApiBlock(appSettings, DownstreamApi, DefaultProperties.ApiScopes, DefaultProperties.MicrosoftGraphBaseUrl);
                 if (updatedDownstreamApiBlock != null)
                 {
                     changesMade = true;
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatform
         {
             var inputParameters = JObject.FromObject(new ApiSettingsBlock
             {
-                Scopes = string.IsNullOrEmpty(scopes) ? DefaultProperties.DefaultScopes : scopes,
+                Scopes = string.IsNullOrEmpty(scopes) ? DefaultProperties.MicrosoftGraphScopes : scopes,
                 BaseUrl = string.IsNullOrEmpty(baseUrl) ? DefaultProperties.MicrosoftGraphBaseUrl : baseUrl
             });
 

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
@@ -526,36 +526,6 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
             await ExposeScopes(graphServiceClient, createdApplication.AppId, createdApplication.Id, scopes);
         }
 
-        // TODO 1.0.6
-        ///// <summary>
-        ///// Expose scopes for the web API.
-        ///// </summary>
-        ///// <param name="graphServiceClient"></param>
-        ///// <param name="createdApplication"></param>
-        ///// <returns></returns>
-        //internal static async Task ExposeScopesForExistingWebApi(GraphServiceClient graphServiceClient, Application createdApplication)
-        //{
-        //    var scopes = createdApplication.Api?.Oauth2PermissionScopes?.ToList() ?? new List<PermissionScope>();
-        //    var existingServicePrincipal = await graphServiceClient.ServicePrincipals[createdApplication.AppId]
-        //        .Request()
-        //        .GetAsync();
-
-        //    if (existingServicePrincipal is null)
-        //    {
-        //        // Creates a service principal if necessary
-        //        var servicePrincipal = new ServicePrincipal
-        //        {
-        //            AppId = createdApplication.AppId,
-        //        };
-
-        //        await graphServiceClient.ServicePrincipals
-        //         .Request()
-        //         .AddAsync(servicePrincipal).ConfigureAwait(false);
-        //    }
-
-        //    await ExposeScopes(graphServiceClient, createdApplication.AppId, createdApplication.Id, scopes);
-        //}
-
         /// <summary>
         /// Admin consent to API permissions
         /// </summary>

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -330,7 +330,7 @@ namespace Microsoft.DotNet.MSIdentity
             clientToolOptions.ProjectType = "blazorwasm-client";
             clientToolOptions.AppDisplayName = string.Concat(clientToolOptions.AppDisplayName ?? serverApplicationParameters.ApplicationDisplayName, "-Client");
             clientToolOptions.HostedAppIdUri = serverApplicationParameters.AppIdUri;
-            clientToolOptions.HostedApiScopes = $"{serverApplicationParameters.AppIdUri}/access_as_user";
+            clientToolOptions.HostedApiScopes = $"{serverApplicationParameters.AppIdUri}/{DefaultProperties.ApiScopes}";
 
             // Provision client app registration
             var provisionClientAppRegistration = new AppProvisioningTool(Commands.CREATE_APP_REGISTRATION_COMMAND, clientToolOptions, silent: true);


### PR DESCRIPTION
Fixes a regression where service principals were not being created when creating app registrations, causing problems with accessing Web APIs. Also small fix to appsettings parsing, to prevent null refs. 
