### PR TITLE
Fix B2C Bugs

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
                 .AddAsync(servicePrincipal).ConfigureAwait(false);
 
             // B2C does not allow user consent, and therefore we need to explicity grant permissions
-            if (applicationParameters.IsB2C)
+            if (applicationParameters.IsB2C && applicationParameters.CallsDownstreamApi) // TODO need to have admin permissions for the downstream API
             {
                 IEnumerable<IGrouping<string, ResourceAndScope>>? scopesPerResource = await AddApiPermissions(
                     applicationParameters,
@@ -112,6 +112,11 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
             {
                 consoleLogger.LogJsonMessage(new JsonResponse(commandName, State.Fail, output: Resources.FailedToCreateApp));
                 return null;
+            }
+
+            if (applicationParameters.IsB2C)
+            {
+                createdApplication.AdditionalData.Add("IsB2C", true);
             }
 
             ApplicationParameters? effectiveApplicationParameters = GetEffectiveApplicationParameters(tenant!, createdApplication, applicationParameters);

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -125,6 +125,15 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 
                 if (applicationList.Any())
                 {
+                    Organization? tenant = await GetTenant(GraphServiceClient);
+                    if (tenant != null && tenant.TenantType.Equals("AAD B2C", StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (Application app in applicationList)
+                        {
+                            app.AdditionalData.Add("IsB2C", true);
+                        }
+                    }
+
                     //order list by created date.
                     applicationList = applicationList.OrderByDescending(app => app.CreatedDateTime).ToList();
 
@@ -149,6 +158,40 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 
             return outputJsonString;
         }
+
+        private static async Task<Organization?> GetTenant(GraphServiceClient graphServiceClient)
+        {
+            Organization? tenant = null;
+            try
+            {
+                tenant = (await graphServiceClient.Organization
+                    .Request()
+                    .GetAsync()).FirstOrDefault();
+            }
+            catch (ServiceException ex)
+            {
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine(ex.InnerException.Message);
+                }
+                else
+                {
+                    if (ex.Message.Contains("User was not found") || ex.Message.Contains("not found in tenant"))
+                    {
+                        Console.WriteLine("User was not found.\nUse both --tenant-id <tenant> --username <username@tenant>.\nAnd re-run the tool.");
+                    }
+                    else
+                    {
+                        Console.WriteLine(ex.Message);
+                    }
+                }
+
+                Environment.Exit(1);
+            }
+
+            return tenant;
+        }
+
 
         internal async Task<string> PrintServicePrincipalList()
         {


### PR DESCRIPTION
Adds check for "Downstream API" before adding API permissions for B2C apps
Adds "IsB2C" field to app registrations, so that "calls-graph" checkbox is disabled for B2C Apps
