### PR TITLE
change `useSqlite` to `useSqLite` for VS scenarios

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
-using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
@@ -18,12 +17,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         public string DataContextClass { get; set; }
 
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName ="sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
-        public DbProvider DatabaseProvider { get; set; } 
+        public DbProvider DatabaseProvider { get; set; }
 
         [Option(Name = "referenceScriptLibraries", ShortName = "scripts", Description = "Switch to specify whether to reference script libraries in the generated views")]
         public bool ReferenceScriptLibraries { get; set; }
@@ -76,7 +75,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             if (model.UseSqlite)
             {
 #pragma warning restore CS0618 // Type or member is obsolete
-                //instead of throwing an error, letting the devs know that its obsolete. 
+                //instead of throwing an error, letting the devs know that its obsolete.
                 logger.LogMessage(MessageStrings.SqliteObsoleteOption, LogMessageLevel.Information);
                 //Setting DatabaseProvider to SQLite if --databaseProvider|-dbProvider is not provided.
                 if (string.IsNullOrEmpty(model.DatabaseProviderString))

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -6,11 +6,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 {
     public class IdentityGeneratorCommandLineModel
     {
-        [Option(Name = "rootNamespace", ShortName = "rn", Description = "Root namesapce to use for generating identity code." )]
+        [Option(Name = "rootNamespace", ShortName = "rn", Description = "Root namesapce to use for generating identity code.")]
         public string RootNamespace { get; set; }
 
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "files", ShortName = "fi", Description = "List of semicolon separated files to scaffold. Use the --listFiles option to see the available options.")]
         public string Files { get; set; }
 
-        [Option(Name = "listFiles", ShortName ="lf", Description = "Lists the files that can be scaffolded by using the '--files' option.")]
+        [Option(Name = "listFiles", ShortName = "lf", Description = "Lists the files that can be scaffolded by using the '--files' option.")]
         public bool ListFiles { get; set; }
 
         [Option(Name = "force", ShortName = "f", Description = "Use this option to overwrite existing files.")]
@@ -38,13 +38,13 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "layout", ShortName = "l", Description = "Specify a custom layout file to use.")]
         public string Layout { get; set; }
 
-        [Option(Name="generateLayout", ShortName="gl", Description="Use this option to generate a new _Layout.cshtml")]
+        [Option(Name = "generateLayout", ShortName = "gl", Description = "Use this option to generate a new _Layout.cshtml")]
         public bool GenerateLayout { get; set; }
 
-        [Option(Name ="bootstrapVersion", ShortName = "b", Description = "Specify the bootstrap version. Valid values: '3', '4', '5'. Default is 5.")]
+        [Option(Name = "bootstrapVersion", ShortName = "b", Description = "Specify the bootstrap version. Valid values: '3', '4', '5'. Default is 5.")]
         public string BootstrapVersion { get; set; }
 
-        [Option(Name ="excludeFiles", ShortName="exf", Description = "Use this option to overwrite all but list of semicolon separated files.  Use the --listFiles option to see the available options.")]
+        [Option(Name = "excludeFiles", ShortName = "exf", Description = "Use this option to overwrite all but list of semicolon separated files.  Use the --listFiles option to see the available options.")]
         public string ExcludeFiles { get; set; }
 
         public bool IsGenerateCustomUser

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -25,11 +25,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         public string EndpointsNamespace { get; set; }
 
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
-        public string DatabaseProviderString { get; set; } 
+        public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }
 
         [Option(Name = "noTypedResults", ShortName = "ntr", Description = "Flag to not use TypedResults for minimal apis.")]
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             if (model.UseSqlite)
             {
 #pragma warning restore CS0618 // Type or member is obsolete
-                //instead of throwing an error, letting the devs know that its obsolete. 
+                //instead of throwing an error, letting the devs know that its obsolete.
                 logger.LogMessage(MessageStrings.SqliteObsoleteOption, LogMessageLevel.Information);
                 //Setting DatabaseProvider to SQLite if --databaseProvider|-dbProvider is not provided.
                 if (string.IsNullOrEmpty(model.DatabaseProviderString))

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/controller.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/controller.json
@@ -4,76 +4,81 @@
     "Arguments": [
 
     ],
-    "Options": [
-        {
-            "Name": "controllerName",
-            "ShortName": "name",
-            "Description": "Name of the controller"
-        },
-        {
-            "Name": "useAsyncActions",
-            "ShortName": "async",
-            "Description": "Switch to indicate whether to generate async controller actions"
-        },
-        {
-            "Name": "noViews",
-            "ShortName": "nv",
-            "Description": "Switch to indicate whether to generate CRUD views"
-        },
-        {
-            "Name": "restWithNoViews",
-            "ShortName": "api",
-            "Description": "Specify this switch to generate a Controller with REST style API, noViews is assumed and any view related options are ignored"
-        },
-        {
-            "Name": "readWriteActions",
-            "ShortName": "actions",
-            "Description": "Specify this switch to generate Controller with read/write actions when a Model class is not used"
-        },
-        {
-            "Name": "model",
-            "ShortName": "m",
-            "Description": "Model class to use"
-        },
-        {
-            "Name": "dataContext",
-            "ShortName": "dc",
-            "Description": "DbContext class to use"
-        },
-        {
-            "Name": "referenceScriptLibraries",
-            "ShortName": "scripts",
-            "Description": "Switch to specify whether to reference script libraries in the generated views"
-        },
-        {
-            "Name": "layout",
-            "ShortName": "l",
-            "Description": "Custom Layout page to use"
-        },
-        {
-            "Name": "useDefaultLayout",
-            "ShortName": "udl",
-            "Description": "Switch to specify that default layout should be used for the views"
-        },
-        {
-            "Name": "force",
-            "ShortName": "f",
-            "Description": "Use this option to overwrite existing files"
-        },
-        {
-            "Name": "relativeFolderPath",
-            "ShortName": "outDir",
-            "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
-        },
-        {
-            "Name": "controllerNamespace",
-            "ShortName": "namespace",
-            "Description": "Specify the name of the namespace to use for the generated controller"
-        },
-      {
-        "Name": "databaseProvider",
-        "ShortName": "dbProvider",
-        "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-      }
-    ]
+  "Options": [
+    {
+      "Name": "controllerName",
+      "ShortName": "name",
+      "Description": "Name of the controller"
+    },
+    {
+      "Name": "useAsyncActions",
+      "ShortName": "async",
+      "Description": "Switch to indicate whether to generate async controller actions"
+    },
+    {
+      "Name": "noViews",
+      "ShortName": "nv",
+      "Description": "Switch to indicate whether to generate CRUD views"
+    },
+    {
+      "Name": "restWithNoViews",
+      "ShortName": "api",
+      "Description": "Specify this switch to generate a Controller with REST style API, noViews is assumed and any view related options are ignored"
+    },
+    {
+      "Name": "readWriteActions",
+      "ShortName": "actions",
+      "Description": "Specify this switch to generate Controller with read/write actions when a Model class is not used"
+    },
+    {
+      "Name": "model",
+      "ShortName": "m",
+      "Description": "Model class to use"
+    },
+    {
+      "Name": "dataContext",
+      "ShortName": "dc",
+      "Description": "DbContext class to use"
+    },
+    {
+      "Name": "referenceScriptLibraries",
+      "ShortName": "scripts",
+      "Description": "Switch to specify whether to reference script libraries in the generated views"
+    },
+    {
+      "Name": "layout",
+      "ShortName": "l",
+      "Description": "Custom Layout page to use"
+    },
+    {
+      "Name": "useDefaultLayout",
+      "ShortName": "udl",
+      "Description": "Switch to specify that default layout should be used for the views"
+    },
+    {
+      "Name": "force",
+      "ShortName": "f",
+      "Description": "Use this option to overwrite existing files"
+    },
+    {
+      "Name": "relativeFolderPath",
+      "ShortName": "outDir",
+      "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
+    },
+    {
+      "Name": "controllerNamespace",
+      "ShortName": "namespace",
+      "Description": "Specify the name of the namespace to use for the generated controller"
+    },
+    {
+      "Name": "databaseProvider",
+      "ShortName": "dbProvider",
+      "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
+    },
+    {
+      "Name": "useSqLite",
+      "ShortName": "sqlite",
+      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
+    }
+  ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/identity.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/identity.json
@@ -52,6 +52,11 @@
       "Name": "bootstrapVersion",
       "ShortName": "b",
       "Description": "Specify the bootstrap version. Valid values: '3', '4'. Default is 4."
+    },
+    {
+      "Name": "useSqLite",
+      "ShortName": "sqlite",
+      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
@@ -27,8 +27,13 @@
       "Description": "Specify the name of the namespace to use for the generated Endpoints file"
     },
     {
-      "Name" : "databaseProvider",
+      "Name": "databaseProvider",
       "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
+    },
+    {
+      "Name": "useSqLite",
+      "ShortName": "sqlite",
+      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ],
   "Options": []

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/razorpage.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/razorpage.json
@@ -11,61 +11,66 @@
             "Description": "The template to use, supported view templates: 'Empty|Create|Edit|Delete|Details|List'"
         }
     ],
-    "Options": [
-        {
-            "Name": "model",
-            "ShortName": "m",
-            "Description": "Model class to use"
-        },
-        {
-            "Name": "dataContext",
-            "ShortName": "dc",
-            "Description": "DbContext class to use"
-        },
-        {
-            "Name": "referenceScriptLibraries",
-            "ShortName": "scripts",
-            "Description": "Switch to specify whether to reference script libraries in the generated views"
-        },
-        {
-            "Name": "layout",
-            "ShortName": "l",
-            "Description": "Custom Layout page to use"
-        },
-        {
-            "Name": "useDefaultLayout",
-            "ShortName": "udl",
-            "Description": "Switch to specify that default layout should be used for the views"
-        },
-        {
-            "Name": "force",
-            "ShortName": "f",
-            "Description": "Use this option to overwrite existing files"
-        },
-        {
-            "Name": "relativeFolderPath",
-            "ShortName": "outDir",
-            "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
-        },
-        {
-            "Name": "namespaceName",
-            "ShortName": "namespace",
-            "Description": "Specify the name of the namespace to use for the generated PageModel"
-        },
-        {
-            "Name": "partialView",
-            "ShortName": "partial",
-            "Description": "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified"
-        },
-        {
-            "Name": "noPageModel",
-            "ShortName": "npm",
-            "Description": "Switch to not generate a PageModel class for Empty template"
-        },
-      {
-        "Name": "databaseProvider",
-        "ShortName": "dbProvider",
-        "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-      }
-    ]
+  "Options": [
+    {
+      "Name": "model",
+      "ShortName": "m",
+      "Description": "Model class to use"
+    },
+    {
+      "Name": "dataContext",
+      "ShortName": "dc",
+      "Description": "DbContext class to use"
+    },
+    {
+      "Name": "referenceScriptLibraries",
+      "ShortName": "scripts",
+      "Description": "Switch to specify whether to reference script libraries in the generated views"
+    },
+    {
+      "Name": "layout",
+      "ShortName": "l",
+      "Description": "Custom Layout page to use"
+    },
+    {
+      "Name": "useDefaultLayout",
+      "ShortName": "udl",
+      "Description": "Switch to specify that default layout should be used for the views"
+    },
+    {
+      "Name": "force",
+      "ShortName": "f",
+      "Description": "Use this option to overwrite existing files"
+    },
+    {
+      "Name": "relativeFolderPath",
+      "ShortName": "outDir",
+      "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
+    },
+    {
+      "Name": "namespaceName",
+      "ShortName": "namespace",
+      "Description": "Specify the name of the namespace to use for the generated PageModel"
+    },
+    {
+      "Name": "partialView",
+      "ShortName": "partial",
+      "Description": "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified"
+    },
+    {
+      "Name": "noPageModel",
+      "ShortName": "npm",
+      "Description": "Switch to not generate a PageModel class for Empty template"
+    },
+    {
+      "Name": "databaseProvider",
+      "ShortName": "dbProvider",
+      "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
+    },
+    {
+      "Name": "useSqLite",
+      "ShortName": "sqlite",
+      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
+    }
+  ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/view.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/view.json
@@ -11,56 +11,61 @@
             "Description": "The view template to use, supported view templates: 'Empty|Create|Edit|Delete|Details|List'"
         }
     ],
-    "Options": [
-        {
-            "Name": "model",
-            "ShortName": "m",
-            "Description": "Model class to use"
-        },
-        {
-            "Name": "dataContext",
-            "ShortName": "dc",
-            "Description": "DbContext class to use"
-        },
-        {
-            "Name": "referenceScriptLibraries",
-            "ShortName": "scripts",
-            "Description": "Switch to specify whether to reference script libraries in the generated views"
-        },
-        {
-            "Name": "layout",
-            "ShortName": "l",
-            "Description": "Custom Layout page to use"
-        },
-        {
-            "Name": "useDefaultLayout",
-            "ShortName": "udl",
-            "Description": "Switch to specify that default layout should be used for the views"
-        },
-        {
-            "Name": "force",
-            "ShortName": "f",
-            "Description": "Use this option to overwrite existing files"
-        },
-        {
-            "Name": "relativeFolderPath",
-            "ShortName": "outDir",
-            "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
-        },
-        {
-            "Name": "controllerNamespace",
-            "ShortName": "namespace",
-            "Description": "Specify the name of the namespace to use for the generated controller"
-        },
-        {
-            "Name": "partialView",
-            "ShortName": "partial",
-            "Description": "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified"
-        },
-      {
-        "Name": "databaseProvider",
-        "ShortName": "dbProvider",
-        "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-      }
-    ]
+  "Options": [
+    {
+      "Name": "model",
+      "ShortName": "m",
+      "Description": "Model class to use"
+    },
+    {
+      "Name": "dataContext",
+      "ShortName": "dc",
+      "Description": "DbContext class to use"
+    },
+    {
+      "Name": "referenceScriptLibraries",
+      "ShortName": "scripts",
+      "Description": "Switch to specify whether to reference script libraries in the generated views"
+    },
+    {
+      "Name": "layout",
+      "ShortName": "l",
+      "Description": "Custom Layout page to use"
+    },
+    {
+      "Name": "useDefaultLayout",
+      "ShortName": "udl",
+      "Description": "Switch to specify that default layout should be used for the views"
+    },
+    {
+      "Name": "force",
+      "ShortName": "f",
+      "Description": "Use this option to overwrite existing files"
+    },
+    {
+      "Name": "relativeFolderPath",
+      "ShortName": "outDir",
+      "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
+    },
+    {
+      "Name": "controllerNamespace",
+      "ShortName": "namespace",
+      "Description": "Specify the name of the namespace to use for the generated controller"
+    },
+    {
+      "Name": "partialView",
+      "ShortName": "partial",
+      "Description": "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified"
+    },
+    {
+      "Name": "databaseProvider",
+      "ShortName": "dbProvider",
+      "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
+    },
+    {
+      "Name": "useSqLite",
+      "ShortName": "sqlite",
+      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
+    }
+  ]
 }


### PR DESCRIPTION
VS uses Sqlite scenarios by adding the option `useSqLite`. 
- Microsoft.Extensions.CommandLineUtils is not case-friendly. Changed this typo in #2139 so reverting it back now.
- adding `useSqLite` back to parameter defintion json files so its available to display in --help.