### PR TITLE
not adding extra whitespace and checking for Main method correctly

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs
@@ -321,11 +321,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         {
             foreach (var codeChange in filteredChanges)
             {
-                if (!useTopLevelsStatements)
-                {
-                    codeChange.LeadingTrivia = codeChange.LeadingTrivia ?? new Formatting();
-                    codeChange.LeadingTrivia.NumberOfSpaces += 12;
-                }
+                codeChange.LeadingTrivia = codeChange.LeadingTrivia ?? new Formatting();
                 codeChange.Block = EditIdentityStrings(codeChange.Block, dbContextClassName, identityUserClassName, useSqlite, codeChange?.LeadingTrivia?.NumberOfSpaces);
             }
 
@@ -362,11 +358,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             {
                 modifiedString = modifiedString.Replace("GetConnectionString(\"{0}\")", $"GetConnectionString(\"{dbContextClassName}Connection\")");
                 modifiedString = modifiedString.Replace("Connection string '{0}'", $"Connection string '{dbContextClassName}Connection'");
-            }
-
-            if (stringToModify.Contains("{1}"))
-            {
-                modifiedString = modifiedString.Replace("{1}", new string(' ', spaces.GetValueOrDefault() + 4));
             }
 
             return modifiedString;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/identityMinimalHostingChanges.json
@@ -13,7 +13,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContext",
-              "Block": "builder.Services.AddDbContext<{0}>(options =>\r\n{1}options.{0}(connectionString))\"",
+              "Block": "builder.Services.AddDbContext<{0}>(options => options.{0}(connectionString))\"",
               "LeadingTrivia": {
                 "Newline": true
               }
@@ -21,7 +21,7 @@
             {
               "InsertAfter": "builder.Services.AddDbContext",
               "CheckBlock": "builder.Services.AddDefaultIdentity",
-              "Block": "builder.Services.AddDefaultIdentity<{0}>(options => options.SignIn.RequireConfirmedAccount = true)\r\n{1}.AddEntityFrameworkStores<{0}>()\"",
+              "Block": "builder.Services.AddDefaultIdentity<{0}>(options => options.SignIn.RequireConfirmedAccount = true).AddEntityFrameworkStores<{0}>()\"",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
@@ -194,12 +194,17 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
 
         internal static MethodDeclarationSyntax GetMethodFromSyntaxRoot(CompilationUnitSyntax root, string methodIdentifier)
         {
-            var namespaceNode = root.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
+            BaseNamespaceDeclarationSyntax namespaceNode = root.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
+            if (namespaceNode == null)
+            {
+                namespaceNode = root.Members.OfType<FileScopedNamespaceDeclarationSyntax>()?.FirstOrDefault();
+            }
+            
             var classNode = namespaceNode?.Members.OfType<ClassDeclarationSyntax>()?.FirstOrDefault() ??
                             root?.Members.OfType<ClassDeclarationSyntax>()?.FirstOrDefault();  
             if (classNode?.ChildNodes().FirstOrDefault(
-                n => n is MethodDeclarationSyntax syntax &&
-                syntax.Identifier.ToString().Equals(methodIdentifier, StringComparison.OrdinalIgnoreCase)) is MethodDeclarationSyntax method)
+                    n => n is MethodDeclarationSyntax syntax &&
+                    syntax.Identifier.ToString().Equals(methodIdentifier, StringComparison.OrdinalIgnoreCase)) is MethodDeclarationSyntax method)
             {
                 return method;
             }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -62,16 +62,23 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             var programDocument = modelTypesLocator.GetAllDocuments().FirstOrDefault(d => d.Name.EndsWith("Program.cs"));
             if (programDocument != null && await programDocument.GetSyntaxRootAsync() is CompilationUnitSyntax root)
             {
-                var fileScopedNamespaceNode = root.Members.OfType<FileScopedNamespaceDeclarationSyntax>()?.FirstOrDefault();
-                if (fileScopedNamespaceNode == null)
+                BaseNamespaceDeclarationSyntax namespaceNode = root.Members.OfType<FileScopedNamespaceDeclarationSyntax>()?.FirstOrDefault();
+                if (namespaceNode == null)
                 {
-                    var namespaceNode = root.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
-                    var classNode = namespaceNode?.Members.OfType<ClassDeclarationSyntax>()?.FirstOrDefault();
-                    var mainMethod = classNode?.ChildNodes().FirstOrDefault(n => n is MethodDeclarationSyntax
-                        && ((MethodDeclarationSyntax)n).Identifier.ToString().Equals(Main, StringComparison.OrdinalIgnoreCase));
+                    namespaceNode = root.Members.OfType<NamespaceDeclarationSyntax>()?.FirstOrDefault();
+                } 
+                var classNode = namespaceNode?.Members.OfType<ClassDeclarationSyntax>()?.FirstOrDefault();
+                var mainMethod = classNode?.ChildNodes().FirstOrDefault(n => n is MethodDeclarationSyntax syntax
+                    && syntax.Identifier.ToString().Equals(Main, StringComparison.OrdinalIgnoreCase));
 
-                    return mainMethod == null;
+                if (mainMethod == null)
+                {
+                    mainMethod = namespaceNode?.ChildNodes().FirstOrDefault(
+                        n => n is MethodDeclarationSyntax syntax &&
+                             syntax.Identifier.ToString().Equals(Main, StringComparison.OrdinalIgnoreCase));
                 }
+
+                return mainMethod == null;
             }
 
             return true;


### PR DESCRIPTION
- not adding extra whitespace when using top level statements.
- checking FileScopedNamespace and regular Namespace for finding methods in `GetMethodFromSyntaxRoot`
  - adding extra logic for `IsUsingTopLevelStatements`