### PR TITLE
changes for first dotnet-scaffold release

### DIFF
--- a/scripts/install-scaffold.cmd
+++ b/scripts/install-scaffold.cmd
@@ -1,4 +1,4 @@
-set VERSION=6.0.0-dev
+set VERSION=7.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/tools/dotnet-msidentity/Program.cs
+++ b/tools/dotnet-msidentity/Program.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return await parser.InvokeAsync(args);
         }
 
-        public static async Task<int> HandleListApps(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleListApps(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleListTenants(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleListTenants(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleListServicePrincipals(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleListServicePrincipals(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleRegisterApplication(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleRegisterApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleUpdateApplication(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleUpdateApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleUnregisterApplication(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleUnregisterApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleCreateAppRegistration(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleCreateAppRegistration(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleUpdateProject(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleUpdateProject(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static async Task<int> HandleClientSecrets(ProvisioningToolOptions provisioningToolOptions)
+        internal static async Task<int> HandleClientSecrets(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -168,13 +168,13 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        public static RootCommand MsIdentityCommand() =>
+        internal static RootCommand MsIdentityCommand() =>
             new RootCommand(
                 description: "Creates or updates an Azure AD / Azure AD B2C application, and updates the project, using your developer credentials (from Visual Studio, Azure CLI, Azure RM PowerShell, VS Code).\n")
             {
             };
 
-        public static Command ListAADAppsCommand() =>
+        internal static Command ListAADAppsCommand() =>
             new Command(
                 name: Commands.LIST_AAD_APPS_COMMAND,
                 description: "Lists AAD Applications for a given tenant/username.\n")
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption()
             };
 
-        public static Command ListServicePrincipalsCommand() =>
+        internal static Command ListServicePrincipalsCommand() =>
             new Command(
                 name: Commands.LIST_SERVICE_PRINCIPALS_COMMAND,
                 description: "Lists AAD Service Principals.\n")
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption()
             };
 
-        public static Command ListTenantsCommand() =>
+        internal static Command ListTenantsCommand() =>
             new Command(
                 name: Commands.LIST_TENANTS_COMMAND,
                 description: "Lists AAD and AAD B2C tenants for a given user.\n")
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 UsernameOption(), JsonOption()
             };
 
-        public static Command CreateClientSecretCommand() =>
+        internal static Command CreateClientSecretCommand() =>
             new Command(
                 name: Commands.ADD_CLIENT_SECRET,
                 description: "Create client secret for an Azure AD or AD B2C app registration.\n")
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), ClientIdOption(), ProjectFilePathOption(), UpdateUserSecretsOption()
             };
 
-        public static Command RegisterApplicationCommand() =>
+        internal static Command RegisterApplicationCommand() =>
             new Command(
                 name: Commands.REGISTER_APPLICATIION_COMMAND,
                 description: "Register an Azure AD or Azure AD B2C app registration in Azure and update the project." +
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), ClientIdOption(), ClientSecretOption(), HostedAppIdUriOption(), ApiClientIdOption(), SusiPolicyIdOption(), ProjectFilePathOption()
             };
 
-        public static Command UpdateProjectCommand() =>
+        internal static Command UpdateProjectCommand() =>
             new Command(
                 name: Commands.UPDATE_PROJECT_COMMAND,
                 description: "Update an Azure AD/AD B2C app registration in Azure and the project." +
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), ClientIdOption(), JsonOption(), ProjectFilePathOption(), ConfigUpdateOption(), CodeUpdateOption(), PackagesUpdateOption(), CallsGraphOption(), CallsDownstreamApiOption(), UpdateUserSecretsOption(), RedirectUriOption()
             };
 
-        public static Command UpdateAppRegistrationCommand() =>
+        internal static Command UpdateAppRegistrationCommand() =>
             new Command(
                 name: Commands.UPDATE_APP_REGISTRATION_COMMAND,
                 description: "Update an Azure AD/AD B2C app registration in Azure.\n")
@@ -234,7 +234,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), HostedAppIdUriOption(), ClientIdOption(), RedirectUriOption(), EnableIdTokenOption(), EnableAccessToken(), ClientProjectOption()
             };
 
-        public static Command CreateAppRegistrationCommand() =>
+        internal static Command CreateAppRegistrationCommand() =>
             new Command(
                 name: Commands.CREATE_APP_REGISTRATION_COMMAND,
                 description: "Create an Azure AD/AD B2C app registration in Azure.\n")
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), AppDisplayName(), ProjectFilePathOption(), ProjectType(), ClientProjectOption()
             };
 
-        public static Command UnregisterApplicationCommand() =>
+        internal static Command UnregisterApplicationCommand() =>
             new Command(
                 name: Commands.UNREGISTER_APPLICATION_COMMAND,
 

--- a/tools/dotnet-msidentity/Program.cs
+++ b/tools/dotnet-msidentity/Program.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return await parser.InvokeAsync(args);
         }
 
-        private static async Task<int> HandleListApps(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleListApps(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleListTenants(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleListTenants(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleListServicePrincipals(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleListServicePrincipals(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleRegisterApplication(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleRegisterApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleUpdateApplication(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleUpdateApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleUnregisterApplication(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleUnregisterApplication(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleCreateAppRegistration(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleCreateAppRegistration(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleUpdateProject(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleUpdateProject(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static async Task<int> HandleClientSecrets(ProvisioningToolOptions provisioningToolOptions)
+        public static async Task<int> HandleClientSecrets(ProvisioningToolOptions provisioningToolOptions)
         {
             if (provisioningToolOptions != null)
             {
@@ -168,13 +168,13 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             return -1;
         }
 
-        private static RootCommand MsIdentityCommand() =>
+        public static RootCommand MsIdentityCommand() =>
             new RootCommand(
                 description: "Creates or updates an Azure AD / Azure AD B2C application, and updates the project, using your developer credentials (from Visual Studio, Azure CLI, Azure RM PowerShell, VS Code).\n")
             {
             };
 
-        private static Command ListAADAppsCommand() =>
+        public static Command ListAADAppsCommand() =>
             new Command(
                 name: Commands.LIST_AAD_APPS_COMMAND,
                 description: "Lists AAD Applications for a given tenant/username.\n")
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption()
             };
 
-        private static Command ListServicePrincipalsCommand() =>
+        public static Command ListServicePrincipalsCommand() =>
             new Command(
                 name: Commands.LIST_SERVICE_PRINCIPALS_COMMAND,
                 description: "Lists AAD Service Principals.\n")
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption()
             };
 
-        private static Command ListTenantsCommand() =>
+        public static Command ListTenantsCommand() =>
             new Command(
                 name: Commands.LIST_TENANTS_COMMAND,
                 description: "Lists AAD and AAD B2C tenants for a given user.\n")
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 UsernameOption(), JsonOption()
             };
 
-        private static Command CreateClientSecretCommand() =>
+        public static Command CreateClientSecretCommand() =>
             new Command(
                 name: Commands.ADD_CLIENT_SECRET,
                 description: "Create client secret for an Azure AD or AD B2C app registration.\n")
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), ClientIdOption(), ProjectFilePathOption(), UpdateUserSecretsOption()
             };
 
-        private static Command RegisterApplicationCommand() =>
+        public static Command RegisterApplicationCommand() =>
             new Command(
                 name: Commands.REGISTER_APPLICATIION_COMMAND,
                 description: "Register an Azure AD or Azure AD B2C app registration in Azure and update the project." +
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), ClientIdOption(), ClientSecretOption(), HostedAppIdUriOption(), ApiClientIdOption(), SusiPolicyIdOption(), ProjectFilePathOption()
             };
 
-        private static Command UpdateProjectCommand() =>
+        public static Command UpdateProjectCommand() =>
             new Command(
                 name: Commands.UPDATE_PROJECT_COMMAND,
                 description: "Update an Azure AD/AD B2C app registration in Azure and the project." +
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), ClientIdOption(), JsonOption(), ProjectFilePathOption(), ConfigUpdateOption(), CodeUpdateOption(), PackagesUpdateOption(), CallsGraphOption(), CallsDownstreamApiOption(), UpdateUserSecretsOption(), RedirectUriOption()
             };
 
-        private static Command UpdateAppRegistrationCommand() =>
+        public static Command UpdateAppRegistrationCommand() =>
             new Command(
                 name: Commands.UPDATE_APP_REGISTRATION_COMMAND,
                 description: "Update an Azure AD/AD B2C app registration in Azure.\n")
@@ -234,7 +234,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), HostedAppIdUriOption(), ClientIdOption(), RedirectUriOption(), EnableIdTokenOption(), EnableAccessToken(), ClientProjectOption()
             };
 
-        private static Command CreateAppRegistrationCommand() =>
+        public static Command CreateAppRegistrationCommand() =>
             new Command(
                 name: Commands.CREATE_APP_REGISTRATION_COMMAND,
                 description: "Create an Azure AD/AD B2C app registration in Azure.\n")
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption(), UsernameOption(), JsonOption(), AppDisplayName(), ProjectFilePathOption(), ProjectType(), ClientProjectOption()
             };
 
-        private static Command UnregisterApplicationCommand() =>
+        public static Command UnregisterApplicationCommand() =>
             new Command(
                 name: Commands.UNREGISTER_APPLICATION_COMMAND,
 

--- a/tools/dotnet-msidentity/Properties/AssemblyInfo.cs
+++ b/tools/dotnet-msidentity/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("dotnet-scaffold, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
         private static Option TargetFrameworkOption() =>
             new Option<string>(
                 aliases: new[] { "-tfm", "--target-framework" },
-                description: "Target Framework to use.For example, net46.")
+                description: "Target Framework to use. For example, net46.")
             {
                 IsRequired = false
             };
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
         private static Command ScaffoldAreaCommand() =>
             new Command(
                 name: AREA_COMMAND,
-                description: "Scaffolds an Area.")
+                description: "Scaffolds an Area")
             {
                 // Arguments & Options
                 AreaNameArgument()
@@ -366,7 +366,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
         private static Command ScaffoldRazorPageCommand() =>
             new Command(
                 name: RAZORPAGE_COMMAND,
-                description: "Scaffolds Razor pages.")
+                description: "Scaffolds Razor pages")
             {
                 // Arguments
                 RazorPageNameArgument(), TemplateNameArgument(),

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -1,20 +1,20 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Diagnostics;
-using System.Threading.Tasks;
+using Microsoft.DotNet.MSIdentity.Tool;
 
 namespace Microsoft.DotNet.Tools.Scaffold
 {
     public class Program
     {
         private const string SCAFFOLD_COMMAND = "scaffold";
-        private const string AREA_COMMAND = "area";
-        private const string CONTROLLER_COMMAND = "controller";
-        private const string IDENTITY_COMMAND = "identity";
-        private const string RAZORPAGE_COMMAND = "razorpage";
-        private const string VIEW_COMMAND = "view";
+        private const string AREA_COMMAND = "--area";
+        private const string CONTROLLER_COMMAND = "--controller";
+        private const string IDENTITY_COMMAND = "--identity";
+        private const string RAZORPAGE_COMMAND = "--razorpage";
+        private const string VIEW_COMMAND = "--view";
         /* 
         dotnet scaffold [generator] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
 
@@ -40,6 +40,45 @@ namespace Microsoft.DotNet.Tools.Scaffold
             rootCommand.AddCommand(ScaffoldRazorPageCommand());
             rootCommand.AddCommand(ScaffoldViewCommand());
             rootCommand.AddCommand(ScaffoldIdentityCommand());
+            //msidentity commands
+            //internal commands
+            var listAadAppsCommand = MSIdentity.Tool.Program.ListAADAppsCommand();
+            var listServicePrincipalsCommand = MSIdentity.Tool.Program.ListServicePrincipalsCommand();
+            var listTenantsCommand = MSIdentity.Tool.Program.ListTenantsCommand();
+            var createClientSecretCommand = MSIdentity.Tool.Program.CreateClientSecretCommand();
+
+            //exposed commands
+            var registerApplicationCommand = MSIdentity.Tool.Program.RegisterApplicationCommand();
+            var unregisterApplicationCommand = MSIdentity.Tool.Program.UnregisterApplicationCommand();
+            var updateAppRegistrationCommand = MSIdentity.Tool.Program.UpdateAppRegistrationCommand();
+            var updateProjectCommand = MSIdentity.Tool.Program.UpdateProjectCommand();
+            var createAppRegistration = MSIdentity.Tool.Program.CreateAppRegistrationCommand();
+
+            //hide internal commands.
+            listAadAppsCommand.IsHidden = true;
+            listServicePrincipalsCommand.IsHidden = true;
+            listTenantsCommand.IsHidden = true;
+            updateProjectCommand.IsHidden = true;
+            createClientSecretCommand.IsHidden = true;
+
+            listAadAppsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListApps);
+            listServicePrincipalsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListServicePrincipals);
+            listTenantsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListTenants);
+            registerApplicationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleRegisterApplication);
+            unregisterApplicationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUnregisterApplication);
+            createAppRegistration.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleCreateAppRegistration);
+            updateAppRegistrationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateApplication);
+            updateProjectCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateProject);
+            createClientSecretCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleClientSecrets);
+            rootCommand.AddCommand(listAadAppsCommand);
+            rootCommand.AddCommand(listServicePrincipalsCommand);
+            rootCommand.AddCommand(listTenantsCommand);
+            rootCommand.AddCommand(registerApplicationCommand);
+            rootCommand.AddCommand(unregisterApplicationCommand);
+            rootCommand.AddCommand(createAppRegistration);
+            rootCommand.AddCommand(updateAppRegistrationCommand);
+            rootCommand.AddCommand(updateProjectCommand);
+            rootCommand.AddCommand(createClientSecretCommand);
 
             rootCommand.Description = "dotnet scaffold [command] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] ";
             if (args.Length == 0)
@@ -71,6 +110,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
                         // The help option for the commands are handled by System.Commandline.
                         return 0;
                     }
+                    args[0] = args[0].Replace("--", "");
                     return VisualStudio.Web.CodeGeneration.Tools.Program.Main(args);
                 default:
                     // The command is not handled by 'dotnet scaffold'.

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotnet-aspnet-codegenerator\dotnet-aspnet-codegenerator.csproj" />
-    <PackageReference Include="System.Commandline" Version="2.0.0-beta1.20574.7" />
+    <ProjectReference Include="$(RepoRoot)\tools\dotnet-aspnet-codegenerator\dotnet-aspnet-codegenerator.csproj" />
+    <ProjectReference Include="$(RepoRoot)\tools\dotnet-msidentity\dotnet-msidentity.csproj" />
+    <PackageReference Include="System.Commandline"  Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
dotnet-scaffold changes:
- adding dotnet-msidentity commands.
- dotnet-aspnet-codegenerator commands have additional `--`. 
- dotnet-scaffold Program.cs calls into the CommandHandlers in Microsoft.DotNet.Tool.Program's CommandHandlers.

Previous help:
```
scaffold:
  dotnet scaffold [command] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build]

Usage:
  scaffold [options] [command]

Options:
  -p, --project <project>                        Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
  -n, --nuget-package-dir <nuget-package-dir>    Specifies the NuGet package directory.
  -c, --configuration <configuration>            Defines the build configuration. The default value is Debug. [default: Debug]
  -tfm, --target-framework <target-framework>    Target Framework to use.For example, net46.
  -b, --build-base-path <build-base-path>        The build base path.
  --no-build                                     Doesn't build the project before running. It also implicitly sets the --no-restore flag.
  --version                                      Show version information
  -?, -h, --help                                 Show help and usage information

Commands:
  area <AreaNameToGenerate>                             Scaffolds an Area.
  controller                                            Scaffolds a Controller
  razorpage <RazorpageNameToGenerate> <TemplateName>    Scaffolds Razor pages.
  view <ViewNameToGenerate> <TemplateName>              Scaffolds a View
  identity                                              Scaffolds Identity

```

New help:
```
scaffold
  dotnet scaffold [command] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 

Usage:
  scaffold [options] [command]

Options:
  -p, --project <project>                      Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
  -n, --nuget-package-dir <nuget-package-dir>  Specifies the NuGet package directory.
  -c, --configuration <configuration>          Defines the build configuration. The default value is Debug. [default: Debug]
  -tfm, --target-framework <target-framework>  Target Framework to use.For example, net46.
  -b, --build-base-path <build-base-path>      The build base path.
  --no-build                                   Doesn't build the project before running. It also implicitly sets the --no-restore flag.
  --version                                    Show version information
  -?, -h, --help                               Show help and usage information

Commands:
  --area <AreaNameToGenerate>                           Scaffolds an Area.
  --controller                                          Scaffolds a Controller
  --razorpage <RazorpageNameToGenerate> <TemplateName>  Scaffolds Razor pages.
  --view <ViewNameToGenerate> <TemplateName>            Scaffolds a View
  --identity                                            Scaffolds Identity
  --register-app                                        Register an Azure AD or Azure AD B2C app registration in Azure and update the project.
                                                        	- Updates the appsettings.json file.
  
  --unregister-app                                      Unregister an Azure AD or Azure AD B2C app registration in Azure.
                                                        	- Updates the appsettings.json file.
  
  --create-app-registration                             Create an Azure AD/AD B2C app registration in Azure.
  
  --update-app-registration                             Update an Azure AD/AD B2C app registration in Azure.
  
```
