### PR TITLE
added ProjectContextHelper.GetXmlKeyValue and IProjectContext.CheckNullableVariable

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 _toolOptions.ProjectFilePath = csProjFiles.First();
             }
             string csprojText = File.ReadAllText(_toolOptions.ProjectFilePath);
-            _toolOptions.ShortTfms = ProjectModifierHelper.ProcessCsprojFile(csprojText);
+            _toolOptions.ShortTfms = ProjectModifierHelper.ProcessCsprojTfms(csprojText);
 
             CodeModifierConfig? codeModifierConfig = GetCodeModifierConfig();
             if (codeModifierConfig is null || !codeModifierConfig.Files.Any())

--- a/src/Scaffolding/VS.Web.CG.Design/Program.cs
+++ b/src/Scaffolding/VS.Web.CG.Design/Program.cs
@@ -75,6 +75,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Design
                         string projectAssetsFile = ProjectModelHelper.GetProjectAssetsFile(projectInformation);
                         //fix package dependencies sent from VS
                         projectInformation = projectInformation.AddPackageDependencies(projectAssetsFile);
+                        projectInformation = projectInformation.CheckNullableVariable();
                         var codeGenArgs = ToolCommandLineHelper.FilterExecutorArguments(args);
                         var isSimulationMode = ToolCommandLineHelper.IsSimulationMode(args);
                         CodeGenCommandExecutor executor = new CodeGenCommandExecutor(projectInformation,

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
         /// </summary>
         /// <param name="csprojText">.csproj file as string</param>
         /// <returns>string[] containing target frameworks of the project</returns>
-        internal static string[] ProcessCsprojFile(string csprojText)
+        internal static string[] ProcessCsprojTfms(string csprojText)
         {
             List<string> processedTfms = new List<string>();
             if (!string.IsNullOrEmpty(csprojText))

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
                     .Dependencies
                     .Any(dep => dep.Name.Equals(name, StringComparison.OrdinalIgnoreCase)));
         }
+
         public static IProjectContext AddPackageDependencies(this IProjectContext projectInformation, string projectAssetsFile)
         {
             //get project assets file
@@ -62,6 +63,31 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
                 ProjectReferenceInformation = projectInformation.ProjectReferenceInformation
             };
             return newProjectContext;
+        }
+
+        /// <summary>
+        /// Given an IProjectContext, check if IProjectContext.Nullable is set, if it is, no changes necessary.
+        /// If not already there, set using ProjectContextHelper.GetXmlKeyValue (parsing the csproj xml file).
+        /// </summary>
+        /// <param name="context">IProjectContext which has csproj path, and the Nullable variable to set.</param>
+        /// <returns>modified IProjectContext with the Nullable property set or the same IProjectContext as passed.</returns>
+        public static IProjectContext CheckNullableVariable(this IProjectContext context)
+        {
+            //if nullable is not empty, return current IProjectContext as is.
+            if (context != null && string.IsNullOrEmpty(context.Nullable))
+            {
+                string csprojText = System.IO.File.ReadAllText(context.ProjectFullPath);
+                string nullableVarValue = ProjectContextHelper.GetXmlKeyValue("nullable", csprojText);
+                if (!string.IsNullOrEmpty(nullableVarValue))
+                {
+                    if (context is CommonProjectContext newProjectContext)
+                    {
+                        newProjectContext.Nullable = nullableVarValue;
+                        return newProjectContext;
+                    }
+                }
+            }
+            return context;
         }
 
     }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
         /// <summary>
         /// Returns the value given a key (aka a xml tag) from the given xml file
         /// </summary>
-        /// <param name="variableKey">variable key or tags in the csproj file</tag></param>
+        /// <param name="variableKey">variable key or tags in the csproj file</param>
         /// <param name="xmlText">xml file text (mostly used for parsing csproj file)</param>
         /// <returns>empty or value from the parsing the elements of the xml file.</returns>
         internal static string GetXmlKeyValue(string variableKey, string xmlText)

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
         /// <summary>
         /// Returns the value given a key (aka a xml tag) from the given xml file
         /// </summary>
-        /// <param name="variableKey">variable key or <tags> in the csproj file</tag></param>
+        /// <param name="variableKey">variable key or tags in the csproj file</tag></param>
         /// <param name="xmlText">xml file text (mostly used for parsing csproj file)</param>
         /// <returns>empty or value from the parsing the elements of the xml file.</returns>
         internal static string GetXmlKeyValue(string variableKey, string xmlText)

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Xml.Linq;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
 using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
 
@@ -171,6 +172,33 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             }
 
             return packageDependencies;
+        }
+
+        /// <summary>
+        /// Returns the value given a key (aka a xml tag) from the given xml file
+        /// </summary>
+        /// <param name="variableKey">variable key or <tags> in the csproj file</tag></param>
+        /// <param name="xmlText">xml file text (mostly used for parsing csproj file)</param>
+        /// <returns>empty or value from the parsing the elements of the xml file.</returns>
+        internal static string GetXmlKeyValue(string variableKey, string xmlText)
+        {
+            string variableValue = string.Empty;
+            if (!string.IsNullOrEmpty(xmlText) && !string.IsNullOrEmpty(variableKey))
+            {
+                //use XDocument to get all csproj elements.
+                XDocument document = XDocument.Parse(xmlText);
+                var docNodes = document.Root?.Elements();
+                var allElements = docNodes?.SelectMany(x => x.Elements());
+                if (allElements != null && allElements.Any())
+                {
+                    var varValueElement = allElements.FirstOrDefault(e => e.Name.LocalName.Equals(variableKey, StringComparison.OrdinalIgnoreCase));
+                    if (varValueElement != null)
+                    {
+                        variableValue = varValueElement.Value;
+                    }
+                }
+            }
+            return variableValue;
         }
     }
 }

--- a/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
+++ b/test/Scaffolding/VS.Web.CG.MSBuild.Test/ProjectContextWriterTests.cs
@@ -16,7 +16,18 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
     {
         static string testAppPath = Path.Combine("..", "TestApps", "ModelTypesLocatorTestClassLibrary");
         private ITestOutputHelper _outputHelper;
+        private const string Net7CsprojVariabledCsproj = @"<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <Var1>$(Var2)$(Var3)</Var1>
+    <Var2>net</Var2>
+    <Var3>7.0</Var3>
+    <TargetFramework>$(Var1)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
+</Project>
+";
         public ProjectContextWriterTests(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
@@ -138,6 +149,26 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.MSBuild
                 Tuple<string, string> nameAndVersion = new Tuple<string, string>(packageName, version);
                 Assert.Equal(expectedPath, ProjectContextHelper.GetPath(nugetPath, nameAndVersion));
             }
+        }
+
+        [Fact]
+        public void GetXmlKeyValueTests()
+        {
+            var tfmValue = ProjectContextHelper.GetXmlKeyValue("TargetFramework", Net7CsprojVariabledCsproj);
+            var var2Value = ProjectContextHelper.GetXmlKeyValue("Var2", Net7CsprojVariabledCsproj);
+            var nullableValue = ProjectContextHelper.GetXmlKeyValue("Nullable", Net7CsprojVariabledCsproj);
+            var implicitValue = ProjectContextHelper.GetXmlKeyValue("ImplicitUsings", Net7CsprojVariabledCsproj);
+            var invalidValue = ProjectContextHelper.GetXmlKeyValue("bleh", Net7CsprojVariabledCsproj);
+            var emptyValue = ProjectContextHelper.GetXmlKeyValue("", Net7CsprojVariabledCsproj);
+            var nullValue = ProjectContextHelper.GetXmlKeyValue(null, Net7CsprojVariabledCsproj);
+
+            Assert.Equal("$(Var1)", tfmValue, ignoreCase: true);
+            Assert.Equal("net", var2Value, ignoreCase: true);
+            Assert.Equal("enable", nullableValue, ignoreCase: true);
+            Assert.Equal("enable", implicitValue, ignoreCase: true);
+            Assert.Equal("", invalidValue, ignoreCase: true);
+            Assert.Equal("", emptyValue, ignoreCase: true);
+            Assert.Equal("", nullValue, ignoreCase: true);
         }
     }
 }

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/ProjectModifierHelperTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/ProjectModifierHelperTests.cs
@@ -498,26 +498,26 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
         }
 
         [Fact]
-        public void ProcessCsprojFile()
+        public void ProcessCsprojTfmsTest()
         {
-            var net7Tfms = ProjectModifierHelper.ProcessCsprojFile(Net7Csproj);
-            var net7Tfms2 = ProjectModifierHelper.ProcessCsprojFile(Net7CsprojVariabledCsproj);
-            var net7Tfms3 = ProjectModifierHelper.ProcessCsprojFile(Net7CsprojVariabledCsproj2);
+            var net7Tfms = ProjectModifierHelper.ProcessCsprojTfms(Net7Csproj);
+            var net7Tfms2 = ProjectModifierHelper.ProcessCsprojTfms(Net7CsprojVariabledCsproj);
+            var net7Tfms3 = ProjectModifierHelper.ProcessCsprojTfms(Net7CsprojVariabledCsproj2);
             Assert.True(net7Tfms.Length == 1 && net7Tfms2.Length == 1 && net7Tfms3.Length == 1);
             Assert.True(net7Tfms.First().Equals("net7.0") && net7Tfms2.First().Equals("net7.0") && net7Tfms3.First().Equals("net7.0"));
 
-            var emptyTfms = ProjectModifierHelper.ProcessCsprojFile(EmptyCsproj);
-            var emptyTfms2 = ProjectModifierHelper.ProcessCsprojFile(EmptyCsproj2);
+            var emptyTfms = ProjectModifierHelper.ProcessCsprojTfms(EmptyCsproj);
+            var emptyTfms2 = ProjectModifierHelper.ProcessCsprojTfms(EmptyCsproj2);
             Assert.True(emptyTfms.Length == 0 && emptyTfms2.Length == 0);
 
-            var invalidTfm = ProjectModifierHelper.ProcessCsprojFile(InvalidCsproj);
-            var invalidTfm2 = ProjectModifierHelper.ProcessCsprojFile(InvalidCsproj2);
-            var invalidTfm3 = ProjectModifierHelper.ProcessCsprojFile(InvalidCsproj3);
+            var invalidTfm = ProjectModifierHelper.ProcessCsprojTfms(InvalidCsproj);
+            var invalidTfm2 = ProjectModifierHelper.ProcessCsprojTfms(InvalidCsproj2);
+            var invalidTfm3 = ProjectModifierHelper.ProcessCsprojTfms(InvalidCsproj3);
             Assert.True(invalidTfm.Length == 0 && invalidTfm2.Length == 0 && invalidTfm3.Length == 0);
 
-            var multiTfm = ProjectModifierHelper.ProcessCsprojFile(MultiTfmCsproj);
-            var multiTfm2 = ProjectModifierHelper.ProcessCsprojFile(MultiTfmVariabledCsproj);
-            var multiTfm3 = ProjectModifierHelper.ProcessCsprojFile(MultiTfmVariabledCsproj2);
+            var multiTfm = ProjectModifierHelper.ProcessCsprojTfms(MultiTfmCsproj);
+            var multiTfm2 = ProjectModifierHelper.ProcessCsprojTfms(MultiTfmVariabledCsproj);
+            var multiTfm3 = ProjectModifierHelper.ProcessCsprojTfms(MultiTfmVariabledCsproj2);
             Assert.True(multiTfm.Length == 2 && net7Tfms2.Length == 1 && multiTfm3.Length == 3);
             Assert.True(multiTfm.Contains("net6.0") && multiTfm.Contains("net7.0"));
             Assert.True(multiTfm2.Contains("net6.0") && multiTfm2.Contains("net7.0"));


### PR DESCRIPTION
Context : IProjectContext is populated using a custom target msbuild restore operation. For the CLI scenario, we have no issues but for the VS scenario, it is not able to populate a newer IProjectContext yet with the `Nullable` property. Therefore, we need to set it in `src/Scaffolding/VS.Web.CG.Design/Program.cs`

- GetXmlKeyValue : parses any xml file and will return string value for any string key provided.
- CheckNullableVariable : checks for a missing nullable variable, and parses the csproj (xml) file to set one.