### PR TITLE
[Scaffolding] checking for full model name (includes namespace) when checking for db context type

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -708,7 +708,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
               
             }
             //get all types and return the one with the same name. There should be no duplicates so only one should match.
-            return _reflectedTypesProvider.GetAllTypesInProject().FirstOrDefault(r => r.Name.Equals(type, StringComparison.OrdinalIgnoreCase));
+            return _reflectedTypesProvider.GetAllTypesInProject().FirstOrDefault(
+                r => r.Name.Equals(type, StringComparison.OrdinalIgnoreCase) ||
+                     r.FullName.Equals(type, StringComparison.OrdinalIgnoreCase));
         }
 
         private void ValidateCommandLine(IdentityGeneratorCommandLineModel model)


### PR DESCRIPTION
DbContext model's full name was not being checked. For example:
```
DbContext class : 

namespace blah 
{
    public class TestDbContext : DbContext 
    {}
}
```


Now, when we pass it to dotnet-aspnet-codegenerator, we can pass it as `blah.TestDbContext` or `TestDbContext`. Before this check, passing `blah.TestDbContext` would create an additional TestDbContext as it would not find the one we are looking for.
