### PR TITLE
bump system commandline version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,7 @@
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,7 +130,7 @@
     <MicrosoftGraphVersion>4.5.0</MicrosoftGraphVersion>
     <MicrosoftIdentityClientExtensionsMsalVersion>2.19.1</MicrosoftIdentityClientExtensionsMsalVersion>
     <NuGetProjectModelVersion>6.3.1</NuGetProjectModelVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.21308.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.22613.1</SystemCommandLineVersion>
     <NewtonsoftJsonMsIdentityPackageVersion>13.0.1</NewtonsoftJsonMsIdentityPackageVersion>
   </PropertyGroup>
 </Project>

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=7.0.0-dev
+set VERSION=8.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/tools/dotnet-msidentity/Program.cs
+++ b/tools/dotnet-msidentity/Program.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.MSIdentity.Tool
     {
         public static async Task<int> Main(string[] args)
         {
-            System.Diagnostics.Debugger.Launch();
             var rootCommand = MsIdentityCommand();
             //new BinderBase for System.Commandline update, new way to bind handlers to commands.
             var provisioningToolBinder = new ProvisioningToolOptionsBinder(
@@ -37,6 +36,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 SusiPolicyIdOption,
                 TenantOption,
                 UsernameOption);
+
             //internal commands
             var listAadAppsCommand = ListAADAppsCommand();
             var listServicePrincipalsCommand = ListServicePrincipalsCommand();
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
             };
 
         internal static Command UnregisterApplicationCommand() =>
-            new Command(
+            new(
                 name: Commands.UNREGISTER_APPLICATION_COMMAND,
 
                 description: "Unregister an Azure AD or Azure AD B2C app registration in Azure." +
@@ -273,48 +273,48 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 TenantOption, UsernameOption, JsonOption, HostedAppIdUriOption, ProjectFilePathOption, ClientIdOption
             };
 
-        private static Option<bool> JsonOption =>
-            new Option<bool>(
+        internal static Option<bool> JsonOption { get; } =
+            new(
                 aliases: new[] { "-j", "--json" },
                 description: "Format output in JSON instead of text.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> EnableIdTokenOption =>
-            new Option<bool>(
+        internal static Option<bool> EnableIdTokenOption { get; } =
+            new(
                 aliases: new[] { "--enable-id-token" },
                 description: "Enable id token.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> EnableAccessToken =>
-            new Option<bool>(
+        internal static Option<bool> EnableAccessToken { get; } =
+            new(
                 aliases: new[] { "--enable-access-token" },
                 description: "Enable access token.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> CallsGraphOption =>
-            new Option<bool>(
+        internal static Option<bool> CallsGraphOption { get; } =
+            new(
                 aliases: new[] { "--calls-graph" },
                 description: "App registration calls microsoft graph.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> CallsDownstreamApiOption =>
-            new Option<bool>(
+        internal static Option<bool> CallsDownstreamApiOption { get; } =
+            new(
                 aliases: new[] { "--calls-downstream-api" },
                 description: "App registration calls downstream api.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> UpdateUserSecretsOption =>
-            new Option<bool>(
+        internal static Option<bool> UpdateUserSecretsOption { get; } =
+            new(
                 aliases: new[] { "--update-user-secrets" },
                 description: "Add secrets to user secrets.json file." +
                              "\n\t- Using dotnet-user-secrets to init and set user secrets.\n")
@@ -322,32 +322,32 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 IsRequired = false
             };
 
-        private static Option<bool> ConfigUpdateOption =>
-            new Option<bool>(
+        internal static Option<bool> ConfigUpdateOption { get; } =
+            new(
                 aliases: new[] { "--config-update" },
                 description: "Allow config changes for dotnet app to work with Azure AD/AD B2C app.")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> CodeUpdateOption =>
-            new Option<bool>(
+        internal static Option<bool> CodeUpdateOption { get; } =
+            new(
                 aliases: new[] { "--code-update" },
                 description: "Allow Startup.cs and other code changes for dotnet app to work with Azure AD/AD B2C app (setup authentication).")
             {
                 IsRequired = false
             };
 
-        private static Option<bool> PackagesUpdateOption =>
-            new Option<bool>(
+        internal static Option<bool> PackagesUpdateOption { get; } =
+            new(
                 aliases: new[] { "--packages-update" },
                 description: "Allow package updates for dotnet app to work with Azure AD/AD B2C app (setup authentication).")
             {
                 IsRequired = false
             };
 
-        private static Option<string> ClientIdOption =>
-            new Option<string>(
+        internal static Option<string> ClientIdOption { get; } =
+            new(
                 aliases: new[] { "--client-id" },
                 description: "Client ID of an existing app registration to use." +
                              "\n\tConfigure project to use an existing Azure app registration instead of creating a new one. The app registration will be updated if needed." +
@@ -356,16 +356,16 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 IsRequired = false
             };
 
-        private static Option<string> AppDisplayName =>
-            new Option<string>(
+        internal static Option<string> AppDisplayName { get; } =
+            new(
                 aliases: new[] { "--app-display-name" },
                 description: "App display name for Azure AD/AD B2C app registration creation.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> ProjectType =>
-            new Option<string>(
+        internal static Option<string> ProjectType { get; } =
+            new(
                 aliases: new[] { "--project-type" },
                 description: "Project type for which to register the azure ad app registration." +
                              "\n\tFor eg., 'webapp', 'webapi', 'blazorwasm-hosted', 'blazorwasm'\n")
@@ -373,56 +373,57 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 IsRequired = false
             };
 
-        private static Option<string> ClientSecretOption =>
-            new Option<string>(
+        internal static Option<string> ClientSecretOption { get; } =
+            new(
                 aliases: new[] { "--client-secret" },
                 description: "Value for the client secret, which also can be referred to as application password.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<IList<string>> RedirectUriOption =>
-            new Option<IList<string>>(
+        internal static Option<IList<string>> RedirectUriOption { get; } =
+            new(
                 aliases: new[] { "--redirect-uris" },
                 description: "Add redirect URIs (web) for the app.\n\t- You can pass in multiple values for this parameter separated by a space.\n")
             {
-                IsRequired = false
+                IsRequired = false,
+                AllowMultipleArgumentsPerToken = true
             };
 
-        private static Option<string> ProjectFilePathOption =>
-            new Option<string>(
+        internal static Option<string> ProjectFilePathOption { get; } =
+            new(
                 aliases: new[] { "-p", "--project-file-path" },
                 description: "Path to the project file (.csproj file) to be used. If not provided, the project file in the current working directory will be used.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> ClientProjectOption =>
-            new Option<string>(
+        internal static Option<string> ClientProjectOption { get; } =
+            new(
                 aliases: new[] { "--client-project" },
                 description: "Path to the project file (.csproj file) for a hosted Blazor WASM client. If provided, implies that project is Blazor WASM Hosted\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> ApiScopesOption =>
-            new Option<string>(
+        internal static Option<string> ApiScopesOption { get; } =
+            new(
                 aliases: new[] { "--api-scopes" },
                 description: "Scopes for the called downstream API, especially useful for B2C scenarios where permissions must be granted manually\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> HostedAppIdUriOption =>
-            new Option<string>(
+        internal static Option<string> HostedAppIdUriOption { get; } =
+            new(
                 aliases: new[] { "--hosted-app-id-uri" },
                 description: "The App ID Uri for the Blazor WebAssembly hosted API. This parameter will only be used for Blazor WebAssembly hosted applications.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> ApiClientIdOption =>
-            new Option<string>(
+        internal static Option<string> ApiClientIdOption { get; } =
+            new(
                 aliases: new[] { "--api-client-id" },
                 description: "Client ID of the Blazor WebAssembly hosted web API." +
                              "\nThis parameter is only used for Blazor WebAssembly hosted applications, where you only want to configure the project.\n")
@@ -430,24 +431,24 @@ namespace Microsoft.DotNet.MSIdentity.Tool
                 IsRequired = false
             };
 
-        private static Option<string> SusiPolicyIdOption =>
-            new Option<string>(
+        internal static Option<string> SusiPolicyIdOption { get; } =
+            new(
                 aliases: new[] { "--susi-policy-id" },
                 description: "Sign-up/Sign-in policy required for configurating a B2C application from code that was created for Azure AD.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> TenantOption =>
-            new Option<string>(
+        internal static Option<string> TenantOption { get; } =
+            new(
                 aliases: new[] { "-t", "--tenant-id" },
                 description: "Azure AD or Azure AD B2C tenant in which to create or update the app registration.\n - If specified, the app registration will be created in given tenant.\n - If not provided, the app registration will be created in yuor home tenant.\n")
             {
                 IsRequired = false
             };
 
-        private static Option<string> UsernameOption =>
-            new Option<string>(
+        internal static Option<string> UsernameOption { get; } =
+            new(
                 aliases: new[] { "-u", "--username" },
                 description: "Username to use to connect to the Azure AD or Azure AD B2C tenant." +
                             "\n- It's only needed if you are signed-in to Visual Studio, or Azure CLI with several identities." +

--- a/tools/dotnet-msidentity/ProvisioningToolOptionsBinder.cs
+++ b/tools/dotnet-msidentity/ProvisioningToolOptionsBinder.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.MSIdentity.Tool
+{
+    internal class ProvisioningToolOptionsBinder : BinderBase<ProvisioningToolOptions>
+    {
+        private readonly Option<bool> _jsonOption;
+        private readonly Option<bool> _enableIdTokenOption;
+        private readonly Option<bool> _enableAccessToken;
+        private readonly Option<bool> _callsGraphOption;
+        private readonly Option<bool> _callsDownstreamApiOption;
+        private readonly Option<bool> _updateUserSecretsOption;
+        private readonly Option<bool> _configUpdateOption;
+        private readonly Option<bool> _codeUpdateOption;
+        private readonly Option<bool> _packagesUpdateOption;
+        private readonly Option<string> _clientIdOption;
+        private readonly Option<string> _appDisplayName;
+        private readonly Option<string> _projectTypeOption;
+        private readonly Option<string> _clientSecretOption;
+        private readonly Option<IList<string>> _redirectUriOption;
+        private readonly Option<string> _projectFilePathOption;
+        private readonly Option<string> _clientProjectOption;
+        private readonly Option<string> _apiScopesOption;
+        private readonly Option<string> _hostedAppIdUriOption;
+        private readonly Option<string> _apiClientIdOption;
+        private readonly Option<string> _susiPolicyIdOption;
+        private readonly Option<string> _tenantOption;
+        private readonly Option<string> _usernameOption;
+
+        public ProvisioningToolOptionsBinder(
+            Option<bool> jsonOption,
+            Option<bool> enableIdTokenOption,
+            Option<bool> enableAccessToken,
+            Option<bool> callsGraphOption,
+            Option<bool> callsDownstreamApiOption,
+            Option<bool> updateUserSecretsOption,
+            Option<bool> configUpdateOption,
+            Option<bool> codeUpdateOption,
+            Option<bool> packagesUpdateOption,
+            Option<string> clientIdOption,
+            Option<string> appDisplayName,
+            Option<string> projectTypeOption,
+            Option<string> clientSecretOption,
+            Option<IList<string>> redirectUriOption,
+            Option<string> projectFilePathOption,
+            Option<string> clientProjectOption,
+            Option<string> apiScopesOption,
+            Option<string> hostedAppIdUriOption,
+            Option<string> apiClientIdOption,
+            Option<string> susiPolicyIdOption,
+            Option<string> tenantOption,
+            Option<string> usernameOption)
+        {
+            _jsonOption = jsonOption;
+            _enableIdTokenOption = enableIdTokenOption;
+            _enableAccessToken = enableAccessToken;
+            _callsGraphOption = callsGraphOption;
+            _callsDownstreamApiOption = callsDownstreamApiOption;
+            _updateUserSecretsOption = updateUserSecretsOption;
+            _configUpdateOption = configUpdateOption;
+            _codeUpdateOption = codeUpdateOption;
+            _packagesUpdateOption = packagesUpdateOption;
+            _clientIdOption = clientIdOption;
+            _appDisplayName = appDisplayName;
+            _projectTypeOption = projectTypeOption;
+            _clientSecretOption = clientSecretOption;
+            _redirectUriOption = redirectUriOption;
+            _projectFilePathOption = projectFilePathOption;
+            _clientProjectOption = clientProjectOption;
+            _apiScopesOption = apiScopesOption;
+            _hostedAppIdUriOption = hostedAppIdUriOption;
+            _apiClientIdOption = apiClientIdOption;
+            _susiPolicyIdOption = susiPolicyIdOption;
+            _tenantOption = tenantOption;
+            _usernameOption = usernameOption;
+        }
+
+        protected override ProvisioningToolOptions GetBoundValue(BindingContext bindingContext)
+        {
+            var redirectUriList = bindingContext.ParseResult.GetValue(_redirectUriOption) ?? new List<string>();
+            return new ProvisioningToolOptions
+            {
+
+                HostedApiScopes = bindingContext.ParseResult.GetValue(_hostedAppIdUriOption),
+                CallsDownstreamApi = bindingContext.ParseResult.GetValue(_callsDownstreamApiOption),
+                UpdateUserSecrets = bindingContext.ParseResult.GetValue(_updateUserSecretsOption),
+                CallsGraph = bindingContext.ParseResult.GetValue(_callsGraphOption),
+                ClientId = bindingContext.ParseResult.GetValue(_clientIdOption),
+                ClientSecret = bindingContext.ParseResult.GetValue(_clientSecretOption),
+                ProjectType = bindingContext.ParseResult.GetValue(_projectTypeOption),
+                SusiPolicyId = bindingContext.ParseResult.GetValue(_susiPolicyIdOption),
+                TenantId = bindingContext.ParseResult.GetValue(_tenantOption),
+                Username = bindingContext.ParseResult.GetValue(_usernameOption),
+                ProjectFilePath = bindingContext.ParseResult.GetValue(_projectFilePathOption),
+                WebApiClientId = bindingContext.ParseResult.GetValue(_apiClientIdOption),
+                HostedAppIdUri = bindingContext.ParseResult.GetValue(_hostedAppIdUriOption),
+                Json = bindingContext.ParseResult.GetValue(_jsonOption),
+                AppDisplayName = bindingContext.ParseResult.GetValue(_appDisplayName),
+                RedirectUris = redirectUriList,
+                EnableIdToken = bindingContext.ParseResult.GetValue(_enableIdTokenOption),
+                EnableAccessToken = bindingContext.ParseResult.GetValue(_enableAccessToken),
+                ConfigUpdate = bindingContext.ParseResult.GetValue(_configUpdateOption),
+                CodeUpdate = bindingContext.ParseResult.GetValue(_codeUpdateOption),
+                PackagesUpdate = bindingContext.ParseResult.GetValue(_packagesUpdateOption),
+                ApiScopes = bindingContext.ParseResult.GetValue(_apiScopesOption),
+                ClientProject = bindingContext.ParseResult.GetValue(_clientProjectOption)
+            };
+        }
+    }
+}

--- a/tools/dotnet-msidentity/ProvisioningToolOptionsBinder.cs
+++ b/tools/dotnet-msidentity/ProvisioningToolOptionsBinder.cs
@@ -1,13 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Binding;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.MSIdentity.Tool
 {
+    /// <summary>
+    /// ProvisioningToolOptionsBinder to setup handlers for dotnet-msidentity commnds.
+    /// Used in Microsoft.DotNet.MSIdentity.Tool.Program in SetHandler calls.
+    /// </summary>
     internal class ProvisioningToolOptionsBinder : BinderBase<ProvisioningToolOptions>
     {
         private readonly Option<bool> _jsonOption;
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.MSIdentity.Tool
 
         protected override ProvisioningToolOptions GetBoundValue(BindingContext bindingContext)
         {
-            var redirectUriList = bindingContext.ParseResult.GetValue(_redirectUriOption) ?? new List<string>();
+            IList<string> redirectUriList = bindingContext.ParseResult.GetValue(_redirectUriOption) ?? new List<string>();
             return new ProvisioningToolOptions
             {
 

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -1,8 +1,8 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.MSIdentity.Tool;
+using MsIdentity = Microsoft.DotNet.MSIdentity.Tool.Program;
 
 namespace Microsoft.DotNet.Tools.Scaffold
 {
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Tools.Scaffold
         private const string IDENTITY_COMMAND = "--identity";
         private const string RAZORPAGE_COMMAND = "--razorpage";
         private const string VIEW_COMMAND = "--view";
-        /* 
-        dotnet scaffold [generator] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
+        /*
+        dotnet scaffold [generator] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build]
 
         This commands supports the following generators :
             Area
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
 
         e.g: dotnet scaffold area <AreaNameToGenerate>
              dotnet scaffold identity
-             dotnet scaffold razorpage 
+             dotnet scaffold razorpage
 
         */
 
@@ -40,18 +40,43 @@ namespace Microsoft.DotNet.Tools.Scaffold
             rootCommand.AddCommand(ScaffoldViewCommand());
             rootCommand.AddCommand(ScaffoldIdentityCommand());
             //msidentity commands
+            //new BinderBase for System.Commandline update, new way to bind handlers to commands.
+            var provisioningToolBinder = new ProvisioningToolOptionsBinder(
+                MsIdentity.JsonOption,
+                MsIdentity.EnableIdTokenOption,
+                MsIdentity.EnableAccessToken,
+                MsIdentity.CallsGraphOption,
+                MsIdentity.CallsDownstreamApiOption,
+                MsIdentity.UpdateUserSecretsOption,
+                MsIdentity.ConfigUpdateOption,
+                MsIdentity.CodeUpdateOption,
+                MsIdentity.PackagesUpdateOption,
+                MsIdentity.ClientIdOption,
+                MsIdentity.AppDisplayName,
+                MsIdentity.ProjectType,
+                MsIdentity.ClientSecretOption,
+                MsIdentity.RedirectUriOption,
+                MsIdentity.ProjectFilePathOption,
+                MsIdentity.ClientProjectOption,
+                MsIdentity.ApiScopesOption,
+                MsIdentity.HostedAppIdUriOption,
+                MsIdentity.ApiClientIdOption,
+                MsIdentity.SusiPolicyIdOption,
+                MsIdentity.TenantOption,
+                MsIdentity.UsernameOption);
+
             //internal commands
-            var listAadAppsCommand = MSIdentity.Tool.Program.ListAADAppsCommand();
-            var listServicePrincipalsCommand = MSIdentity.Tool.Program.ListServicePrincipalsCommand();
-            var listTenantsCommand = MSIdentity.Tool.Program.ListTenantsCommand();
-            var createClientSecretCommand = MSIdentity.Tool.Program.CreateClientSecretCommand();
+            var listAadAppsCommand = MsIdentity.ListAADAppsCommand();
+            var listServicePrincipalsCommand = MsIdentity.ListServicePrincipalsCommand();
+            var listTenantsCommand = MsIdentity.ListTenantsCommand();
+            var createClientSecretCommand = MsIdentity.CreateClientSecretCommand();
 
             //exposed commands
-            var registerApplicationCommand = MSIdentity.Tool.Program.RegisterApplicationCommand();
-            var unregisterApplicationCommand = MSIdentity.Tool.Program.UnregisterApplicationCommand();
-            var updateAppRegistrationCommand = MSIdentity.Tool.Program.UpdateAppRegistrationCommand();
-            var updateProjectCommand = MSIdentity.Tool.Program.UpdateProjectCommand();
-            var createAppRegistration = MSIdentity.Tool.Program.CreateAppRegistrationCommand();
+            var registerApplicationCommand = MsIdentity.RegisterApplicationCommand();
+            var unregisterApplicationCommand = MsIdentity.UnregisterApplicationCommand();
+            var updateAppRegistrationCommand = MsIdentity.UpdateAppRegistrationCommand();
+            var updateProjectCommand = MsIdentity.UpdateProjectCommand();
+            var createAppRegistration = MsIdentity.CreateAppRegistrationCommand();
 
             //hide internal commands.
             listAadAppsCommand.IsHidden = true;
@@ -60,15 +85,16 @@ namespace Microsoft.DotNet.Tools.Scaffold
             updateProjectCommand.IsHidden = true;
             createClientSecretCommand.IsHidden = true;
 
-           /* listAadAppsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListApps);
-            listServicePrincipalsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListServicePrincipals);
-            listTenantsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListTenants);
-            registerApplicationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleRegisterApplication);
-            unregisterApplicationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUnregisterApplication);
-            createAppRegistration.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleCreateAppRegistration);
-            updateAppRegistrationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateApplication);
-            updateProjectCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateProject);
-            createClientSecretCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleClientSecrets);*/
+            listAadAppsCommand.SetHandler(MsIdentity.HandleListApps, provisioningToolBinder);
+            listServicePrincipalsCommand.SetHandler(MsIdentity.HandleListServicePrincipals, provisioningToolBinder);
+            listTenantsCommand.SetHandler(MsIdentity.HandleListTenants, provisioningToolBinder);
+            registerApplicationCommand.SetHandler(MsIdentity.HandleRegisterApplication, provisioningToolBinder);
+            unregisterApplicationCommand.SetHandler(MsIdentity.HandleUnregisterApplication, provisioningToolBinder);
+            updateAppRegistrationCommand.SetHandler(MsIdentity.HandleUpdateApplication, provisioningToolBinder);
+            updateProjectCommand.SetHandler(MsIdentity.HandleUpdateProject, provisioningToolBinder);
+            createClientSecretCommand.SetHandler(MsIdentity.HandleClientSecrets, provisioningToolBinder);
+            createAppRegistration.SetHandler(MsIdentity.HandleCreateAppRegistration, provisioningToolBinder);
+
             rootCommand.AddCommand(listAadAppsCommand);
             rootCommand.AddCommand(listServicePrincipalsCommand);
             rootCommand.AddCommand(listTenantsCommand);
@@ -451,7 +477,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
                 description: "Scaffolds Identity")
             {
                 // Options
-                DBContextOption(), FilesListOption(), ListFilesOption(), UserClassOption(), UseSQLliteOption(), OverwriteFilesOption(), UseDefaultUIOption(), CustomLayoutOption(), 
+                DBContextOption(), FilesListOption(), ListFilesOption(), UserClassOption(), UseSQLliteOption(), OverwriteFilesOption(), UseDefaultUIOption(), CustomLayoutOption(),
                 GenerateLayoutOption(), BootStrapVersionOption()
             };
     }

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.MSIdentity.Tool;
@@ -61,7 +60,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
             updateProjectCommand.IsHidden = true;
             createClientSecretCommand.IsHidden = true;
 
-            listAadAppsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListApps);
+           /* listAadAppsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListApps);
             listServicePrincipalsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListServicePrincipals);
             listTenantsCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleListTenants);
             registerApplicationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleRegisterApplication);
@@ -69,7 +68,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
             createAppRegistration.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleCreateAppRegistration);
             updateAppRegistrationCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateApplication);
             updateProjectCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleUpdateProject);
-            createClientSecretCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleClientSecrets);
+            createClientSecretCommand.Handler = CommandHandler.Create<ProvisioningToolOptions>(MSIdentity.Tool.Program.HandleClientSecrets);*/
             rootCommand.AddCommand(listAadAppsCommand);
             rootCommand.AddCommand(listServicePrincipalsCommand);
             rootCommand.AddCommand(listTenantsCommand);
@@ -137,7 +136,7 @@ namespace Microsoft.DotNet.Tools.Scaffold
         private static Option ConfigurationOption() =>
             new Option<string>(
                 aliases: new[] { "-c", "--configuration" },
-                getDefaultValue: () => "Debug",
+                defaultValueFactory: () => "Debug",
                 description: "Defines the build configuration. The default value is Debug.")
             {
                 IsRequired = false


### PR DESCRIPTION
bumping System.CommandLine version to 2.0.0-beta4.22613.1.
- added `dotnet-libraries` nuget feed for the latest System.CommandLine package
- added `ProvisioningToolOptionsBinder` for using `SetHandler` instead of `CommandHandler.Create`
- changed all the Options for dotnet-msidentity from new objects to readonly properties.