### PR TITLE
Fix authentication bug (regenerate msal.cache)

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/DeveloperCredentials/MsalTokenCredential.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/DeveloperCredentials/MsalTokenCredential.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.MSIdentity.DeveloperCredentials
 
             AuthenticationResult? result = account is null
                 ? await GetAuthenticationWithoutAccount(requestContext.Scopes, app, cancellationToken)
-                : await GetAuthenticationWithAccount(requestContext, app, account, cancellationToken);
+                : await GetAuthenticationWithAccount(requestContext.Scopes, app, account, cancellationToken);
 
             if (result is null || result.AccessToken is null)
             {
@@ -102,12 +102,12 @@ namespace Microsoft.DotNet.MSIdentity.DeveloperCredentials
             return new AccessToken(result!.AccessToken!, result.ExpiresOn); 
         }
 
-        private async Task<AuthenticationResult?> GetAuthenticationWithAccount(TokenRequestContext requestContext, IPublicClientApplication app, IAccount? account, CancellationToken cancellationToken)
+        private async Task<AuthenticationResult?> GetAuthenticationWithAccount(string[] scopes, IPublicClientApplication app, IAccount? account, CancellationToken cancellationToken)
         {
             AuthenticationResult? result = null;
             try
             {
-                result = await app.AcquireTokenSilent(requestContext.Scopes, account)
+                result = await app.AcquireTokenSilent(scopes, account)
                     .WithAuthority(Instance, TenantId)
                     .ExecuteAsync(cancellationToken);
             }
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.MSIdentity.DeveloperCredentials
             {
                 try
                 {
-                    result = await app.AcquireTokenInteractive(requestContext.Scopes)
+                    result = await app.AcquireTokenInteractive(scopes)
                         .WithAccount(account)
                         .WithClaims(ex.Claims)
                         .WithAuthority(Instance, TenantId)

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -299,6 +299,15 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An Azure AD tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant..
+        /// </summary>
+        internal static string ClientDoesNotExist {
+            get {
+                return ResourceManager.GetString("ClientDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Client secret - {0}..
         /// </summary>
         internal static string ClientSecret {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -159,6 +159,9 @@
   <data name="AuthNotEnabled" xml:space="preserve">
     <value>Authentication is not enabled yet in this project. An app registration will be created, but the tool does not add the code yet (work in progress).</value>
   </data>
+  <data name="ClientDoesNotExist" xml:space="preserve">
+    <value>An Azure AD tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant.</value>
+  </data>
   <data name="ClientSecret" xml:space="preserve">
     <value>Client secret - {0}.</value>
   </data>


### PR DESCRIPTION
The tool has been relying on Visual Studio to populate or create the msal.cache file for storing account information, but since VS has transitioned to using WAM it no longer populates the msal.cache file. To work around this, we can make a call to AcquireTokenInteractive when an account is not found, and this will pop up a browser window allowing for picking an account. 