### PR TITLE
Use AdhocWorkspace instead of MSBuildWorkspace

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -44,6 +45,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
         /// <returns></returns>
         public async Task AddAuthCodeAsync()
         {
+            Debugger.Launch();
             if (string.IsNullOrEmpty(_toolOptions.ProjectFilePath))
             {
                 var csProjFiles = _files.Where(file => file.EndsWith(".csproj"));
@@ -64,7 +66,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             }
 
             // Initialize CodeAnalysis.Project wrapper
-            CodeAnalysis.Project project = await CodeAnalysisHelper.LoadCodeAnalysisProjectAsync(_toolOptions.ProjectFilePath, _files);
+            CodeAnalysis.Project project = CodeAnalysisHelper.LoadCodeAnalysisProject(_toolOptions.ProjectFilePath, _files);
             if (project is null)
             {
                 return;
@@ -228,8 +230,8 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 file.FileName = await ProjectModifierHelper.GetStartupClass(project.Documents.ToList()) ?? file.FileName;
             }
 
-            var fileDoc = project.Documents.Where(d => d.Name.Equals(file.FileName)).FirstOrDefault();
-            if (fileDoc is null || string.IsNullOrEmpty(fileDoc.FilePath))
+            var fileDoc = project.Documents.Where(d => d.Name.EndsWith(file.FileName)).FirstOrDefault();
+            if (fileDoc is null || string.IsNullOrEmpty(fileDoc.Name))
             {
                 return;
             }
@@ -246,7 +248,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             if (modifiedRoot != null)
             {
                 documentEditor.ReplaceNode(documentEditor.OriginalRoot, modifiedRoot);
-                await documentBuilder.WriteToClassFileAsync(fileDoc.FilePath);
+                await documentBuilder.WriteToClassFileAsync(fileDoc.Name);
                 _output.AppendLine($"Modified {file.FileName}"); // TODO strings.
             }
         }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -45,7 +44,6 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
         /// <returns></returns>
         public async Task AddAuthCodeAsync()
         {
-            Debugger.Launch();
             if (string.IsNullOrEmpty(_toolOptions.ProjectFilePath))
             {
                 var csProjFiles = _files.Where(file => file.EndsWith(".csproj"));

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeAnalysisHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeAnalysisHelper.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.MSBuild;
+using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
 {
@@ -8,15 +8,15 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
     public static class CodeAnalysisHelper
     {
         //helps create a CodeAnalysis.Project with project files given a project path.
-        public static async Task<CodeAnalysis.Project> LoadCodeAnalysisProjectAsync(
+        public static CodeAnalysis.Project LoadCodeAnalysisProject(
             string projectFilePath,
             IEnumerable<string> files)
         {
-            var workspace = MSBuildWorkspace.Create();
-            var project = await workspace.OpenProjectAsync(projectFilePath);
+            var workspace = new AdhocWorkspace();
+            var project = workspace.AddProject(Path.GetFileName(projectFilePath), "C#");
             var projectWithFiles = project.WithAllSourceFiles(files);
             project = projectWithFiles ?? project;
             return project;
-        }        
+        }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -496,6 +497,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
 
         internal static async Task<string> UpdateDocument(Document document)
         {
+            Debugger.Launch();
             var classFileTxt = await document.GetTextAsync();
 
             // Note: For files without .cs extension, document.Name is the full filepath

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -9,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.MSIdentity.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.CodeModifier;
 using Microsoft.DotNet.Scaffolding.Shared.CodeModifier.CodeChange;
 
@@ -497,12 +495,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
 
         internal static async Task<string> UpdateDocument(Document document)
         {
-            Debugger.Launch();
             var classFileTxt = await document.GetTextAsync();
-
-            // Note: For files without .cs extension, document.Name is the full filepath
-            var filePath = document.Name.EndsWith(".cs") ? document.FilePath : document.Name;
-            File.WriteAllText(filePath, classFileTxt.ToString(), new UTF8Encoding(false));
+            File.WriteAllText(document.Name, classFileTxt.ToString(), new UTF8Encoding(false));
 
             return $"Modified {document.Name}.\n"; // todo strings.
         }

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/CodeAnalysisHelperTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/CodeAnalysisHelperTests.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Microsoft.DotNet.Scaffolding.Shared.CodeModifier;
+using Xunit;
+
+namespace Microsoft.DotNet.Scaffolding.Shared.Tests
+{
+    public class CodeAnalysisHelperTests
+    {
+        [Fact]
+        public void LoadCodeAnalysisProjectTest()
+        {
+            var files = new List<string>();
+            var projectPath = string.Empty; // TODO test project
+            var project = CodeAnalysisHelper.LoadCodeAnalysisProject(projectPath, files);
+            Assert.NotNull(project);
+        }
+    }
+}


### PR DESCRIPTION
Changes CodeAnalysisHelper to use AdhocWorkspace instead of MSBuildWorkspace

With this change, Document filepaths are always found via Document.Name whereas before, .cs files had the filepath stored in Document.FilePath

