### PR TITLE
add `AspNetCore.Http.HttpResults` namespace when TypedResults is enabled.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiModel.cs
@@ -115,8 +115,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
 
                 if (OpenAPI)
                 {
-                    requiredNamespaces.Add("Microsoft.AspNetCore.Http.HttpResults");
                     requiredNamespaces.Add("Microsoft.AspNetCore.OpenApi");
+                }
+
+                if (UseTypedResults)
+                {
+                    requiredNamespaces.Add("Microsoft.AspNetCore.Http.HttpResults");
                 }
 
                 // Finally we remove the ControllerNamespace as it's not required.


### PR DESCRIPTION
- add `Microsoft.AspNetCore.Http.HttpResults` namespace when MinimalApiModel.UseTypedResults is true, not when OpenAPI is true.