### PR TITLE
checking if endpoints class is static, if not, creating one.

### DIFF
--- a/test/Scaffolding/Shared/MSBuildProjectStrings.cs
+++ b/test/Scaffolding/Shared/MSBuildProjectStrings.cs
@@ -311,7 +311,7 @@ routes.MapDelete(""/api/Car/{id}"", (int id) =>
 .WithName(""DeleteCar"");  
     }
 }";
-        public const string EndpointsEmptyClass = @"namespace MinimalApiTest { class Endpoints { } } ";
+        public const string EndpointsEmptyClass = @"namespace MinimalApiTest { static class Endpoints { } } ";
         public const string MinimalProgramcsFile = @"var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -417,8 +417,29 @@ namespace Library1.Models
     }
 }";
 
-// Strings for 3 layered project
-    public const string WebProjectTxt = @"
+        public const string CarWithoutNamespaceTxt = @"
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+public class Car
+{
+    public string ID { get; set; }
+    public string Name { get; set; }
+    public int ManufacturerID { get; set; }
+    public Manufacturer Manufacturer { get; set; }
+    [DataType(DataType.MultilineText)]
+    public string Notes { get; set; }
+}
+
+public class Manufacturer
+{
+    public int ID { get; set; }
+    public string Name { get; set; }
+    public virtual ICollection<Car> Cars { get; set; }
+}";
+
+        // Strings for 3 layered project
+        public const string WebProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk.Web"">
   <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" Condition=""Exists('$(MSBuildThisFileDirectory)\TestCodeGeneration.targets')"" />
 


### PR DESCRIPTION
Check if endpoints class is static,
- if it **IS**, continue as usual, create endpoints method in that class.
- if it **IS NOT**, create a new static class in the same file (at the end of the file) and add the scaffolded endpoints method to the newly created class.

- additional fix where `Microsoft.EntityFrameworkCore` namespace is added if a DbContext is being used, not just when a DbContext namespace is present (in the endpoints class).