### PR TITLE
Minimal api changes

### DIFF
--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-VERSION=6.0.3
+VERSION=7.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR
 NUPKG=artifacts/packages/Debug/Shipping/
-
 #kill all dotnet procs
 pkill -f dotnet
 rm -rf artifacts

--- a/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -113,10 +113,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                     var lastNode = dbContextNode.ChildNodes().Last();
 
                     var safeModelName = GetSafeModelName(modelType.Name, dbContext.TypeSymbol);
-                    var nullablilitySign = nullableEnabled ? "? " : " ";
+                    var nullabilityClause = nullableEnabled ? " = default!;" : "";
                     // Todo : Need pluralization for property name below.
                     // It is not always safe to just use DbSet<modelType.Name> as there can be multiple class names in different namespaces.
-                    var dbSetProperty = "public DbSet<" + modelType.FullName + ">" + nullablilitySign + safeModelName + " { get; set; }" + Environment.NewLine;
+                    var dbSetProperty = "public DbSet<" + modelType.FullName + ">" + safeModelName + " { get; set; }" + nullabilityClause + Environment.NewLine;
                     var propertyDeclarationWrapper = CSharpSyntaxTree.ParseText(dbSetProperty);
 
                     var newNode = rootNode.InsertNodesAfter(lastNode,

--- a/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                     var nullabilityClause = nullableEnabled ? " = default!;" : "";
                     // Todo : Need pluralization for property name below.
                     // It is not always safe to just use DbSet<modelType.Name> as there can be multiple class names in different namespaces.
-                    var dbSetProperty = "public DbSet<" + modelType.FullName + ">" + safeModelName + " { get; set; }" + nullabilityClause + Environment.NewLine;
+                    var dbSetProperty = "public DbSet<" + modelType.FullName + "> " + safeModelName + " { get; set; }" + nullabilityClause + Environment.NewLine;
                     var propertyDeclarationWrapper = CSharpSyntaxTree.ParseText(dbSetProperty);
 
                     var newNode = rootNode.InsertNodesAfter(lastNode,

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -158,6 +158,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                         usings.Add(templateModel.DbContextNamespace);
                     }
 
+                    if (templateModel.OpenAPI)
+                    {
+                        usings.Add("Microsoft.AspNetCore.Http.HttpResults");
+                    }
+
                     var endpointsCodeFile = new CodeFile { Usings = usings.ToArray()};
                     var docBuilder = new DocumentBuilder(docEditor, endpointsCodeFile, ConsoleLogger);
                     var newRoot = docBuilder.AddUsings(new CodeChangeOptions());

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -161,6 +161,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     if (templateModel.OpenAPI)
                     {
                         usings.Add("Microsoft.AspNetCore.Http.HttpResults");
+                        usings.Add("Microsoft.AspNetCore.OpenApi");
                     }
 
                     var endpointsCodeFile = new CodeFile { Usings = usings.ToArray()};

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -79,6 +79,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, useSqlite: model.UseSqlite);
             }
 
+            if (model.OpenApi)
+            {
+                ValidateOpenApiDependencies(ProjectContext.PackageDependencies);
+            }
+
             var templateModel = new MinimalApiModel(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName, model.EndpintsClassName)
             {
                 EndpointsName = model.EndpintsClassName,
@@ -341,6 +346,22 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             return null;
         }
 
+        private void ValidateOpenApiDependencies(IEnumerable<DependencyDescription> packages)
+        {
+            var openApiDependencies = new HashSet<string>()
+            {
+                "Swashbuckle.AspNetCore",
+                "Microsoft.AspNetCore.OpenApi"
+            };
+
+            var missingPackages = openApiDependencies.Where(d => !packages.Any(p => p.Name.Equals(d, StringComparison.OrdinalIgnoreCase)));
+            if (CalledFromCommandline && missingPackages.Any())
+            {
+                throw new InvalidOperationException(
+                    string.Format(MessageStrings.InstallPackagesForScaffoldingIdentity, string.Join(",", missingPackages)));
+            }
+        }
+        
         private string GetMinimalApiCodeModifierConfig()
         {
             string jsonText = string.Empty;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
@@ -110,6 +110,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     requiredNamespaces.Add(DbContextNamespace);
                 }
 
+                if (OpenAPI)
+                {
+                    requiredNamespaces.Add("Microsoft.AspNetCore.Http.HttpResults");
+                }
+
                 // Finally we remove the ControllerNamespace as it's not required.
                 requiredNamespaces.Remove(EndpointsNamespace);
                 return new HashSet<string>(requiredNamespaces);

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
@@ -113,6 +113,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 if (OpenAPI)
                 {
                     requiredNamespaces.Add("Microsoft.AspNetCore.Http.HttpResults");
+                    requiredNamespaces.Add("Microsoft.AspNetCore.OpenApi");
                 }
 
                 // Finally we remove the ControllerNamespace as it's not required.

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -12,6 +12,7 @@
     string deleteModel = $"Delete{@modelName}";
     string createModel = $"Create{@modelName}";
     string updateModel = $"Update{@modelName}";
+    string resultsExtension = (Model.OpenAPI ? "TypedResults" : "Results") + ".NoContent()";
 }
 @{
     foreach (var namespaceName in Model.RequiredNamespaces)
@@ -25,7 +26,8 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        routes.MapGet("@routePrefix", () =>
+        var group = routes.MapGroup("@routePrefix");
+        group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };
         })
@@ -42,7 +44,7 @@ public static class @endPointsClassName
     }
     }
 
-        routes.MapGet("@routePrefix/{id}", (int id) =>
+        group.MapGet("/{id}", (int id) =>
         {
             //return new @modelName { ID = id };
         })
@@ -59,9 +61,9 @@ public static class @endPointsClassName
     }
     }
 
-        routes.MapPut("@routePrefix/{id}", (int id, @modelName input) =>
+        group.MapPut("/{id}", (int id, @modelName input) =>
         {
-            return Results.NoContent();
+            return @resultsExtension;
         })
     @{
     if(Model.OpenAPI)
@@ -76,7 +78,7 @@ public static class @endPointsClassName
     }
     }
 
-        routes.MapPost("@routePrefix/", (@modelName model) =>
+        group.MapPost("/", (@modelName model) =>
         {
             //return Results.Created($"/@pluralModel/{model.ID}", model);
         })
@@ -93,7 +95,7 @@ public static class @endPointsClassName
     }
     }
 
-        routes.MapDelete("@routePrefix/{id}", (int id) =>
+        group.MapDelete("/{id}", (int id) =>
         {
             //return Results.Ok(new @modelName { ID = id });
         })

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -27,6 +27,12 @@ public static class @endPointsClassName
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("@routePrefix");
+    @{
+    if(Model.OpenAPI)
+    {
+        @:group.WithOpenApi();
+    }
+    }    
         group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -14,10 +14,11 @@
     string dbContextName = Model.ContextTypeName;
     var entitySetName = Model.ModelMetadata.EntitySetName;
     var primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
+    var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
     var primaryKeyType = Model.ModelMetadata.PrimaryKeys[0].TypeName;
     var modelToList = $"{@entitySetName}.ToListAsync()";
-    var findModel = $"{@entitySetName}.FindAsync({@primaryKeyName})";
+    var findModel = $"{@entitySetName}.FindAsync({@primaryKeyNameLowerCase})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
@@ -61,7 +62,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
@@ -82,7 +83,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
@@ -129,7 +130,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -45,6 +45,12 @@ public static class @endPointsClassName
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("@routePrefix");
+    @{
+    if(Model.OpenAPI)
+    {
+        @:group.WithOpenApi();
+    }
+    }    
         group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -20,12 +20,19 @@
     var findModel = $"{@entitySetName}.FindAsync({@primaryKeyName})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
+    string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
+    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsOkModel = $"{resultsExtension}.Ok(model)";
+    string resultsNoContent = $"{resultsExtension}.NoContent()";
+    string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
+    string createdApiVar = string.Format("$\"/{0}/{{{1}.{2}}}\",{3}", @pluralModel, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
+    string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
 }
 using Microsoft.EntityFrameworkCore;
 @{
     foreach (var namespaceName in Model.RequiredNamespaces)
     {
-@:using @namespaceName;
+    @:using @namespaceName;
     }
 }
 namespace @Model.EndpointsNamespace;
@@ -34,114 +41,115 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        routes.MapGet("@routePrefix", async (@dbContextName db) =>
+        var group = routes.MapGroup("@routePrefix");
+        group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI)
+        {
         @:.WithTags(nameof(@modelName))
         @:.WithName("@getAllModels")
         @:.Produces<@modelList>(StatusCodes.Status200OK);
-    }
-    else
-    {
+        }
+        else
+        {
         @:.WithName("@getAllModels");
+        }
     }
-}
 
-        routes.MapGet("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
-                    ? Results.Ok(model)
-                    : Results.NotFound();
+                    ? @resultsOkModel
+                    : @resultsNotFound;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI)
+        {
         @:.WithTags(nameof(@modelName))
         @:.WithName("@getModelById")
         @:.Produces<@modelName>(StatusCodes.Status200OK)
         @:.Produces(StatusCodes.Status404NotFound);
-    }
-    else
-    {
+        }
+        else
+        {
         @:.WithName("@getModelById");
+        }
     }
-}
 
-        routes.MapPut("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
             if (foundModel is null)
             {
-                return Results.NotFound();
+                return @resultsNotFound;
             }
             //update model properties here
 
             await db.SaveChangesAsync();
 
-            return Results.NoContent();
+            return @resultsNoContent;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI)
+        {
         @:.WithTags(nameof(@modelName))
         @:.WithName("@updateModel")
         @:.Produces(StatusCodes.Status404NotFound)
         @:.Produces(StatusCodes.Status204NoContent);
-    }
-    else
-    {
+        }
+        else
+        {
         @:.WithName("@updateModel");
+        }
     }
-}
 
-        routes.MapPost("@routePrefix/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPost("/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
         {
             db.@add;
             await db.SaveChangesAsync();
-            return Results.Created($"/@pluralModel/{@Model.ModelVariable.@primaryKeyName}", @Model.ModelVariable);
+            return @resultsCreated;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI)
+        {
         @:.WithTags(nameof(@modelName))
         @:.WithName("@createModel")
         @:.Produces<@modelName>(StatusCodes.Status201Created);
-    }
-    else
-    {
+        }
+        else
+        {
         @:.WithName("@createModel");
+        }
     }
-}
 
-        routes.MapDelete("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {
                 db.@remove;
                 await db.SaveChangesAsync();
-                return Results.Ok(@Model.ModelVariable);
+                return @resultsOkModelVariable;
             }
 
-            return Results.NotFound();
+            return @resultsNotFound;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI)
+        {
         @:.WithTags(nameof(@modelName))
         @:.WithName("@deleteModel")
         @:.Produces<@modelName>(StatusCodes.Status200OK)
         @:.Produces(StatusCodes.Status404NotFound);
-    }
-    else
-    {
+        }
+        else
+        {
         @:.WithName("@deleteModel");
+        }
     }
-}
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -28,7 +28,7 @@
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
-    string createdApiVar = string.Format("$\"/{0}/{{{1}.{2}}}\",{3}", @pluralModel, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
+    string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
     string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
 }
 using Microsoft.EntityFrameworkCore;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -21,6 +21,8 @@
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
+    string typedTaskWithNotFound = Model.OpenAPI ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
+    string typedTaskWithNoContent = Model.OpenAPI ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
@@ -32,7 +34,7 @@ using Microsoft.EntityFrameworkCore;
 @{
     foreach (var namespaceName in Model.RequiredNamespaces)
     {
-    @:using @namespaceName;
+@:using @namespaceName;
     }
 }
 namespace @Model.EndpointsNamespace;
@@ -59,7 +61,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapGet("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
@@ -80,7 +82,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapPut("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
@@ -127,7 +129,7 @@ public static class @endPointsClassName
         }
     }
 
-        group.MapDelete("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -33,6 +33,12 @@
 public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("@routePrefix");
+    @{
+    if(Model.OpenAPI)
+    {
+        @:group.WithOpenApi();
+    }
+    }    
         group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -20,6 +20,8 @@
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
+    string typedTaskWithNotFound = Model.OpenAPI ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
+    string typedTaskWithNoContent = Model.OpenAPI ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
@@ -47,7 +49,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapGet("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
@@ -68,7 +70,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapPut("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
@@ -115,7 +117,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapDelete("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -12,11 +12,12 @@
     string dbContextName = Model.ContextTypeName;
     var entitySetName = Model.ModelMetadata.EntitySetName;
     var primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
+    var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
     var primaryKeyType = Model.ModelMetadata.PrimaryKeys[0].TypeName;
     var modelList = $"List<{@modelName}>";
     var modelToList = $"{@entitySetName}.ToListAsync()";
-    var findModel = $"{@entitySetName}.FindAsync({@primaryKeyName})";
+    var findModel = $"{@entitySetName}.FindAsync({@primaryKeyNameLowerCase})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
@@ -49,7 +50,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
@@ -70,7 +71,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
@@ -117,7 +118,7 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     }
 }
 
-        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -27,7 +27,7 @@
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
-    string createdApiVar = string.Format("$\"/{0}/{{{1}.{2}}}\",{3}", @pluralModel, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
+    string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
     string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
 }
 public static void @Model.MethodName (this IEndpointRouteBuilder routes)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -19,16 +19,22 @@
     var findModel = $"{@entitySetName}.FindAsync({@primaryKeyName})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
+    string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
+    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsOkModel = $"{resultsExtension}.Ok(model)";
+    string resultsNoContent = $"{resultsExtension}.NoContent()";
+    string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
+    string createdApiVar = string.Format("$\"/{0}/{{{1}.{2}}}\",{3}", @pluralModel, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
+    string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
 }
-
-
 public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        routes.MapGet("@routePrefix", async (@dbContextName db) =>
+        var group = routes.MapGroup("@routePrefix");
+        group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;
         })
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:.WithTags(nameof(@modelName))
@@ -39,16 +45,16 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         @:.WithName("@getAllModels");
     }
-    }
+}
 
-        routes.MapGet("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapGet("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             return await db.@findModel
                 is @modelName model
-                    ? Results.Ok(model)
-                    : Results.NotFound();
+                    ? @resultsOkModel
+                    : @resultsNotFound;
         })
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:.WithTags(nameof(@modelName))
@@ -60,23 +66,23 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         @:.WithName("@getModelById");
     }
-    }
+}
 
-        routes.MapPut("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var foundModel = await db.@findModel;
 
             if (foundModel is null)
             {
-                return Results.NotFound();
+                return @resultsNotFound;
             }
             //update model properties here
 
             await db.SaveChangesAsync();
 
-            return Results.NoContent();
-        })   
-    @{
+            return @resultsNoContent;
+        })
+@{
     if(Model.OpenAPI)
     {
         @:.WithTags(nameof(@modelName))
@@ -88,15 +94,15 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         @:.WithName("@updateModel");
     }
-    }
+}
 
-        routes.MapPost("@routePrefix/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPost("/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
         {
             db.@add;
             await db.SaveChangesAsync();
-            return Results.Created($"/@pluralModel/{@Model.ModelVariable.@primaryKeyName}", @Model.ModelVariable);
+            return @resultsCreated;
         })
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:.WithTags(nameof(@modelName))
@@ -107,21 +113,20 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         @:.WithName("@createModel");
     }
-    }
+}
 
-
-        routes.MapDelete("@routePrefix/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
+        group.MapDelete("/{id}", async (@primaryKeyShortTypeName @primaryKeyName, @dbContextName db) =>
         {
             if (await db.@findModel is @modelName @Model.ModelVariable)
             {
                 db.@remove;
                 await db.SaveChangesAsync();
-                return Results.Ok(@Model.ModelVariable);
+                return @resultsOkModelVariable;
             }
 
-            return Results.NotFound();
+            return @resultsNotFound;
         })
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:.WithTags(nameof(@modelName))
@@ -133,5 +138,5 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         @:.WithName("@deleteModel");
     }
-    }
+}
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -12,11 +12,13 @@
     string deleteModel = $"Delete{@modelName}";
     string createModel = $"Create{@modelName}";
     string updateModel = $"Update{@modelName}";
+    string resultsExtension = (Model.OpenAPI ? "TypedResults" : "Results") + ".NoContent()";
 }
  
-    public static void @Model.MethodName (this IEndpointRouteBuilder routes)
+   public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        routes.MapGet("@routePrefix", () =>
+        var group = routes.MapGroup("@routePrefix");
+        group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };
         })
@@ -33,7 +35,7 @@
     }
     }
 
-        routes.MapGet("@routePrefix/{id}", (int id) =>
+        group.MapGet("/{id}", (int id) =>
         {
             //return new @modelName { ID = id };
         })
@@ -50,9 +52,9 @@
     }
     }
 
-        routes.MapPut("@routePrefix/{id}", (int id, @modelName input) =>
+        group.MapPut("/{id}", (int id, @modelName input) =>
         {
-            return Results.NoContent();
+            return @resultsExtension;
         })
     @{
     if(Model.OpenAPI)
@@ -67,7 +69,7 @@
     }
     }
 
-        routes.MapPost("@routePrefix/", (@modelName model) =>
+        group.MapPost("/", (@modelName model) =>
         {
             //return Results.Created($"/@pluralModel/{model.ID}", model);
         })
@@ -84,7 +86,7 @@
     }
     }
 
-        routes.MapDelete("@routePrefix/{id}", (int id) =>
+        group.MapDelete("/{id}", (int id) =>
         {
             //return Results.Ok(new @modelName { ID = id });
         })

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -18,6 +18,12 @@
    public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("@routePrefix");
+    @{
+    if(Model.OpenAPI)
+    {
+        @:group.WithOpenApi();
+    }
+    }    
         group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/compiler/resources/DbContextNullable_After.txt
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/compiler/resources/DbContextNullable_After.txt
@@ -7,6 +7,6 @@ namespace ContextNamespace
         public MyContext() : base()
         {
         }
-        public DbSet<ModelNamespace.MyModel>? MyModel { get; set; }
+        public DbSet<ModelNamespace.MyModel> MyModel { get; set; } = default!;
     }
 }


### PR DESCRIPTION
Addressing #1937 
- using routes.MapGroup instead of routes.Map(Get/Put/Post etc.)
- adding `Microsoft.AspNetCore.Http.HttpResults` to usings.
- changing nullable DbContext set from `public DbSet<Model>? DbSet { get; set; }` -->  `public DbSet<Model> DbSet { get; set; } = default!` for parity with scaffolding templates.
- addressing #1963 
- addressing #1954