### PR TITLE
previous fix didn't work, using Build.props now

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,7 @@
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)"/>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManager)"/>
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,6 +47,7 @@
     <!-- Microsoft.Extensions.FileProviders.Physical -->
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>7.0.0-preview.3.22175.4</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+    <NuGetPackagingVersion>6.2.1</NuGetPackagingVersion>
     <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!-- Everything below here are Packages only used by test projects -->
     <!-- Microsoft.AspNetCore.Server.Kestrel -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,5 +12,6 @@
     <PackageReference Include="xunit.skippablefact" Version="$(XunitSkippableFactPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/dotnet-msidentity/dotnet-msidentity.csproj
+++ b/tools/dotnet-msidentity/dotnet-msidentity.csproj
@@ -54,7 +54,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -12,6 +12,5 @@
   <ItemGroup>
     <ProjectReference Include="..\dotnet-aspnet-codegenerator\dotnet-aspnet-codegenerator.csproj" />
     <PackageReference Include="System.Commandline" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To fix Component governance vulnerability issue with Newtonsoft.Json v9.0.1 being installed. 
#1947  didn't work.
