### PR TITLE
bumping up NuGet.Packaging to fix vulnerability.

### DIFF
--- a/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/dotnet-msidentity/dotnet-msidentity.csproj
+++ b/tools/dotnet-msidentity/dotnet-msidentity.csproj
@@ -54,6 +54,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\dotnet-aspnet-codegenerator\dotnet-aspnet-codegenerator.csproj" />
     <PackageReference Include="System.Commandline" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To fix Component governance vulnerability issue with Newtonsoft.Json v9.0.1 being installed.


