### PR TITLE
adding target for and carrying over project refs.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Msbuild/ProjectReferenceInformationProvider.cs
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/ProjectReferenceInformationProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
             {
                 ProjectName = name,
                 AssemblyName = assemblyName,
-                CompilationItems = compileItems,
+                CompilationItems = compileItems.ToList(),
                 FullPath = fullPath
             };
         }

--- a/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -17,6 +17,7 @@ Outputs the Project Information needed for CodeGeneration to a file.
     <EvaluateProjectInfoForCodeGenerationDependsOn>
       $(EvaluateProjectInfoForCodeGenerationDependsOn);
       ResolveReferences;
+      ResolveProjectReferences;
     </EvaluateProjectInfoForCodeGenerationDependsOn>
   </PropertyGroup>
 

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             var id = AddProject(projectInformation, configuration);
             // Since we have resolved all references, we can directly use them as MetadataReferences.
             // Trying to get ProjectReferences manually might lead to problems when the projects have circular dependency.
-            var projReferenceInformation = RoslynWorkspaceHelper.GetProjectReferenceInformation(projectInformation.ProjectReferences);
+            var projReferenceInformation = projectInformation.ProjectReferenceInformation;
 
             if (projReferenceInformation != null && projReferenceInformation.Any())
             {

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspaceHelper.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
             {
                 ProjectName = name,
                 AssemblyName = assemblyName,
-                CompilationItems = compileItems,
+                CompilationItems = compileItems.ToList(),
                 FullPath = fullPath
             };
         }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
@@ -58,7 +58,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
                 TargetFramework = projectInformation.TargetFramework,
                 TargetFrameworkMoniker = projectInformation.TargetFrameworkMoniker,
                 GeneratedImplicitNamespaceImportFile = projectInformation.GeneratedImplicitNamespaceImportFile,
-                Nullable = projectInformation.Nullable
+                Nullable = projectInformation.Nullable,
+                ProjectReferenceInformation = projectInformation.ProjectReferenceInformation
             };
             return newProjectContext;
         }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectReferenceInformation.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectReferenceInformation.cs
@@ -29,6 +29,6 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
         /// Items included in the project reference for compilation
         /// &lt;Compile Include="" /&gt;
         /// </summary>
-        public IEnumerable<string> CompilationItems { get; set; }
+        public List<string> CompilationItems { get; set; }
     }
 }


### PR DESCRIPTION
After removing MSBuildLocator to get msbuild assemblies and loading msbuild projects, project references fail for models, db contexts etc.
- added `ResolveProjectReferences` task.