### PR TITLE
updating all source projects to net7.0.

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeWriter.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeWriter.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
         private static bool IsTfmPreRelease(string tfm)
         {
-            return tfm.Equals("net6.0", StringComparison.OrdinalIgnoreCase);
+            return tfm.Equals("net7.0", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void SetUserSecrets(string projectPath, string key, string value, IConsoleLogger consoleLogger)

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <OutputType>Library</OutputType>

--- a/src/Scaffolding/VS.Web.CG.Core/VS.Web.CG.Core.csproj
+++ b/src/Scaffolding/VS.Web.CG.Core/VS.Web.CG.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains the core infrastructure used by ASP.NET Core Code Generators.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Core</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Scaffolding/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>win-arm</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -6,7 +6,7 @@
 
   <Import Project="Shared.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
     <PackageId>Microsoft.VisualStudio.Web.CodeGeneration.Design</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -21,7 +21,7 @@
                       $(OutputPath)$(AssemblyName).xml;"
              Condition=" '$(DotNetBuildFromSource)' != 'true' ">
       <Pack>true</Pack>
-      <PackagePath>lib\net6.0\</PackagePath>
+      <PackagePath>lib\net7.0\</PackagePath>
     </Content>
   </ItemGroup>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
+++ b/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains Entity Framework Core Services used by ASP.NET Core Code Generators.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -21,7 +21,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
   </PropertyGroup>
 
   <PropertyGroup>
-    <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)..\toolassets\net6.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+    <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)..\toolassets\net7.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
   </PropertyGroup>
 
   <UsingTask TaskName="ProjectContextWriter"

--- a/src/Scaffolding/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MSBuild task (EvaluateProjectInfoForCodeGeneration) used by Microsoft.VisualStudio.Web.CodeGeneration.Tools</Description>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Msbuild</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Msbuild</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/Scaffolding/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
+++ b/src/Scaffolding/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Code Generators for ASP.NET Core MVC. Contains code generators for MVC Controllers and Views.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGenerators.Mvc</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGenerators.Mvc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,14 +11,14 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- This embedded resource is also packaged in order to allow VS to inspect the file. -->
-    <EmbeddedResource Include="Identity\bootstrap5_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net6.0\" />
+    <EmbeddedResource Include="Identity\bootstrap5_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net7.0\" />
     <Content Remove="Identity\bootstrap5_identitygeneratorfilesconfig.json" />
-    <EmbeddedResource Include="Identity\bootstrap4_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net6.0\" />
+    <EmbeddedResource Include="Identity\bootstrap4_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net7.0\" />
     <Content Remove="Identity\bootstrap4_identitygeneratorfilesconfig.json" />
-    <EmbeddedResource Include="Identity\bootstrap3_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net6.0\" />
+    <EmbeddedResource Include="Identity\bootstrap3_identitygeneratorfilesconfig.json" Pack="true" PackagePath="lib\net7.0\" />
     <Content Remove="Identity\bootstrap3_identitygeneratorfilesconfig.json" />
-    <EmbeddedResource Include="Identity\identityMinimalHostingChanges.json" Pack="true" PackagePath="lib\net6.0\" />
-    <EmbeddedResource Include="Minimal Api\minimalApiChanges.json" Pack="true" PackagePath="lib\net6.0\" />
+    <EmbeddedResource Include="Identity\identityMinimalHostingChanges.json" Pack="true" PackagePath="lib\net7.0\" />
+    <EmbeddedResource Include="Minimal Api\minimalApiChanges.json" Pack="true" PackagePath="lib\net7.0\" />
     <Content Remove="Identity\identityMinimalHostingChanges.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
+++ b/src/Scaffolding/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains Razor based templating host used by ASP.NET Core Code Generators.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Templating</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Templating</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains utilities used by ASP.NET Core Code Generation packages.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Utils</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Utils</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Scaffolding/VS.Web.CG/VS.Web.CG.csproj
+++ b/src/Scaffolding/VS.Web.CG/VS.Web.CG.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains the CodeGenCommand that finds the appropriate code generator and invokes it from project dependencies.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>Microsoft.DotNet.Scaffolding.Shared</AssemblyName>
     <RootNamespace>Microsoft.DotNet.Scaffolding.Shared</RootNamespace>
     <Description>Contains interfaces for Project Model and messaging for scaffolding.</Description>

--- a/test/Scaffolding/TestApps/ClassLibrary1/ClassLibrary1.csproj
+++ b/test/Scaffolding/TestApps/ClassLibrary1/ClassLibrary1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepoRoot)test\Scaffolding\TestPackage.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/Scaffolding/TestApps/ClassLibrary2/ClassLibrary2.csproj
+++ b/test/Scaffolding/TestApps/ClassLibrary2/ClassLibrary2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <Import Project="$(RepoRoot)test\Scaffolding\TestPackage.props" />
   <ItemGroup>

--- a/test/Scaffolding/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
+++ b/test/Scaffolding/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
   <Import Project="$(RepoRoot)test\Scaffolding\TestPackage.props" />
   <ItemGroup>

--- a/test/Scaffolding/TestApps/ModelTypesLocatorTestWebApp/ModelTypesLocatorTestWebApp.csproj
+++ b/test/Scaffolding/TestApps/ModelTypesLocatorTestWebApp/ModelTypesLocatorTestWebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
     <Import Project="$(RepoRoot)test\Scaffolding\TestPackage.props" />

--- a/test/Scaffolding/TestApps/PreviousPackage/PreviousPackage.csproj
+++ b/test/Scaffolding/TestApps/PreviousPackage/PreviousPackage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Scaffolding/TestApps/StablePackage/StablePackage.csproj
+++ b/test/Scaffolding/TestApps/StablePackage/StablePackage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/ProjectModelHelperTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/ProjectModelHelperTests.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
     {
         [Theory]
         [InlineData(new object[] {
-            new string[] { ".NETCoreApp,Version=v3.1", ".NETCoreApp,Version=v5.0", ".NETCoreApp,Version=v6.0", ".NETCoreApp, Version = v2.1" },
-            new string[] { "netcoreapp3.1", "net5.0", "net6.0", "netcoreapp2.1" }
+            new string[] { ".NETCoreApp,Version=v3.1", ".NETCoreApp,Version=v5.0", ".NETCoreApp,Version=v6.0", ".NETCoreApp, Version = v2.1", ".NETCoreApp,Version=v7.0" },
+            new string[] { "netcoreapp3.1", "net5.0", "net6.0", "netcoreapp2.1", "net7.0" }
         })]
         public void GetShortTfmTests(string[] tfmMonikers, string[] shortTfms)
         {

--- a/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Code Generation tool for ASP.NET Core. Contains the dotnet-aspnet-codegenerator command used for generating controllers and views. </Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Tools</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NoWarn>$(NoWarn);NU5118</NoWarn>
@@ -34,7 +34,7 @@
   <ItemGroup>
     <None Include="$(RepoRoot)\src\Scaffolding\VS.Web.CG.Msbuild\Target\build\Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets" CopyToPublishDirectory="Always" Link="build\microsoft.visualstudio.web.codegeneration.tools.targets" />
     <None Include="$(RepoRoot)\src\Scaffolding\VS.Web.CG.Msbuild\Target\buildMultiTargeting\Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets" CopyToPublishDirectory="Always" Link="buildMultiTargeting\microsoft.visualstudio.web.codegeneration.tools.targets" />
-    <None Include="$(ArtifactsBinDir)\VS.Web.CG.Msbuild\$(Configuration)\net6.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" CopyToPublishDirectory="Always" Link="toolassets\net6.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" />  
+    <None Include="$(ArtifactsBinDir)\VS.Web.CG.Msbuild\$(Configuration)\net7.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" CopyToPublishDirectory="Always" Link="toolassets\net7.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" />  
   </ItemGroup> 
 
   <ItemGroup>

--- a/tools/dotnet-msidentity/dotnet-msidentity.csproj
+++ b/tools/dotnet-msidentity/dotnet-msidentity.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Scaffolding tool for .NET projects. Contains the dotnet-scaffold command used for generating areas, views, controllers, identity pages etc. </Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>exe</OutputType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
Updating all projects to net7.0.
- overdue and removes reliance on .NET 6 runtime.


