### PR TITLE
Fix output for app registrations

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/MicrosoftIdentityPlatform/MicrosoftIdentityPlatformApplicationManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.MSIdentity.MicrosoftIdentityPlatformApplication
 {
     public class MicrosoftIdentityPlatformApplicationManager
     {
-        private StringBuilder _output = new StringBuilder();
+        private readonly StringBuilder _output = new StringBuilder();
         const string MicrosoftGraphAppId = "00000003-0000-0000-c000-000000000000";
         const string ScopeType = "Scope";
         private const string DefaultCallbackPath = "signin-oidc";

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             var graphObjectsList = await GetGraphObjects();
             if (graphObjectsList is null)
             {
-                return new JsonResponse(CommandName, State.Fail, Resources.FailedToRetrieveADObjectsError).ToJsonString();
+                return new JsonResponse(CommandName, State.Fail, output: Resources.FailedToRetrieveADObjectsError).ToJsonString();
             }
 
             IList<Application> applicationList = new List<Application>();
@@ -141,22 +141,21 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 
                 //order list by created date.
                 applicationList = applicationList.OrderByDescending(app => app.CreatedDateTime).ToList();
+            }
 
-                if (ProvisioningToolOptions.Json)
+            if (ProvisioningToolOptions.Json)
+            {
+                outputJsonString = new JsonResponse(CommandName, State.Success, applicationList).ToJsonString();
+            }
+            else
+            {
+                Console.Write(
+                    "--------------------------------------------------------------\n" +
+                    "Application Name\t\t\t\tApplication ID\n" +
+                    "--------------------------------------------------------------\n\n");
+                foreach (var app in applicationList)
                 {
-                    JsonResponse jsonResponse = new JsonResponse(CommandName, State.Success, applicationList);
-                    outputJsonString = jsonResponse.ToJsonString();
-                }
-                else
-                {
-                    Console.Write(
-                        "--------------------------------------------------------------\n" +
-                        "Application Name\t\t\t\tApplication ID\n" +
-                        "--------------------------------------------------------------\n\n");
-                    foreach (var app in applicationList)
-                    {
-                        Console.WriteLine($"{app.DisplayName.PadRight(35)}\t\t{app.AppId}");
-                    }
+                    Console.WriteLine($"{app.DisplayName.PadRight(35)}\t\t{app.AppId}");
                 }
             }
 


### PR DESCRIPTION
A few small fixes:
- if GetGraphObjects method fails, puts the output in the JsonResponse Output field rather than the Content field
- if there are no app registrations, but everything succeeded, returns a JsonResponse with empty list rather than failing