### PR TITLE
minimal api net7 changes

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -44,8 +44,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithOpenApi()
-        @:.WithName("@getAllModels");
+        @:.WithName("@getAllModels")
+        @:.WithOpenApi();
     }
     else
     {
@@ -60,8 +60,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithOpenApi()
-        @:.WithName("@getModelById");
+        @:.WithName("@getModelById")
+        @:.WithOpenApi();
     }
     else
     {
@@ -76,8 +76,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithOpenApi()
-        @:.WithName("@updateModel");
+        @:.WithName("@updateModel")
+        @:.WithOpenApi();
     }
     else
     {
@@ -101,8 +101,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithOpenApi()
-        @:.WithName("@createModel");
+        @:.WithName("@createModel")
+        @:.WithOpenApi();
     }
     else
     {
@@ -126,8 +126,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithOpenApi()
-        @:.WithName("@deleteModel");
+        @:.WithName("@deleteModel")
+        @:.WithOpenApi();
     }
     else
     {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -26,13 +26,17 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("@routePrefix");
     @{
     if(Model.OpenAPI)
     {
-        @:group.WithOpenApi();
+        @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
+    }
+    else
+    {
+        @:var group = routes.MapGroup("@routePrefix");
     }
     }    
+
         group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };
@@ -40,9 +44,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
-        @:.WithName("@getAllModels")
-        @:.Produces<@modelArray>(StatusCodes.Status200OK);
+        @:.WithOpenApi()
+        @:.WithName("@getAllModels");
     }
     else
     {
@@ -57,9 +60,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
-        @:.WithName("@getModelById")
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        @:.WithOpenApi()
+        @:.WithName("@getModelById");
     }
     else
     {
@@ -74,9 +76,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
-        @:.WithName("@updateModel")
-        @:.Produces(StatusCodes.Status204NoContent);
+        @:.WithOpenApi()
+        @:.WithName("@updateModel");
     }
     else
     {
@@ -91,9 +92,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
-        @:.WithName("@createModel")
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+        @:.WithOpenApi()
+        @:.WithName("@createModel");
     }
     else
     {
@@ -108,9 +108,8 @@ public static class @endPointsClassName
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
-        @:.WithName("@deleteModel")
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        @:.WithOpenApi()
+        @:.WithName("@deleteModel");
     }
     else
     {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -87,7 +87,16 @@ public static class @endPointsClassName
 
         group.MapPost("/", (@modelName model) =>
         {
-            //return Results.Created($"/@pluralModel/{model.ID}", model);
+        @{
+        if(Model.OpenAPI)
+        {
+            @://return TypedResults.Created($"/@pluralModel/{model.ID}", model);
+        }
+        else
+        {
+            @://return Results.Created($"/@pluralModel/{model.ID}", model);
+        }
+        }
         })
     @{
     if(Model.OpenAPI)
@@ -103,7 +112,16 @@ public static class @endPointsClassName
 
         group.MapDelete("/{id}", (int id) =>
         {
-            //return Results.Ok(new @modelName { ID = id });
+        @{
+        if(Model.OpenAPI)
+        {
+            @://return TypedResults.Ok(new @modelName { ID = id });
+        }
+        else
+        {
+            @://return Results.Ok(new @modelName { ID = id });
+        }
+        }
         })
     @{
     if(Model.OpenAPI)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -44,13 +44,17 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("@routePrefix");
     @{
     if(Model.OpenAPI)
     {
-        @:group.WithOpenApi();
+        @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
     }
-    }    
+    else
+    {
+        @:var group = routes.MapGroup("@routePrefix");
+    }
+}    
+
         group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;
@@ -58,9 +62,8 @@ public static class @endPointsClassName
     @{
         if(Model.OpenAPI)
         {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getAllModels")
-        @:.Produces<@modelList>(StatusCodes.Status200OK);
+        @:.WithOpenApi();
         }
         else
         {
@@ -78,10 +81,8 @@ public static class @endPointsClassName
     @{
         if(Model.OpenAPI)
         {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getModelById")
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
+        @:.WithOpenApi();
         }
         else
         {
@@ -106,10 +107,8 @@ public static class @endPointsClassName
     @{
         if(Model.OpenAPI)
         {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@updateModel")
-        @:.Produces(StatusCodes.Status404NotFound)
-        @:.Produces(StatusCodes.Status204NoContent);
+        @:.WithOpenApi();
         }
         else
         {
@@ -126,9 +125,8 @@ public static class @endPointsClassName
     @{
         if(Model.OpenAPI)
         {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@createModel")
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+        @:.WithOpenApi();
         }
         else
         {
@@ -150,10 +148,8 @@ public static class @endPointsClassName
     @{
         if(Model.OpenAPI)
         {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@deleteModel")
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
+        @:.WithOpenApi();
         }
         else
         {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -32,13 +32,17 @@
 }
 public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("@routePrefix");
-    @{
+@{
     if(Model.OpenAPI)
     {
-        @:group.WithOpenApi();
+        @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
     }
-    }    
+    else
+    {
+        @:var group = routes.MapGroup("@routePrefix");
+    }
+}    
+
         group.MapGet("/", async (@dbContextName db) =>
         {
             return await db.@modelToList;
@@ -46,9 +50,8 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getAllModels")
-        @:.Produces<@modelList>(StatusCodes.Status200OK);
+        @:.WithOpenApi();
     }
     else
     {
@@ -66,10 +69,8 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getModelById")
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
+        @:.WithOpenApi();
     }
     else
     {
@@ -94,10 +95,8 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@updateModel")
-        @:.Produces(StatusCodes.Status404NotFound)
-        @:.Produces(StatusCodes.Status204NoContent);
+        @:.WithOpenApi();
     }
     else
     {
@@ -114,9 +113,8 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@createModel")
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+        @:.WithOpenApi();
     }
     else
     {
@@ -138,10 +136,8 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@deleteModel")
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
+        @:.WithOpenApi();
     }
     else
     {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -78,7 +78,16 @@
 
         group.MapPost("/", (@modelName model) =>
         {
-            //return Results.Created($"/@pluralModel/{model.ID}", model);
+        @{
+        if(Model.OpenAPI)
+        {
+            @://return TypedResults.Created($"/@pluralModel/{model.ID}", model);
+        }
+        else
+        {
+            @://return Results.Created($"/@pluralModel/{model.ID}", model);
+        }
+        }
         })
     @{
     if(Model.OpenAPI)
@@ -94,7 +103,16 @@
 
         group.MapDelete("/{id}", (int id) =>
         {
-            //return Results.Ok(new @modelName { ID = id });
+        @{
+        if(Model.OpenAPI)
+        {
+            @://return TypedResults.Ok(new @modelName { ID = id });
+        }
+        else
+        {
+            @://return Results.Ok(new @modelName { ID = id });
+        }
+        }
         })
     @{
     if(Model.OpenAPI)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -17,13 +17,17 @@
  
    public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("@routePrefix");
-    @{
+@{
     if(Model.OpenAPI)
     {
-        @:group.WithOpenApi();
+        @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
     }
-    }    
+    else
+    {
+        @:var group = routes.MapGroup("@routePrefix");
+    }
+}    
+
         group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };
@@ -31,9 +35,8 @@
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getAllModels")
-        @:.Produces<@modelArray>(StatusCodes.Status200OK);
+        @:.WithOpenApi();
     }
     else
     {
@@ -48,9 +51,8 @@
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@getModelById")
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        @:.WithOpenApi();
     }
     else
     {
@@ -65,9 +67,8 @@
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@updateModel")
-        @:.Produces(StatusCodes.Status204NoContent);
+        @:.WithOpenApi();
     }
     else
     {
@@ -82,9 +83,8 @@
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@createModel")
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+        @:.WithOpenApi();
     }
     else
     {
@@ -99,9 +99,8 @@
     @{
     if(Model.OpenAPI)
     {
-        @:.WithTags(nameof(@modelName))
         @:.WithName("@deleteModel")
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        @:.WithOpenApi();
     }
     else
     {


### PR DESCRIPTION
Addressing changes from #2037.

Notes (@DamianEdwards) : 
> `Update non-EF Core scaffolder to also use TypedResults`
- the non-EF scaffolder has commented out the Results return so just have changed it TypedResults but still commented out.
