### PR TITLE
adding option to opt out of typed results and templates changes

### DIFF
--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -21,3 +21,4 @@ call D:
 call cd  %SRC_DIR%/%NUPKG% 
 call dotnet tool install -g dotnet-aspnet-codegenerator --add-source %SRC_DIR%\%NUPKG% --version %VERSION%
 call cd %SRC_DIR%
+call taskkill /f /im dotnet.exe

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             {
                 ValidateOpenApiDependencies(ProjectContext.PackageDependencies);
             }
-
+            
             var templateModel = new MinimalApiModel(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName, model.EndpintsClassName)
             {
                 EndpointsName = model.EndpintsClassName,
@@ -92,7 +92,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 NullableEnabled = "enable".Equals(ProjectContext?.Nullable, StringComparison.OrdinalIgnoreCase),
                 OpenAPI = model.OpenApi,
                 MethodName = $"Map{modelTypeAndContextModel.ModelType.Name}Endpoints",
-                UseSqlite = model.UseSqlite
+                UseSqlite = model.UseSqlite,
+                UseTypedResults = !model.NoTypedResults
             };
 
             var endpointsModel = ModelTypesLocator.GetAllTypes().FirstOrDefault(t => t.Name.Equals(model.EndpintsClassName));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -25,6 +25,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        [Option(Name = "noTypedResults", ShortName = "ntr", Description = "Flag to not use TypedResults for minimal apis.")]
+        public bool NoTypedResults { get; set; }
+
         public MinimalApiGeneratorCommandLineModel()
         {
         }
@@ -37,6 +40,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             OpenApi = copyFrom.OpenApi;
             EndpointsNamespace = copyFrom.EndpointsNamespace;
             UseSqlite = copyFrom.UseSqlite;
+            NoTypedResults = copyFrom.NoTypedResults;
         }
 
         public MinimalApiGeneratorCommandLineModel Clone()

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
@@ -45,6 +45,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         //Sqlite for sqlite and mac/linux scenarios.
         public bool UseSqlite { get; set; }
 
+        //Use TypedResults for minimal apis.
+        public bool UseTypedResults { get; set; }
+
         //Generated namespace for a Endpoints class/file. If using an existing file, does not apply.
         public string EndpointsNamespace { get; set; }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -26,7 +26,7 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
@@ -35,17 +35,23 @@ public static class @endPointsClassName
     {
         @:var group = routes.MapGroup("@routePrefix");
     }
-    }    
+}    
 
         group.MapGet("/", () =>
         {
             return new [] { new @modelConstructor };
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@getAllModels")
         @:.WithOpenApi();
+    }
+    else if(Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@getAllModels")
+        @:.WithOpenApi()
+        @:.Produces<@modelArray>(StatusCodes.Status200OK);
     }
     else
     {
@@ -58,10 +64,16 @@ public static class @endPointsClassName
             //return new @modelName { ID = id };
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@getModelById")
         @:.WithOpenApi();
+    }
+    else if(Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@getModelById")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK);
     }
     else
     {
@@ -74,10 +86,16 @@ public static class @endPointsClassName
             return @resultsExtension;
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@updateModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@updateModel")
+        @:.WithOpenApi()
+        @:.Produces(StatusCodes.Status204NoContent);
     }
     else
     {
@@ -99,10 +117,16 @@ public static class @endPointsClassName
         }
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@createModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@createModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status201Created);
     }
     else
     {
@@ -124,10 +148,16 @@ public static class @endPointsClassName
         }
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@deleteModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@deleteModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK);
     }
     else
     {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -12,7 +12,8 @@
     string deleteModel = $"Delete{@modelName}";
     string createModel = $"Create{@modelName}";
     string updateModel = $"Update{@modelName}";
-    string resultsExtension = (Model.OpenAPI ? "TypedResults" : "Results") + ".NoContent()";
+    string resultsExtension = (Model.UseTypedResults ? "TypedResults" : "Results") + ".NoContent()";
+    string builderExtensionSpaces = new string(' ', 8);
 }
 @{
     foreach (var namespaceName in Model.RequiredNamespaces)
@@ -41,72 +42,57 @@ public static class @endPointsClassName
         {
             return new [] { new @modelConstructor };
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    string builderExtensions = $".WithName(\"{@getAllModels}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if(Model.OpenAPI && !Model.UseTypedResults)
+    if(!Model.UseTypedResults)
     {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi()
-        @:.Produces<@modelArray>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@getAllModels");
-    }
-    }
-
+        @:@builderExtensions;
+}
+        
         group.MapGet("/{id}", (int id) =>
         {
             //return new @modelName { ID = id };
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@getModelById}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if(Model.OpenAPI && !Model.UseTypedResults)
+    if(!Model.UseTypedResults)
     {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@getModelById");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapPut("/{id}", (int id, @modelName input) =>
         {
             return @resultsExtension;
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@updateModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi()
-        @:.Produces(StatusCodes.Status204NoContent);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
     }
-    else
-    {
-        @:.WithName("@updateModel");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapPost("/", (@modelName model) =>
         {
         @{
-        if(Model.OpenAPI)
+        if(!Model.UseTypedResults)
         {
             @://return TypedResults.Created($"/@pluralModel/{model.ID}", model);
         }
@@ -116,28 +102,23 @@ public static class @endPointsClassName
         }
         }
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@createModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@createModel")
-        @:.WithOpenApi();
+    builderExtensions+= $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@createModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+    builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
     }
-    else
-    {
-        @:.WithName("@createModel");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapDelete("/{id}", (int id) =>
         {
-        @{
-        if(Model.OpenAPI)
+@{
+        if(!Model.UseTypedResults)
         {
             @://return TypedResults.Ok(new @modelName { ID = id });
         }
@@ -145,24 +126,19 @@ public static class @endPointsClassName
         {
             @://return Results.Ok(new @modelName { ID = id });
         }
-        }
+}
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@deleteModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@deleteModel");  
-    }
+        @:@builderExtensions;  
     }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -21,15 +21,16 @@
     var findModel = $"{@entitySetName}.FindAsync({@primaryKeyNameLowerCase})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
-    string resultsExtension = Model.OpenAPI ? (Model.UseTypedResults ? "TypedResults" : "Results") : "Results";
-    string typedTaskWithNotFound = Model.OpenAPI ?  (Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "") : "";
-    string typedTaskWithNoContent = Model.OpenAPI ? (Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "") : "";
+    string resultsExtension = Model.UseTypedResults ? "TypedResults" : "Results";
+    string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
+    string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
     string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
     string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
+    string builderExtensionSpaces = new string(' ', 8);
 }
 using Microsoft.EntityFrameworkCore;
 @{
@@ -44,7 +45,7 @@ public static class @endPointsClassName
 {
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
@@ -59,23 +60,19 @@ public static class @endPointsClassName
         {
             return await db.@modelToList;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        string builderExtensions = $".WithName(\"{@getAllModels}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
+        if (!Model.UseTypedResults)
         {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi()
-        @:.Produces<@modelList>(StatusCodes.Status200OK);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
         }
-        else
-        {
-        @:.WithName("@getAllModels");
-        }
-    }
+
+        @:@builderExtensions;
+}
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -84,24 +81,19 @@ public static class @endPointsClassName
                     ? @resultsOkModel
                     : @resultsNotFound;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
-        {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi();
-        }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
-        {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
-        }
-        else
-        {
-        @:.WithName("@getModelById");
-        }
+@{
+    builderExtensions = $".WithName(\"{@getModelById}\")";
+    if(Model.OpenAPI)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
+    if (!Model.UseTypedResults)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)"; 
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+    }
+        @:@builderExtensions;
+}
 
         group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -117,24 +109,20 @@ public static class @endPointsClassName
 
             return @resultsNoContent;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        builderExtensions = $".WithName(\"{@updateModel}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
+        if (!Model.UseTypedResults)
         {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi()
-        @:.Produces(StatusCodes.Status404NotFound)
-        @:.Produces(StatusCodes.Status204NoContent);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
         }
-        else
-        {
-        @:.WithName("@updateModel");
-        }
-    }
+
+        @:@builderExtensions;
+}
 
         group.MapPost("/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -142,23 +130,18 @@ public static class @endPointsClassName
             await db.SaveChangesAsync();
             return @resultsCreated;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        builderExtensions = $".WithName(\"{@createModel}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@createModel")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if(Model.OpenAPI && !Model.UseTypedResults)
+        if(!Model.UseTypedResults)
         {
-        @:.WithName("@createModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
         }
-        else
-        {
-        @:.WithName("@createModel");
-        }
-    }
+        @:@builderExtensions;
+}
 
         group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -171,23 +154,18 @@ public static class @endPointsClassName
 
             return @resultsNotFound;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
-        {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi();
-        }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
-        {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
-        }
-        else
-        {
-        @:.WithName("@deleteModel");
-        }
+@{
+    builderExtensions = $".WithName(\"{@deleteModel}\")";
+    if(Model.OpenAPI)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
+    if (!Model.UseTypedResults)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+    }
+        @:@builderExtensions;
+}
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -21,9 +21,9 @@
     var findModel = $"{@entitySetName}.FindAsync({@primaryKeyNameLowerCase})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
-    string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
-    string typedTaskWithNotFound = Model.OpenAPI ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
-    string typedTaskWithNoContent = Model.OpenAPI ? $"Task<Results<NotFound, NoContent>>" : "";
+    string resultsExtension = Model.OpenAPI ? (Model.UseTypedResults ? "TypedResults" : "Results") : "Results";
+    string typedTaskWithNotFound = Model.OpenAPI ?  (Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "") : "";
+    string typedTaskWithNoContent = Model.OpenAPI ? (Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "") : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
@@ -60,10 +60,16 @@ public static class @endPointsClassName
             return await db.@modelToList;
         })
     @{
-        if(Model.OpenAPI)
+        if(Model.OpenAPI && Model.UseTypedResults)
         {
         @:.WithName("@getAllModels")
         @:.WithOpenApi();
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@getAllModels")
+        @:.WithOpenApi()
+        @:.Produces<@modelList>(StatusCodes.Status200OK);
         }
         else
         {
@@ -79,10 +85,17 @@ public static class @endPointsClassName
                     : @resultsNotFound;
         })
     @{
-        if(Model.OpenAPI)
+        if(Model.OpenAPI && Model.UseTypedResults)
         {
         @:.WithName("@getModelById")
         @:.WithOpenApi();
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@getModelById")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK)
+        @:.Produces(StatusCodes.Status404NotFound);
         }
         else
         {
@@ -105,10 +118,17 @@ public static class @endPointsClassName
             return @resultsNoContent;
         })
     @{
-        if(Model.OpenAPI)
+        if(Model.OpenAPI && Model.UseTypedResults)
         {
         @:.WithName("@updateModel")
         @:.WithOpenApi();
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@updateModel")
+        @:.WithOpenApi()
+        @:.Produces(StatusCodes.Status404NotFound)
+        @:.Produces(StatusCodes.Status204NoContent);
         }
         else
         {
@@ -123,10 +143,16 @@ public static class @endPointsClassName
             return @resultsCreated;
         })
     @{
-        if(Model.OpenAPI)
+        if(Model.OpenAPI && Model.UseTypedResults)
         {
         @:.WithName("@createModel")
         @:.WithOpenApi();
+        }
+        else if(Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@createModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status201Created);
         }
         else
         {
@@ -146,10 +172,17 @@ public static class @endPointsClassName
             return @resultsNotFound;
         })
     @{
-        if(Model.OpenAPI)
+        if(Model.OpenAPI && Model.UseTypedResults)
         {
         @:.WithName("@deleteModel")
         @:.WithOpenApi();
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@deleteModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK)
+        @:.Produces(StatusCodes.Status404NotFound);
         }
         else
         {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -30,9 +30,9 @@
     string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
     string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
 }
-public static void @Model.MethodName (this IEndpointRouteBuilder routes)
+    public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-@{
+    @{
     if(Model.OpenAPI)
     {
         @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
@@ -47,17 +47,23 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
         {
             return await db.@modelToList;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI && Model.UseTypedResults)
+        {
         @:.WithName("@getAllModels")
         @:.WithOpenApi();
-    }
-    else
-    {
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@getAllModels")
+        @:.WithOpenApi()
+        @:.Produces<@modelList>(StatusCodes.Status200OK);
+        }
+        else
+        {
         @:.WithName("@getAllModels");
+        }
     }
-}
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -66,17 +72,24 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
                     ? @resultsOkModel
                     : @resultsNotFound;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI && Model.UseTypedResults)
+        {
         @:.WithName("@getModelById")
         @:.WithOpenApi();
-    }
-    else
-    {
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@getModelById")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK)
+        @:.Produces(StatusCodes.Status404NotFound);
+        }
+        else
+        {
         @:.WithName("@getModelById");
+        }
     }
-}
 
         group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -92,17 +105,24 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 
             return @resultsNoContent;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI && Model.UseTypedResults)
+        {
         @:.WithName("@updateModel")
         @:.WithOpenApi();
-    }
-    else
-    {
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@updateModel")
+        @:.WithOpenApi()
+        @:.Produces(StatusCodes.Status404NotFound)
+        @:.Produces(StatusCodes.Status204NoContent);
+        }
+        else
+        {
         @:.WithName("@updateModel");
+        }
     }
-}
 
         group.MapPost("/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -110,17 +130,23 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
             await db.SaveChangesAsync();
             return @resultsCreated;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI && Model.UseTypedResults)
+        {
         @:.WithName("@createModel")
         @:.WithOpenApi();
-    }
-    else
-    {
+        }
+        else if(Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@createModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status201Created);
+        }
+        else
+        {
         @:.WithName("@createModel");
+        }
     }
-}
 
         group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -133,15 +159,22 @@ public static void @Model.MethodName (this IEndpointRouteBuilder routes)
 
             return @resultsNotFound;
         })
-@{
-    if(Model.OpenAPI)
-    {
+    @{
+        if(Model.OpenAPI && Model.UseTypedResults)
+        {
         @:.WithName("@deleteModel")
         @:.WithOpenApi();
-    }
-    else
-    {
+        }
+        else if (Model.OpenAPI && !Model.UseTypedResults)
+        {
+        @:.WithName("@deleteModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK)
+        @:.Produces(StatusCodes.Status404NotFound);
+        }
+        else
+        {
         @:.WithName("@deleteModel");
+        }
     }
-}
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -20,19 +20,20 @@
     var findModel = $"{@entitySetName}.FindAsync({@primaryKeyNameLowerCase})";
     var add = $"{@entitySetName}.Add({@Model.ModelVariable})";
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
-    string resultsExtension = Model.OpenAPI ? "TypedResults" : "Results";
-    string typedTaskWithNotFound = Model.OpenAPI ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
-    string typedTaskWithNoContent = Model.OpenAPI ? $"Task<Results<NotFound, NoContent>>" : "";
+    string resultsExtension = Model.UseTypedResults ? "TypedResults" : "Results";
+    string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
+    string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
     string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
     string resultsCreated = $"{resultsExtension}.Created(" + $"{@createdApiVar}" + ")";
+    string builderExtensionSpaces = new string(' ', 8);
 }
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
-    @{
+@{
     if(Model.OpenAPI)
     {
         @:var group = routes.MapGroup("@routePrefix").WithTags(nameof(@modelName));
@@ -47,23 +48,19 @@
         {
             return await db.@modelToList;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        string builderExtensions = $".WithName(\"{@getAllModels}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
+        if (!Model.UseTypedResults)
         {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi()
-        @:.Produces<@modelList>(StatusCodes.Status200OK);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
         }
-        else
-        {
-        @:.WithName("@getAllModels");
-        }
-    }
+
+        @:@builderExtensions;
+}
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -72,24 +69,19 @@
                     ? @resultsOkModel
                     : @resultsNotFound;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
-        {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi();
-        }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
-        {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
-        }
-        else
-        {
-        @:.WithName("@getModelById");
-        }
+@{
+    builderExtensions = $".WithName(\"{@getModelById}\")";
+    if(Model.OpenAPI)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
+    if (!Model.UseTypedResults)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)"; 
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+    }
+        @:@builderExtensions;
+}
 
         group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -105,24 +97,20 @@
 
             return @resultsNoContent;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        builderExtensions = $".WithName(\"{@updateModel}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
+        if (!Model.UseTypedResults)
         {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi()
-        @:.Produces(StatusCodes.Status404NotFound)
-        @:.Produces(StatusCodes.Status204NoContent);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
         }
-        else
-        {
-        @:.WithName("@updateModel");
-        }
-    }
+
+        @:@builderExtensions;
+}
 
         group.MapPost("/", async (@modelName @Model.ModelVariable, @dbContextName db) =>
         {
@@ -130,23 +118,18 @@
             await db.SaveChangesAsync();
             return @resultsCreated;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
+@{
+        builderExtensions = $".WithName(\"{@createModel}\")";
+        if(Model.OpenAPI)
         {
-        @:.WithName("@createModel")
-        @:.WithOpenApi();
+            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
         }
-        else if(Model.OpenAPI && !Model.UseTypedResults)
+        if(!Model.UseTypedResults)
         {
-        @:.WithName("@createModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
         }
-        else
-        {
-        @:.WithName("@createModel");
-        }
-    }
+        @:@builderExtensions;
+}
 
         group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
@@ -159,22 +142,17 @@
 
             return @resultsNotFound;
         })
-    @{
-        if(Model.OpenAPI && Model.UseTypedResults)
-        {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi();
-        }
-        else if (Model.OpenAPI && !Model.UseTypedResults)
-        {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK)
-        @:.Produces(StatusCodes.Status404NotFound);
-        }
-        else
-        {
-        @:.WithName("@deleteModel");
-        }
+@{
+    builderExtensions = $".WithName(\"{@deleteModel}\")";
+    if(Model.OpenAPI)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
+    if (!Model.UseTypedResults)
+    {
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+    }
+        @:@builderExtensions;
+}
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -15,7 +15,7 @@
     string resultsExtension = (Model.OpenAPI ? "TypedResults" : "Results") + ".NoContent()";
 }
  
-   public static void @Model.MethodName (this IEndpointRouteBuilder routes)
+    public static void @Model.MethodName (this IEndpointRouteBuilder routes)
     {
 @{
     if(Model.OpenAPI)
@@ -33,10 +33,16 @@
             return new [] { new @modelConstructor };
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@getAllModels")
         @:.WithOpenApi();
+    }
+    else if(Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@getAllModels")
+        @:.WithOpenApi()
+        @:.Produces<@modelArray>(StatusCodes.Status200OK);
     }
     else
     {
@@ -54,6 +60,12 @@
         @:.WithName("@getModelById")
         @:.WithOpenApi();
     }
+    else if(Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@getModelById")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK);
+    }
     else
     {
         @:.WithName("@getModelById");
@@ -65,10 +77,16 @@
             return @resultsExtension;
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@updateModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@updateModel")
+        @:.WithOpenApi()
+        @:.Produces(StatusCodes.Status204NoContent);
     }
     else
     {
@@ -90,10 +108,16 @@
         }
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@createModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@createModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status201Created);
     }
     else
     {
@@ -115,10 +139,16 @@
         }
         })
     @{
-    if(Model.OpenAPI)
+    if(Model.OpenAPI && Model.UseTypedResults)
     {
         @:.WithName("@deleteModel")
         @:.WithOpenApi();
+    }
+    else if (Model.OpenAPI && !Model.UseTypedResults)
+    {
+        @:.WithName("@deleteModel")
+        @:.WithOpenApi()
+        @:.Produces<@modelName>(StatusCodes.Status200OK);
     }
     else
     {

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -12,7 +12,8 @@
     string deleteModel = $"Delete{@modelName}";
     string createModel = $"Create{@modelName}";
     string updateModel = $"Update{@modelName}";
-    string resultsExtension = (Model.OpenAPI ? "TypedResults" : "Results") + ".NoContent()";
+    string resultsExtension = (Model.UseTypedResults ? "TypedResults" : "Results") + ".NoContent()";
+     string builderExtensionSpaces = new string(' ', 8);
 }
  
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)
@@ -32,72 +33,57 @@
         {
             return new [] { new @modelConstructor };
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    string builderExtensions = $".WithName(\"{@getAllModels}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if(Model.OpenAPI && !Model.UseTypedResults)
+    if(!Model.UseTypedResults)
     {
-        @:.WithName("@getAllModels")
-        @:.WithOpenApi()
-        @:.Produces<@modelArray>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@getAllModels");
-    }
-    }
-
+        @:@builderExtensions;
+}
+        
         group.MapGet("/{id}", (int id) =>
         {
             //return new @modelName { ID = id };
         })
-    @{
+@{
+    builderExtensions = $".WithName(\"{@getModelById}\")";
     if(Model.OpenAPI)
     {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if(Model.OpenAPI && !Model.UseTypedResults)
+    if(!Model.UseTypedResults)
     {
-        @:.WithName("@getModelById")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@getModelById");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapPut("/{id}", (int id, @modelName input) =>
         {
             return @resultsExtension;
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@updateModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi();
+    builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@updateModel")
-        @:.WithOpenApi()
-        @:.Produces(StatusCodes.Status204NoContent);
+    builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
     }
-    else
-    {
-        @:.WithName("@updateModel");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapPost("/", (@modelName model) =>
         {
         @{
-        if(Model.OpenAPI)
+        if(!Model.UseTypedResults)
         {
             @://return TypedResults.Created($"/@pluralModel/{model.ID}", model);
         }
@@ -107,28 +93,23 @@
         }
         }
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@createModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@createModel")
-        @:.WithOpenApi();
+    builderExtensions+= $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@createModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status201Created);
+    builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
     }
-    else
-    {
-        @:.WithName("@createModel");
-    }
-    }
+        @:@builderExtensions;
+}
 
         group.MapDelete("/{id}", (int id) =>
         {
-        @{
-        if(Model.OpenAPI)
+@{
+        if(!Model.UseTypedResults)
         {
             @://return TypedResults.Ok(new @modelName { ID = id });
         }
@@ -136,23 +117,18 @@
         {
             @://return Results.Ok(new @modelName { ID = id });
         }
-        }
+}
         })
-    @{
-    if(Model.OpenAPI && Model.UseTypedResults)
+@{
+    builderExtensions = $".WithName(\"{@deleteModel}\")";
+    if(Model.OpenAPI)
     {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi();
+        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
     }
-    else if (Model.OpenAPI && !Model.UseTypedResults)
+    if (!Model.UseTypedResults)
     {
-        @:.WithName("@deleteModel")
-        @:.WithOpenApi()
-        @:.Produces<@modelName>(StatusCodes.Status200OK);
+        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
-    else
-    {
-        @:.WithName("@deleteModel");  
-    }
+        @:@builderExtensions;  
     }
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -13,7 +13,7 @@
     string createModel = $"Create{@modelName}";
     string updateModel = $"Update{@modelName}";
     string resultsExtension = (Model.UseTypedResults ? "TypedResults" : "Results") + ".NoContent()";
-     string builderExtensionSpaces = new string(' ', 8);
+    string builderExtensionSpaces = new string(' ', 8);
 }
  
     public static void @Model.MethodName (this IEndpointRouteBuilder routes)


### PR DESCRIPTION
Addressing more changes #2037  :
- added `MinimalApiGenerator.NoTypedResults` instead of TypedResults to make it an opt out option.
  - opposite of `MinimalApiGenerator.OpenAPI` where it is an opt in, mistake in hindsight but due to backwards compat, cannot reverse this. Will be a minor fix for .NET 8 timeline.
  - Opting in would allow an alternate of writing the API endpoints with `Produces` and `Results`.
- Template changes can be reviewed in this [repo](https://github.com/deepchoudhery/minimal-api-endpoints) (both EF and non EF scenarios)

