### PR TITLE
Refactor console logger and catch app provisioning exceptions

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 {
                     var errorMsg = string.Format(Resources.ProjectPathError, _toolOptions.ProjectFilePath);
                     _consoleLogger.LogFailure(errorMsg);
-                    return;
+                    Environment.Exit(1);
                 }
                 
                 _toolOptions.ProjectFilePath = csProjFiles.First();

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 if (csProjFiles.Count() != 1)
                 {
                     var errorMsg = string.Format(Resources.ProjectPathError, _toolOptions.ProjectFilePath);
-                    _consoleLogger.LogFailure(errorMsg, Commands.UPDATE_PROJECT_COMMAND);
+                    _consoleLogger.LogFailure(errorMsg);
                     return;
                 }
                 
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 await HandleCodeFileAsync(file, project, options, codeModifierConfig.Identifier);
             }
 
-            _consoleLogger.LogJsonMessage(new JsonResponse(Commands.UPDATE_PROJECT_COMMAND, State.Success, output: _output.ToString().TrimEnd()));
+            _consoleLogger.LogJsonMessage(State.Success, output: _output.ToString().TrimEnd());
         }
 
         internal static string GetCodeFileString(CodeFile file, string identifier) // todo make all code files strings

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -50,8 +50,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                 if (csProjFiles.Count() != 1)
                 {
                     var errorMsg = string.Format(Resources.ProjectPathError, _toolOptions.ProjectFilePath);
-                    _consoleLogger.LogFailure(errorMsg);
-                    Environment.Exit(1);
+                    _consoleLogger.LogFailureAndExit(errorMsg);
                 }
                 
                 _toolOptions.ProjectFilePath = csProjFiles.First();

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/DeveloperCredentials/MsalTokenCredential.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/DeveloperCredentials/MsalTokenCredential.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Microsoft.DotNet.MSIdentity.Properties;
 using Microsoft.DotNet.MSIdentity.Shared;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
@@ -105,11 +106,10 @@ namespace Microsoft.DotNet.MSIdentity.DeveloperCredentials
             {
                 if (account == null && !string.IsNullOrEmpty(Username))
                 {
-                    _consoleLogger.LogFailure(
+                    _consoleLogger.LogFailureAndExit(
                         $"No valid tokens found in the cache.\n" +
                         $"Please sign-in to Visual Studio with this account: {Username}.\n\n" +
                         $"After signing-in, re-run the tool.");
-                    Environment.Exit(1);
                 }
                 result = await app.AcquireTokenInteractive(requestContext.Scopes)
                     .WithAccount(account)
@@ -119,33 +119,30 @@ namespace Microsoft.DotNet.MSIdentity.DeveloperCredentials
             }
             catch (MsalServiceException ex)
             {
+                // AAD error codes: https://learn.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes
                 if (ex.Message.Contains("AADSTS70002")) // "The client does not exist or is not enabled for consumers"
                 {
                     // We want to exit here because this is probably an MSA without an AAD tenant.
-                    _consoleLogger.LogFailure(
+                    _consoleLogger.LogFailureAndExit(
                         "An Azure AD tenant, and a user in that tenant, " +
                         "needs to be created for this account before an application can be created. " +
                         "See https://aka.ms/ms-identity-app/create-a-tenant. ");
-                    Environment.Exit(1);
                 }
 
                 // we want to exit here. Re-sign in will not resolve the issue.
-                _consoleLogger.LogFailure($"Error encountered with sign-in. See error message for details:\n{ex.Message}");
-                Environment.Exit(1);
+                _consoleLogger.LogFailureAndExit(string.Join(Environment.NewLine, Resources.SignInError, ex.Message));
             }
             catch (Exception ex)
             {
-                _consoleLogger.LogFailure($"Error encountered with sign-in. See error message for details:\n{ex.Message}");
-                Environment.Exit(1);
+                _consoleLogger.LogFailureAndExit(string.Join(Environment.NewLine, Resources.SignInError, ex.Message));
             }
 
             if (result is null)
             {
-                _consoleLogger.LogFailure($"Failed to acquire a token");
-                Environment.Exit(1);
+                _consoleLogger.LogFailureAndExit(Resources.FailedToAcquireToken);
             }
 
-            return new AccessToken(result.AccessToken, result.ExpiresOn);
+            return new AccessToken(result!.AccessToken, result.ExpiresOn);
         }
     }
 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -548,6 +548,15 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to acquire a token..
+        /// </summary>
+        internal static string FailedToAcquireToken {
+            get {
+                return ResourceManager.GetString("FailedToAcquireToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to create Azure AD/AD B2C app registration..
         /// </summary>
         internal static string FailedToCreateApp {
@@ -589,6 +598,15 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         internal static string FailedToRetrieveADObjectsError {
             get {
                 return ResourceManager.GetString("FailedToRetrieveADObjectsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to retrieve application parameters..
+        /// </summary>
+        internal static string FailedToRetrieveApplicationParameters {
+            get {
+                return ResourceManager.GetString("FailedToRetrieveApplicationParameters", resourceCulture);
             }
         }
         
@@ -719,6 +737,15 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         internal static string ResourceFileParseError {
             get {
                 return ResourceManager.GetString("ResourceFileParseError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error encountered with sign-in. See error message for details:.
+        /// </summary>
+        internal static string SignInError {
+            get {
+                return ResourceManager.GetString("SignInError", resourceCulture);
             }
         }
         

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -575,7 +575,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to provision Client Application.
+        ///   Looks up a localized string similar to Failed to provision Client Application for Blazor WASM hosted project.
         /// </summary>
         internal static string FailedToProvisionClientApp {
             get {
@@ -611,7 +611,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update client app program.cs file.
+        ///   Looks up a localized string similar to Failed to update client app program.cs file for Blazor WASM hosted project.
         /// </summary>
         internal static string FailedToUpdateClientAppCode {
             get {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -240,6 +240,9 @@
   <data name="FailedClientSecretWithApp" xml:space="preserve">
     <value>Failed to add client secret for Azure AD app : {0}({1})</value>
   </data>
+  <data name="FailedToAcquireToken" xml:space="preserve">
+    <value>Failed to acquire a token.</value>
+  </data>
   <data name="FailedToCreateApp" xml:space="preserve">
     <value>Failed to create Azure AD/AD B2C app registration.</value>
   </data>
@@ -255,6 +258,9 @@
   </data>
   <data name="FailedToRetrieveADObjectsError" xml:space="preserve">
     <value>Failed to retrieve all Azure AD/AD B2C objects(apps/service principals</value>
+  </data>
+  <data name="FailedToRetrieveApplicationParameters" xml:space="preserve">
+    <value>Failed to retrieve application parameters.</value>
   </data>
   <data name="FailedToUpdateApp" xml:space="preserve">
     <value>Failed to update Azure AD app registration {0} ({1})</value>
@@ -306,6 +312,9 @@
   <data name="ResourceFileParseError" xml:space="preserve">
     <value>Resource file {0} could not be parsed.</value>
     <comment>0 = CodeModifierConfigPropertyInfo.Name</comment>
+  </data>
+  <data name="SignInError" xml:space="preserve">
+    <value>Error encountered with sign-in. See error message for details:</value>
   </data>
   <data name="Success" xml:space="preserve">
     <value>SUCCESS</value>

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -251,7 +251,7 @@
     <comment>0 = File name, 1 = Exception message</comment>
   </data>
   <data name="FailedToProvisionClientApp" xml:space="preserve">
-    <value>Failed to provision Client Application</value>
+    <value>Failed to provision Client Application for Blazor WASM hosted project</value>
   </data>
   <data name="FailedToRetrieveADObjectsError" xml:space="preserve">
     <value>Failed to retrieve all Azure AD/AD B2C objects(apps/service principals</value>
@@ -265,7 +265,7 @@
     <comment>0 = null object</comment>
   </data>
   <data name="FailedToUpdateClientAppCode" xml:space="preserve">
-    <value>Failed to update client app program.cs file</value>
+    <value>Failed to update client app program.cs file for Blazor WASM hosted project</value>
   </data>
   <data name="InitializeUserSecrets" xml:space="preserve">
     <value>Initializing User Secrets . . .</value>

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -18,6 +18,7 @@ using Microsoft.DotNet.MSIdentity.Properties;
 using Microsoft.DotNet.MSIdentity.Shared;
 using Microsoft.DotNet.MSIdentity.Tool;
 using Microsoft.Graph;
+using ConsoleLogger = Microsoft.DotNet.MSIdentity.Shared.ConsoleLogger;
 using Directory = System.IO.Directory;
 using ProjectDescription = Microsoft.DotNet.MSIdentity.Project.ProjectDescription;
 
@@ -251,12 +252,10 @@ namespace Microsoft.DotNet.MSIdentity
             ApplicationParameters? resultAppParameters = await MicrosoftIdentityPlatformApplicationManager.CreateNewAppAsync(tokenCredential, applicationParameters, ConsoleLogger);
             if (resultAppParameters is null || string.IsNullOrEmpty(resultAppParameters.ClientId))
             {
-                string failMessage = Resources.FailedToCreateApp;
-                ConsoleLogger.LogMessage(failMessage, LogMessageType.Error);
-                return null;
+                ConsoleLogger.LogFailure(Resources.FailedToCreateApp);
+                Environment.Exit(1);
             }
 
-            ConsoleLogger.LogMessage(string.Format(Resources.CreatedAppRegistration, resultAppParameters.ApplicationDisplayName, resultAppParameters.ClientId));
             return resultAppParameters;
         }
 

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/AppProvisioningTool.cs
@@ -343,7 +343,7 @@ namespace Microsoft.DotNet.MSIdentity
             if (clientApplicationParameters == null)
             {
                 ConsoleLogger.LogFailure(Resources.FailedToProvisionClientApp);
-                return null;
+                Environment.Exit(1);
             }
 
             // Update program.cs file
@@ -353,7 +353,7 @@ namespace Microsoft.DotNet.MSIdentity
             if (clientApplicationParameters == null)
             {
                 ConsoleLogger.LogFailure(Resources.FailedToUpdateClientAppCode);
-                return null;
+                Environment.Exit(1);
             }
 
             return clientApplicationParameters;
@@ -477,6 +477,7 @@ namespace Microsoft.DotNet.MSIdentity
             if (string.IsNullOrEmpty(applicationParameters.GraphEntityId))
             {
                 ConsoleLogger.LogFailure(Resources.FailedClientSecret);
+                Environment.Exit(1);
             }
             else
             {
@@ -503,11 +504,13 @@ namespace Microsoft.DotNet.MSIdentity
                     {
                         output = string.Format(Resources.FailedClientSecretWithApp, applicationParameters.ApplicationDisplayName, applicationParameters.ClientId);
                         ConsoleLogger.LogFailure(output);
+                        Environment.Exit(1);
                     }
                 }
                 catch (ServiceException se)
                 {
                     ConsoleLogger.LogFailure(se.Error?.Code);
+                    Environment.Exit(1);
                 }
             }
         }
@@ -530,6 +533,7 @@ namespace Microsoft.DotNet.MSIdentity
             {
                 string outputMessage = $"Unable to unregister the Azure AD w/ client id = {applicationParameters.ClientId}\n";
                 ConsoleLogger.LogFailure(outputMessage);
+                Environment.Exit(1);
             }
         }
 

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/GraphObjectRetriever.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/GraphObjectRetriever.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -66,7 +67,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                         {
                             nextPage = null;
                             _consoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
-                            return null;
+                            Environment.Exit(1);
                         }
                     }
                 }
@@ -74,7 +75,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             catch (ServiceException)
             {
                 _consoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
-                return null;
+                Environment.Exit(1);
             }
 
             return graphObjectsList;
@@ -88,6 +89,8 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 tenant = (await _graphServiceClient.Organization
                     .Request()
                     .GetAsync()).FirstOrDefault();
+
+                return tenant;
             }
             catch (ServiceException ex)
             {
@@ -111,8 +114,6 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 _consoleLogger.LogFailure(errorMessage);
                 return null;
             }
-
-            return tenant;
         }
     }
 }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/GraphObjectRetriever.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/GraphObjectRetriever.cs
@@ -66,16 +66,14 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                         catch (ServiceException)
                         {
                             nextPage = null;
-                            _consoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
-                            Environment.Exit(1);
+                            _consoleLogger.LogFailureAndExit(Resources.FailedToRetrieveADObjectsError);
                         }
                     }
                 }
             }
             catch (ServiceException)
             {
-                _consoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
-                Environment.Exit(1);
+                _consoleLogger.LogFailureAndExit(Resources.FailedToRetrieveADObjectsError);
             }
 
             return graphObjectsList;
@@ -111,7 +109,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                     }
                 }
 
-                _consoleLogger.LogFailure(errorMessage);
+                _consoleLogger.LogFailureAndExit(errorMessage);
                 return null;
             }
         }

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -108,8 +108,12 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 
             if (applicationList.Any())
             {
-                Organization? tenant = await GraphObjectRetriever.GetTenant();
-                if (tenant != null && tenant.TenantType.Equals("AAD B2C", StringComparison.OrdinalIgnoreCase))
+                var tenant = await GraphObjectRetriever.GetTenant();
+                if (tenant is null)
+                {
+                    Environment.Exit(1);
+                }
+                if (tenant.TenantType.Equals("AAD B2C", StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var app in applicationList)
                     {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
         {
             ProvisioningToolOptions = provisioningToolOptions;
             CommandName = commandName;
-            ConsoleLogger = new ConsoleLogger(ProvisioningToolOptions.Json);
+            ConsoleLogger = new ConsoleLogger(CommandName, ProvisioningToolOptions.Json);
             TokenCredential = new MsalTokenCredential(ProvisioningToolOptions.TenantId, ProvisioningToolOptions.Username, ConsoleLogger);
             GraphServiceClient = new GraphServiceClient(new TokenCredentialAuthenticationProvider(TokenCredential));
             AzureManagementAPI = new AzureManagementAuthenticationProvider(TokenCredential);
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             var graphObjectsList = await GraphObjectRetriever.GetGraphObjects();
             if (graphObjectsList is null)
             {
-                ConsoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError, CommandName);
+                ConsoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
                 Environment.Exit(1);
             }
 

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Tool/MsAADTool.cs
@@ -93,12 +93,11 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             var graphObjectsList = await GraphObjectRetriever.GetGraphObjects();
             if (graphObjectsList is null)
             {
-                ConsoleLogger.LogFailure(Resources.FailedToRetrieveADObjectsError);
-                Environment.Exit(1);
+                ConsoleLogger.LogFailureAndExit(Resources.FailedToRetrieveADObjectsError);
             }
 
             IList<Application> applicationList = new List<Application>();
-            foreach (var graphObj in graphObjectsList)
+            foreach (var graphObj in graphObjectsList!)
             {
                 if (graphObj is Application app)
                 {
@@ -109,11 +108,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             if (applicationList.Any())
             {
                 var tenant = await GraphObjectRetriever.GetTenant();
-                if (tenant is null)
-                {
-                    Environment.Exit(1);
-                }
-                if (tenant.TenantType.Equals("AAD B2C", StringComparison.OrdinalIgnoreCase))
+                if (tenant != null && tenant.TenantType.Equals("AAD B2C", StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var app in applicationList)
                     {

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
@@ -8,8 +8,11 @@ namespace Microsoft.DotNet.MSIdentity.Shared
         private readonly bool _jsonOutput;
         private readonly bool _silent;
 
-        public ConsoleLogger(bool jsonOutput = false, bool silent = false)
+        private string CommandName { get; }
+
+        public ConsoleLogger(string commandName = null, bool jsonOutput = false, bool silent = false)
         {
+            CommandName = commandName;
             _jsonOutput = jsonOutput;
             _silent = silent;
             Console.OutputEncoding = Encoding.UTF8;
@@ -46,23 +49,24 @@ namespace Microsoft.DotNet.MSIdentity.Shared
             }
         }
 
-        public void LogJsonMessage(JsonResponse jsonMessage)
+        public void LogJsonMessage(string state = null, object content = null, string output = null)
         {
             if (!_silent)
             {
                 if (_jsonOutput)
                 {
+                    var jsonMessage = new JsonResponse(CommandName, state, content, output);
                     Console.WriteLine(jsonMessage.ToJsonString());
                 }
                 else
                 {
-                    if (jsonMessage.State == State.Fail)
+                    if (state == State.Fail)
                     {
-                        LogMessage(jsonMessage.Output, LogMessageType.Error);
+                        LogMessage(output, LogMessageType.Error);
                     }
                     else
                     {
-                        LogMessage(jsonMessage.Output);
+                        LogMessage(output);
                     }
                 }
             }
@@ -76,13 +80,13 @@ namespace Microsoft.DotNet.MSIdentity.Shared
             }
         }
 
-        public void LogFailure(string failureMessage, string commandName = null)
+        public void LogFailure(string failureMessage)
         {
             if (!_silent)
             {
                 if (_jsonOutput)
                 {
-                    LogJsonMessage(new JsonResponse(commandName, State.Fail, output: failureMessage));
+                    LogJsonMessage(State.Fail, output: failureMessage);
                 }
                 else
                 {

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
@@ -82,16 +82,13 @@ namespace Microsoft.DotNet.MSIdentity.Shared
 
         public void LogFailure(string failureMessage)
         {
-            if (!_silent)
+            if (_jsonOutput)
             {
-                if (_jsonOutput)
-                {
-                    LogJsonMessage(State.Fail, output: failureMessage);
-                }
-                else
-                {
-                    LogMessage(failureMessage, LogMessageType.Error);
-                }
+                LogJsonMessage(State.Fail, output: failureMessage);
+            }
+            else
+            {
+                LogMessage(failureMessage, LogMessageType.Error);
             }
         }
     }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ConsoleLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.MSIdentity.Shared
 
         public ConsoleLogger(string commandName = null, bool jsonOutput = false, bool silent = false)
         {
-            CommandName = commandName;
+            CommandName = commandName ?? string.Empty;
             _jsonOutput = jsonOutput;
             _silent = silent;
             Console.OutputEncoding = Encoding.UTF8;
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.MSIdentity.Shared
             }
         }
 
-        public void LogFailure(string failureMessage)
+        public void LogFailureAndExit(string failureMessage)
         {
             if (_jsonOutput)
             {
@@ -90,6 +90,8 @@ namespace Microsoft.DotNet.MSIdentity.Shared
             {
                 LogMessage(failureMessage, LogMessageType.Error);
             }
+
+            Environment.Exit(1);
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/IConsoleLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/IConsoleLogger.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.MSIdentity.Shared
         void LogMessage(string message, LogMessageType level, bool removeNewLine = false);
         void LogMessage(string message, bool removeNewLine = false);
         void LogJsonMessage(string state = null, object content = null, string output = null);
-        void LogFailure(string failureMessage);
+        void LogFailureAndExit(string failureMessage);
     }
 
     public enum LogMessageType

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/IConsoleLogger.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/IConsoleLogger.cs
@@ -4,8 +4,8 @@ namespace Microsoft.DotNet.MSIdentity.Shared
     {
         void LogMessage(string message, LogMessageType level, bool removeNewLine = false);
         void LogMessage(string message, bool removeNewLine = false);
-        void LogJsonMessage(JsonResponse jsonMessage);
-        void LogFailure(string failureMessage, string commandName = null);
+        void LogJsonMessage(string state = null, object content = null, string output = null);
+        void LogFailure(string failureMessage);
     }
 
     public enum LogMessageType

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/JsonResponse.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/JsonResponse.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 
 namespace Microsoft.DotNet.MSIdentity.Shared
@@ -12,9 +11,9 @@ namespace Microsoft.DotNet.MSIdentity.Shared
 
         public JsonResponse(string command, string state = null, object content = null, string output = null)
         {
+            Command = command;
             State = state;
             Content = content;
-            Command = command ?? throw new ArgumentNullException(nameof(command));
             Output = output;
         }
 


### PR DESCRIPTION
Some refactors to ConsoleLogger.cs, including passing in the CommandName. 

Catch exceptions that may be thrown while creating a new app registration (for example, permissions ServiceException), then log failure.

Also ensuring that Environment.Exit is called after logging failure, so that the JSON response will be parsed correctly in VS. There were sometimes multiple JSON responses and that caused a parsing error. 