### PR TITLE
init. Removed dependency on MSBuildLocator.RegisterDefaults().

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -62,12 +61,6 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             if (codeModifierConfig is null || !codeModifierConfig.Files.Any())
             {
                 return;
-            }
-
-            // Initialize Microsoft.Build assemblies
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
             }
 
             // Initialize CodeAnalysis.Project wrapper

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
@@ -37,7 +37,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\Shared\Microsoft.DotNet.Scaffolding.Shared\Microsoft.DotNet.Scaffolding.Shared.csproj" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0"/>
     <Folder Include="Resources\" />
   </ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Design/CodeGenCommandExecutor.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/CodeGenCommandExecutor.cs
@@ -74,8 +74,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
         {
             var applicationInfo = new ApplicationInfo(
                 projectInformation.ProjectName,
-                Path.GetDirectoryName(projectInformation.ProjectFullPath),
-                new RoslynWorkspaceHelper(projectInformation.ProjectFullPath));
+                Path.GetDirectoryName(projectInformation.ProjectFullPath));
             serviceProvider.Add<IProjectContext>(projectInformation);
             serviceProvider.Add<IApplicationInfo>(applicationInfo);
             serviceProvider.Add<ICodeGenAssemblyLoadContext>(new DefaultAssemblyLoadContext());

--- a/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -14,7 +14,6 @@
   
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\Shared\Microsoft.DotNet.Scaffolding.Shared\Microsoft.DotNet.Scaffolding.Shared.csproj" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(OutputPath)$(AssemblyName).dll;

--- a/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
@@ -91,10 +90,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             var startupType = _modelTypesLocator.GetType(startupClassName).FirstOrDefault() ?? _modelTypesLocator.GetType("Startup").FirstOrDefault();
 
             ModelType dbContextSymbolInWebProject = null;
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
             //if there is no Startup.cs (minimal hosting app), this scaffolding scanerio is not supported.
             if (startupType == null)
             {
@@ -307,7 +302,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 
         private async Task AddModelTypeToExistingDbContextIfNeeded(ModelType dbContextSymbol, IApplicationInfo appInfo)
         {
-            bool nullabledEnabled = "enable".Equals(appInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase);
+            bool nullabledEnabled = "enable".Equals(_projectContext.Nullable, StringComparison.OrdinalIgnoreCase);
             var addResult = _dbContextEditorServices.AddModelToContext(dbContextSymbol, _modelTypeSymbol, nullabledEnabled);
             var projectCompilation = await _workspace.CurrentSolution.Projects
                 .First(project => project.AssemblyName == _projectContext.AssemblyName)
@@ -382,7 +377,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             }
             // Create a new Context
             _logger.LogMessage(string.Format(MessageStrings.GeneratingDbContext, _dbContextFullTypeName));
-            bool nullabledEnabled = "enable".Equals(applicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase);
+            bool nullabledEnabled = "enable".Equals(_projectContext.Nullable, StringComparison.OrdinalIgnoreCase);
             bool useTopLevelsStatements = await ProjectModifierHelper.IsUsingTopLevelStatements(_modelTypesLocator);
             var dbContextTemplateModel = new NewDbContextTemplateModel(_dbContextFullTypeName, _modelTypeSymbol, programType, nullabledEnabled);
             _dbContextSyntaxTree = await _dbContextEditorServices.AddNewContext(dbContextTemplateModel);
@@ -451,7 +446,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             }
             // Create a new Context
             _logger.LogMessage(string.Format(MessageStrings.GeneratingDbContext, _dbContextFullTypeName));
-            bool nullabledEnabled = "enable".Equals(applicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase);
+            bool nullabledEnabled = "enable".Equals(_projectContext.Nullable, StringComparison.OrdinalIgnoreCase);
             var dbContextTemplateModel = new NewDbContextTemplateModel(_dbContextFullTypeName, _modelTypeSymbol, programType, nullabledEnabled);
 
             _dbContextSyntaxTree = await _dbContextEditorServices.AddNewContext(dbContextTemplateModel);

--- a/src/Scaffolding/VS.Web.CG.Msbuild/ProjectContextWriter.cs
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/ProjectContextWriter.cs
@@ -83,6 +83,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
 
         //not required as it might not get a value (fails if required and value not present).
         public string GeneratedImplicitNamespaceImportFile { get; set; }
+
+        //not required as it might not get a value (fails if required and value not present).
+        public string Nullable { get; set; }
         #endregion
 
         public override bool Execute()
@@ -108,7 +111,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
                 TargetDirectory = this.TargetDirectory,
                 TargetFramework = this.TargetFramework,
                 TargetFrameworkMoniker = this.TargetFrameworkMoniker, 
-                GeneratedImplicitNamespaceImportFile = this.GeneratedImplicitNamespaceImportFile
+                GeneratedImplicitNamespaceImportFile = this.GeneratedImplicitNamespaceImportFile,
+                Nullable = this.Nullable
             };
 
             var projectReferences = msBuildContext.ProjectReferences;

--- a/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -48,6 +48,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           ProjectRuntimeConfigFileName="$(ProjectRuntimeConfigFileName)"
                           ProjectAssetsFile="$(ProjectAssetsFile)"
                           GeneratedImplicitNamespaceImportFile = "$(GeneratedImplicitNamespaceImportFile)"
+                          Nullable = "$(Nullable)"
     />
  </Target>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.Project;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
@@ -81,10 +80,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                 controllerGeneratorModel.ControllerName = modelTypeAndContextModel.ModelType.Name + Constants.ControllerSuffix;
             }
 
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
             var namespaceName = string.IsNullOrEmpty(controllerGeneratorModel.ControllerNamespace)
                 ? GetDefaultControllerNamespace(controllerGeneratorModel.RelativeFolderPath)
                 : controllerGeneratorModel.ControllerNamespace;
@@ -95,7 +90,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                 UseAsync = controllerGeneratorModel.UseAsync, // This is no longer used for controllers with context.
                 ControllerNamespace = namespaceName,
                 ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata,
-                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
+                NullableEnabled = "enable".Equals(ProjectContext.Nullable, StringComparison.OrdinalIgnoreCase)
             };
 
             await CodeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, GetTemplateName(controllerGeneratorModel), TemplateFolders, templateModel);

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -75,11 +74,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 ModelTypesLocator,
                 areaName : string.Empty);
 
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
-
             if (!string.IsNullOrEmpty(modelTypeAndContextModel.DbContextFullName) && CalledFromCommandline)
             {
                 EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, useSqlite: model.UseSqlite);
@@ -90,7 +84,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 EndpointsName = model.EndpintsClassName,
                 EndpointsNamespace = namespaceName,
                 ModelMetadata = modelTypeAndContextModel.ContextProcessingResult?.ModelMetadata,
-                NullableEnabled = "enable".Equals(AppInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase),
+                NullableEnabled = "enable".Equals(ProjectContext?.Nullable, StringComparison.OrdinalIgnoreCase),
                 OpenAPI = model.OpenApi,
                 MethodName = $"Map{modelTypeAndContextModel.ModelType.Name}Endpoints",
                 UseSqlite = model.UseSqlite

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageGeneratorTemplateModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
         public IModelMetadata ModelMetadata { get; set; }
 
         public string JQueryVersion { get; set; }
-        public bool NullableEnabled { get; set; } = false;
+        public string NullableEnabled { get; set; } 
 
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration;
@@ -252,7 +251,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 JQueryVersion = "1.10.2", //Todo
                 BootstrapVersion = razorGeneratorModel.BootstrapVersion,
                 ContentVersion = DetermineContentVersion(razorGeneratorModel),
-                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
+                NullableEnabled = _projectContext.Nullable
             };
 
             return templateModel;
@@ -270,11 +269,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             if (string.IsNullOrEmpty(razorGeneratorModel.BootstrapVersion))
             {
                 razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
-            }
-
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
             }
 
             RazorPageWithContextTemplateModel2 templateModel = new RazorPageWithContextTemplateModel2(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName)
@@ -295,7 +289,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 BootstrapVersion = razorGeneratorModel.BootstrapVersion,
                 ContentVersion = DetermineContentVersion(razorGeneratorModel),
                 UseSqlite = razorGeneratorModel.UseSqlite,
-                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
+                NullableEnabled = _projectContext.Nullable
             };
 
             return templateModel;

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGeneratorTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewGeneratorTemplateModel.cs
@@ -25,6 +25,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
         public IModelMetadata ModelMetadata { get; set; }
 
         public string JQueryVersion { get; set; }
-        public bool NullableEnabled { get; set; }
+        public string NullableEnabled { get; set; }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/ViewScaffolderBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
@@ -168,10 +167,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             bool isLayoutSelected = !viewGeneratorModel.PartialView &&
                 (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
 
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
             ViewGeneratorTemplateModel templateModel = new ViewGeneratorTemplateModel()
             {
                 ViewDataTypeName = modelTypeAndContextModel?.ModelType?.FullName,
@@ -183,7 +178,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 ReferenceScriptLibraries = viewGeneratorModel.ReferenceScriptLibraries,
                 ModelMetadata = modelTypeAndContextModel?.ContextProcessingResult?.ModelMetadata,
                 JQueryVersion = "1.10.2", //Todo,
-                NullableEnabled = "enable".Equals(ApplicationInfo?.WorkspaceHelper?.GetMsBuildProperty("Nullable"), StringComparison.OrdinalIgnoreCase)
+                NullableEnabled = _projectContext.Nullable
             };
 
             return templateModel;

--- a/src/Scaffolding/VS.Web.CG.Utils/DotNet/ApplicationInfo.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/DotNet/ApplicationInfo.cs
@@ -8,13 +8,13 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
 {
     public class ApplicationInfo : IApplicationInfo
     {
-        public ApplicationInfo(string appName, string appBasePath, RoslynWorkspaceHelper workspaceHelper)
-            : this(appName, appBasePath, "Debug", workspaceHelper)
+        public ApplicationInfo(string appName, string appBasePath)
+            : this(appName, appBasePath, "Debug")
         {
 
         }
 
-        public ApplicationInfo(string appName, string appBasePath, string appConfiguration, RoslynWorkspaceHelper workspaceHelper)
+        public ApplicationInfo(string appName, string appBasePath, string appConfiguration)
         {
             if (appName == null)
             {
@@ -31,7 +31,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
             ApplicationName = appName;
             ApplicationBasePath = appBasePath;
             ApplicationConfiguration = appConfiguration;
-            WorkspaceHelper = workspaceHelper;
         }
 
         public string ApplicationBasePath
@@ -45,11 +44,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
         }
 
         public string ApplicationConfiguration
-        {
-            get; private set;
-        }
-
-        public RoslynWorkspaceHelper WorkspaceHelper
         {
             get; private set;
         }

--- a/src/Scaffolding/VS.Web.CG.Utils/DotNet/IApplicationInfo.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/DotNet/IApplicationInfo.cs
@@ -9,6 +9,5 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.DotNet
         string ApplicationBasePath { get; }
         string ApplicationName { get; }
         string ApplicationConfiguration { get; }
-        RoslynWorkspaceHelper WorkspaceHelper { get;  }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Contains utilities used by ASP.NET Core Code Generation packages.</Description>
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
 

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
@@ -34,12 +34,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             var id = AddProject(projectInformation, configuration);
             // Since we have resolved all references, we can directly use them as MetadataReferences.
             // Trying to get ProjectReferences manually might lead to problems when the projects have circular dependency.
-            if (!MSBuildLocator.IsRegistered)
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
-            RoslynWorkspaceHelper roslynHelper = new RoslynWorkspaceHelper(projectInformation.ProjectFullPath);
-            var projReferenceInformation = roslynHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
+
+            //System.Diagnostics.Debugger.Launch();
+            var projReferenceInformation = RoslynWorkspaceHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
 
             if (projReferenceInformation != null && projReferenceInformation.Any())
             {

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -34,8 +34,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             var id = AddProject(projectInformation, configuration);
             // Since we have resolved all references, we can directly use them as MetadataReferences.
             // Trying to get ProjectReferences manually might lead to problems when the projects have circular dependency.
-
-            //System.Diagnostics.Debugger.Launch();
             var projReferenceInformation = RoslynWorkspaceHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
 
             if (projReferenceInformation != null && projReferenceInformation.Any())

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using Microsoft.CodeAnalysis;

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
@@ -7,59 +7,9 @@ using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
 {
-    public class RoslynWorkspaceHelper
+    public static class RoslynWorkspaceHelper
     {
-        private string _projectPath;
-        private Project _project;
-        public Project MsBuildProject
-        {
-            get
-            {
-                if (_project == null)
-                {
-                    _project = new Project(_projectPath);
-                }
-                return _project;
-            }
-        }
-
-        public RoslynWorkspaceHelper(string projectPath)
-        {
-            _projectPath = projectPath;
-        }
-
-        public Dictionary<string, string> GetMsBuildProperties(IEnumerable<string> properties)
-        {
-            Dictionary<string, string> msbuildProperties = new Dictionary<string, string>();
-            if (properties != null && properties.Any())
-            {
-                foreach (string property in properties)
-                {
-                    string value = GetMsBuildProperty(property);
-                    if (!string.IsNullOrEmpty(value))
-                    {
-                        msbuildProperties.Add(property, value);
-                    }
-                }
-            }
-            return msbuildProperties;
-        }
-
-        public string GetMsBuildProperty(string property)
-        {
-            if (!string.IsNullOrEmpty(property))
-            {
-                string value = MsBuildProject?.GetProperty(property)?.EvaluatedValue;
-                if (!string.IsNullOrEmpty(value))
-                {
-                    return value;
-                }
-            }
-
-            return string.Empty;
-        }
-
-        internal IEnumerable<ProjectReferenceInformation> GetProjectReferenceInformation(IEnumerable<string> projectReferenceStrings)
+        internal static IEnumerable<ProjectReferenceInformation> GetProjectReferenceInformation(IEnumerable<string> projectReferenceStrings)
         {
             List<ProjectReferenceInformation> projectReferenceInformation = new List<ProjectReferenceInformation>();
             if (projectReferenceStrings != null && projectReferenceStrings.Any())
@@ -81,7 +31,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             return projectReferenceInformation;
         }
 
-        private ProjectReferenceInformation GetProjectInformation(Project project)
+        internal static ProjectReferenceInformation GetProjectInformation(Project project)
         {
             var compileItems = project.GetItems("Compile").Select(i => i.EvaluatedInclude);
             var fullPath = project.FullPath;

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/CommonProjectContext.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/CommonProjectContext.cs
@@ -74,5 +74,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
 
         /// <inheritdoc/>
         public string GeneratedImplicitNamespaceImportFile { get; set; }
+
+        public string Nullable { get; set; }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/IProjectContext.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/IProjectContext.cs
@@ -129,5 +129,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
         /// .cs file in obj folder generated at compile time with all default namespace imports in .NET 6+.
         /// </summary>
         string GeneratedImplicitNamespaceImportFile { get; }
+
+        string Nullable { get; }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
@@ -57,7 +57,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
                 TargetDirectory = projectInformation.TargetDirectory,
                 TargetFramework = projectInformation.TargetFramework,
                 TargetFrameworkMoniker = projectInformation.TargetFrameworkMoniker,
-                GeneratedImplicitNamespaceImportFile = projectInformation.GeneratedImplicitNamespaceImportFile
+                GeneratedImplicitNamespaceImportFile = projectInformation.GeneratedImplicitNamespaceImportFile,
+                Nullable = projectInformation.Nullable
             };
             return newProjectContext;
         }

--- a/test/Scaffolding/Shared/MSBuildProjectStrings.cs
+++ b/test/Scaffolding/Shared/MSBuildProjectStrings.cs
@@ -11,6 +11,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     internal class MsBuildProjectStrings
     {
         public const string RootProjectName = "Test.csproj";
+        public const string RootProjectName2 = "Test2.csproj";
+        public const string RootProjectName3 = "Test3.csproj";
+
         public const string RootProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk.Web"">
   <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" Condition=""Exists('$(MSBuildThisFileDirectory)\TestCodeGeneration.targets')"" />
@@ -909,6 +912,37 @@ namespace Test
   </ItemGroup>
 </Project>
 ";
+        public const string Net6NullableEnabled = @"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" />
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>
+";
+
+        public const string Net6NullableDisabled = @"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" />
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>
+";
+
+        public const string Net6NullableMissing = @"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" />
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>";
+
         public const string BaseDbContextText = @"
 using Microsoft.EntityFrameworkCore;
 using Test.Models;
@@ -1134,7 +1168,8 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           ProjectDepsFileName=""$(ProjectDepsFileName)""
                           ProjectRuntimeConfigFileName=""$(ProjectRuntimeConfigFileName)""
                           ProjectAssetsFile=""$(ProjectAssetsFile)""
-                          GeneratedImplicitNamespaceImportFile = ""$(GeneratedImplicitNamespaceImportFile)""/>
+                          GeneratedImplicitNamespaceImportFile = ""$(GeneratedImplicitNamespaceImportFile)""
+                          Nullable=""$(Nullable)""/>
   </Target>
 </Project>
 ";

--- a/test/Scaffolding/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Scaffolding/Shared/MsBuildProjectSetupHelper.cs
@@ -92,6 +92,25 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             RestoreAndBuild(fileProvider.Root, outputHelper);
         }
 
+        internal void SetupCodeGenerationProjectNullableMissing(TemporaryFileProvider fileProvider, ITestOutputHelper outputHelper)
+        {
+            fileProvider.Add("global.json", GlobalJsonText);
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "net6.0"));
+
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.ProjectContextWriterMsbuildHelperText);
+
+            var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+            fileProvider.Copy(msbuildTaskDllPath, "toolAssets/net6.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+
+            var rootProjectTxt = MsBuildProjectStrings.Net6NullableMissing;
+            fileProvider.Add(MsBuildProjectStrings.RootProjectName3, rootProjectTxt);
+            fileProvider.Add("Startup.cs", MsBuildProjectStrings.EmptyTestStartupText);
+            fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
+            fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
+
+            RestoreAndBuild(fileProvider.Root, outputHelper);
+        }
+
         internal void SetupCodeGenerationProjectNullableEnabled(TemporaryFileProvider fileProvider, ITestOutputHelper outputHelper)
         {
             fileProvider.Add("global.json", GlobalJsonText);

--- a/test/Scaffolding/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Scaffolding/Shared/MsBuildProjectSetupHelper.cs
@@ -73,6 +73,44 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             RestoreAndBuild(fileProvider.Root, outputHelper);
         }
 
+        internal void SetupCodeGenerationProjectNullableDisabled(TemporaryFileProvider fileProvider, ITestOutputHelper outputHelper)
+        {
+            fileProvider.Add("global.json", GlobalJsonText);
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "net6.0"));
+
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.ProjectContextWriterMsbuildHelperText);
+
+            var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+            fileProvider.Copy(msbuildTaskDllPath, "toolAssets/net6.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+
+            var rootProjectTxt = MsBuildProjectStrings.Net6NullableDisabled;
+            fileProvider.Add(MsBuildProjectStrings.RootProjectName2, rootProjectTxt);
+            fileProvider.Add("Startup.cs", MsBuildProjectStrings.EmptyTestStartupText);
+            fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
+            fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
+
+            RestoreAndBuild(fileProvider.Root, outputHelper);
+        }
+
+        internal void SetupCodeGenerationProjectNullableEnabled(TemporaryFileProvider fileProvider, ITestOutputHelper outputHelper)
+        {
+            fileProvider.Add("global.json", GlobalJsonText);
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "net6.0"));
+
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.ProjectContextWriterMsbuildHelperText);
+
+            var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+            fileProvider.Copy(msbuildTaskDllPath, "toolAssets/net6.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+
+            var rootProjectTxt = MsBuildProjectStrings.Net6NullableEnabled;
+            fileProvider.Add(MsBuildProjectStrings.RootProjectName3, rootProjectTxt);
+            fileProvider.Add("Startup.cs", MsBuildProjectStrings.EmptyTestStartupText);
+            fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
+            fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
+
+            RestoreAndBuild(fileProvider.Root, outputHelper);
+        }
+
         public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));

--- a/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -42,6 +42,36 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
             }
         }
 
+        [Fact]
+        public void TestProjectContextNullableDisabled()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupCodeGenerationProjectNullableDisabled(fileProvider, _outputHelper);
+                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName2);
+
+                var projectContext = GetProjectContext(path, true);
+                //we know the project name is Test so test some basic properties.
+                Assert.NotNull(projectContext.Nullable);
+                Assert.Equal("disable", projectContext.Nullable);
+            }
+        }
+
+        [Fact]
+        public void TestProjectContextNullableEnabled()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupCodeGenerationProjectNullableEnabled(fileProvider, _outputHelper);
+                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName3);
+
+                var projectContext = GetProjectContext(path, true);
+                //we know the project name is Test so test some basic properties.
+                Assert.NotNull(projectContext.Nullable);
+                Assert.Equal("enable", projectContext.Nullable);
+            }
+        }
+
         [SkippableTheory]
         [InlineData("C:\\Users\\User\\.nuget\\packages\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\packages\\x.y.z\\1.2.3")]
         [InlineData("C:\\Users\\User\\.nuget\\", "X.Y.Z", "1.2.3", "C:\\Users\\User\\.nuget\\x.y.z\\1.2.3")]

--- a/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
                 var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName2);
 
                 var projectContext = GetProjectContext(path, true);
-                //we know the project name is Test so test some basic properties.
                 Assert.NotNull(projectContext.Nullable);
                 Assert.Equal("disable", projectContext.Nullable);
             }
@@ -62,13 +61,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
         {
             using (var fileProvider = new TemporaryFileProvider())
             {
-                new MsBuildProjectSetupHelper().SetupCodeGenerationProjectNullableDisabled(fileProvider, _outputHelper);
-                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName2);
+                new MsBuildProjectSetupHelper().SetupCodeGenerationProjectNullableMissing(fileProvider, _outputHelper);
+                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName3);
 
                 var projectContext = GetProjectContext(path, true);
-                //we know the project name is Test so test some basic properties.
-                Assert.NotNull(projectContext.Nullable);
-                Assert.Equal("disable", projectContext.Nullable);
+                Assert.Null(projectContext.Nullable);
             }
         }
 
@@ -81,7 +78,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
                 var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName3);
 
                 var projectContext = GetProjectContext(path, true);
-                //we know the project name is Test so test some basic properties.
                 Assert.NotNull(projectContext.Nullable);
                 Assert.Equal("enable", projectContext.Nullable);
             }

--- a/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -58,6 +58,21 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
         }
 
         [Fact]
+        public void TestProjectContextNullableMissing()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupCodeGenerationProjectNullableDisabled(fileProvider, _outputHelper);
+                var path = Path.Combine(fileProvider.Root, MsBuildProjectStrings.RootProjectName2);
+
+                var projectContext = GetProjectContext(path, true);
+                //we know the project name is Test so test some basic properties.
+                Assert.NotNull(projectContext.Nullable);
+                Assert.Equal("disable", projectContext.Nullable);
+            }
+        }
+
+        [Fact]
         public void TestProjectContextNullableEnabled()
         {
             using (var fileProvider = new TemporaryFileProvider())

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/ControllerGeneratorBaseTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/ControllerGeneratorBaseTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
             _codeGenActionService = new Mock<ICodeGeneratorActionsService>();
             _serviceProvider = new Mock<IServiceProvider>();
             _logger = new ConsoleLogger();
-            _applicationInfo = new ApplicationInfo("TestApp", "..", null);
+            _applicationInfo = new ApplicationInfo("TestApp", "..");
         }
 
         [Fact]
@@ -38,8 +38,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
                 _applicationInfo,
                 _codeGenActionService.Object,
                 _serviceProvider.Object,
-                _logger
-                );
+                _logger);
 
             var model = GetModel();
             model.ControllerNamespace = "Invalid Namespace";

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                     UseSqlite = false
                 };
 
-                var applicationInfo = new ApplicationInfo("TestApp", "Sample", null);
+                var applicationInfo = new ApplicationInfo("TestApp", "Sample");
 
                 var builder = new IdentityGeneratorTemplateModelBuilder(
                     commandLineModel,
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             IdentityGeneratorCommandLineModel commandLineModel = new IdentityGeneratorCommandLineModel();
             commandLineModel.Layout = existingLayoutFile;
 
-            IApplicationInfo applicationInfo = new ApplicationInfo("test", LayoutFileLocationTestProjectBasePath, null);
+            IApplicationInfo applicationInfo = new ApplicationInfo("test", LayoutFileLocationTestProjectBasePath);
             CommonProjectContext context = new CommonProjectContext();
             context.ProjectFullPath = LayoutFileLocationTestProjectBasePath;
             context.ProjectName = "TestProject";

--- a/test/Scaffolding/VS.Web.CG.Sources.Test/ApplicationInfoTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Sources.Test/ApplicationInfoTests.cs
@@ -14,7 +14,7 @@ namespace ConsoleApplication
         [Fact]
         public void ApplicationEnvironment_Test()
         {
-            _applicationInfo = new ApplicationInfo("TestApplication", Directory.GetCurrentDirectory(), null);
+            _applicationInfo = new ApplicationInfo("TestApplication", Directory.GetCurrentDirectory());
             Assert.Equal(Directory.GetCurrentDirectory(), _applicationInfo.ApplicationBasePath);
             Assert.Equal("TestApplication", _applicationInfo.ApplicationName);
         }


### PR DESCRIPTION
We were using Microsoft.Build.Locator to load in requisite Microsoft.Build assemblies (using MSBuildLocator.RegisterDefaults()) to : 
- initialize Microsoft.Build.Evaluation.Project object
- use `Project.GetProperty("ms build property name")?.EvaluatedValue` to get needed MSBuild project properties
- we needed the "Nullable" property.

Now:
- Added Nullable string property to IProjectContext
- Initialize IProjectContext during runtime msbuild operation using updated `VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets` file.
- Nullable property populated at runtime without performing additional Microsoft.Build initialization and calls.

Changes : 
- Removed package references to `Microsoft.Build.Locator`
- Removed all calls to MSBuildLocator.RegisterDefaults().
- Added tests with nullable = enable, disable and the nullable property missing (disable by default).



