### PR TITLE
fix minimal api --outDir bug

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <VersionPrefix>7.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
     <!--

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -129,9 +129,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             string outputFileName = commandLineModel.EndpintsClassName + Constants.CodeFileExtension;
             string outputFolder = string.IsNullOrEmpty(commandLineModel.RelativeFolderPath)
                 ? AppInfo.ApplicationBasePath
-                : Path.Join(AppInfo.ApplicationBasePath, commandLineModel.RelativeFolderPath);
+                : Path.Combine(AppInfo.ApplicationBasePath, commandLineModel.RelativeFolderPath);
 
-            var outputPath = Path.Join(outputFolder, outputFileName);
+            var outputPath = Path.Combine(outputFolder, outputFileName);
             return outputPath;
         }
 

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             Assert.Contains(minimalApiModel.MethodName, programCsText);
         }
 
-        [SkippableFact]
+        [Fact]
         public void ValidateAndGetOutputPathTests()
         {
             Skip.If(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows));

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
@@ -15,6 +15,7 @@ using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Web.CodeGeneration.Test.Sources;
 using System.Runtime.InteropServices;
+using System.IO;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
@@ -109,9 +110,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         [Fact]
         public void ValidateAndGetOutputPathTests()
         {
-            Skip.If(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             Mock<IApplicationInfo> _mockApp = new Mock<IApplicationInfo>();
-            var applicationBasePath = @"C:\AppPath";
+            bool isWindows = OperatingSystem.IsWindows();
+            var applicationBasePath = Path.Combine("C:", "AppPath");
             _mockApp.Setup(app => app.ApplicationBasePath)
                 .Returns(applicationBasePath);
             var minimalApiGenerator = CreateMinimalApiGenerator();
@@ -119,16 +120,25 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             {
                 ModelClass = "testModel",
                 EndpintsClassName = "testClass",
-                RelativeFolderPath = @"Endpoints\Endpoint"
+                RelativeFolderPath = isWindows ? @"Endpoints\Endpoint" : @"Endpoints/Endpoint"
             };
             var minimalCommandlineWithoutRelativePath = new MinimalApiGeneratorCommandLineModel
             {
                 ModelClass = "testModel2",
                 EndpintsClassName = "testClass2",
             };
-                
-            Assert.Equal(@"C:\AppPath\Endpoints\Endpoint\testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
-            Assert.Equal(@"C:\AppPath\testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
+
+            if (isWindows)
+            {
+                Assert.Equal(@"C:\AppPath\Endpoints\Endpoint\testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
+                Assert.Equal(@"C:\AppPath\testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
+            }
+            else
+            {
+                Assert.Equal(@"C:/AppPath/Endpoints/Endpoint/testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
+                Assert.Equal(@"C:/AppPath/testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
+            }
+            
         }
 
         [Fact]

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/MinimalApiGeneratorTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         {
             Mock<IApplicationInfo> _mockApp = new Mock<IApplicationInfo>();
             bool isWindows = OperatingSystem.IsWindows();
-            var applicationBasePath = Path.Combine("C:", "AppPath");
+            var applicationBasePath = "AppPath";
             _mockApp.Setup(app => app.ApplicationBasePath)
                 .Returns(applicationBasePath);
             var minimalApiGenerator = CreateMinimalApiGenerator();
@@ -130,15 +130,14 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
             if (isWindows)
             {
-                Assert.Equal(@"C:\AppPath\Endpoints\Endpoint\testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
-                Assert.Equal(@"C:\AppPath\testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
+                Assert.Equal(@"AppPath\Endpoints\Endpoint\testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
+                Assert.Equal(@"AppPath\testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
             }
             else
             {
-                Assert.Equal(@"C:/AppPath/Endpoints/Endpoint/testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
-                Assert.Equal(@"C:/AppPath/testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
-            }
-            
+                Assert.Equal(@"AppPath/Endpoints/Endpoint/testClass.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandline));
+                Assert.Equal(@"AppPath/testClass2.cs", minimalApiGenerator.ValidateAndGetOutputPath(minimalCommandlineWithoutRelativePath));
+            }   
         }
 
         [Fact]
@@ -179,7 +178,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
             var project = workspace.AddProject(projectInfo);
             appInfo.Setup(app => app.ApplicationBasePath)
-                .Returns(@"C:\AppPath");
+                .Returns(@"AppPath");
 
             projectContext.Setup(ctx => ctx.AssemblyName)
                 .Returns("TestAssembly");


### PR DESCRIPTION
Addresses #1884 
- Changed `Path.Join` to `Path.Combine`
- Not skipping test for this use.