### PR TITLE
Add Susi Policy Id parameter for Code Update 

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescription/ProjectDescriptionReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescription/ProjectDescriptionReader.cs
@@ -40,7 +40,8 @@ namespace Microsoft.DotNet.MSIdentity.Project
                 }
             }
 
-            return null;
+            // If projectDescription cannot be inferred, default to Web App
+            return ProjectDescriptions.FirstOrDefault(p => string.Equals(ProjectTypes.WebApp, p.Identifier));
         }
 
         static readonly JsonSerializerOptions serializerOptionsWithComments = new JsonSerializerOptions
@@ -52,16 +53,10 @@ namespace Microsoft.DotNet.MSIdentity.Project
         {
             get
             {
-                if (_projectDescriptions == null)
-                {
-                    _projectDescriptions = AppProvisioningTool.Properties
+                _projectDescriptions ??= AppProvisioningTool.Properties
                         .Where(p => p.Name.StartsWith("dotnet") && p.PropertyType == typeof(byte[]))
                         .Select(p => GetProjectDescription(p))
                         .ToList();
-
-                    //  TODO: provide an extension mechanism to add such files outside the tool.
-                    //  In that case the validation would not be an exception? but would need to provide error messages
-                }
 
                 return _projectDescriptions;
             }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -216,6 +216,10 @@ namespace Microsoft.DotNet.MSIdentity
             {
                 projectSettings.ApplicationParameters.AppIdUri = provisioningToolOptions.HostedAppIdUri;
             }
+            if (!string.IsNullOrEmpty(provisioningToolOptions.SusiPolicyId))
+            {
+                projectSettings.ApplicationParameters.SusiPolicy = provisioningToolOptions.SusiPolicyId;
+            }
 
             return projectSettings;
         }

--- a/tools/dotnet-msidentity/Program.cs
+++ b/tools/dotnet-msidentity/Program.cs
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                              "\n\t- Updates the Startup.cs file." +
                              "\n\t- Updates the user secrets.\n")
             {
-                TenantOption(), UsernameOption(), ClientIdOption(), JsonOption(), ProjectFilePathOption(), ConfigUpdateOption(), CodeUpdateOption(), PackagesUpdateOption(), CallsGraphOption(), CallsDownstreamApiOption(), UpdateUserSecretsOption(), RedirectUriOption()
+                TenantOption(), UsernameOption(), ClientIdOption(), JsonOption(), ProjectFilePathOption(), ConfigUpdateOption(), CodeUpdateOption(), PackagesUpdateOption(), CallsGraphOption(), CallsDownstreamApiOption(), UpdateUserSecretsOption(), RedirectUriOption(), SusiPolicyIdOption()
             };
 
         internal static Command UpdateAppRegistrationCommand() =>


### PR DESCRIPTION
Adds the optional parameter "--susi-policy-id" for the code update command. Used for B2C scenarios to update the appsettings.json file with the correct B2C Sign up sign in policy ID.

Also makes "dotnet-webapp" the default project type in case the project type cannot be inferred.