### PR TITLE
fix --useSqlite for mac scenarios

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 
 [*.cs]
 indent_size = 4
-dotnet_sort_system_directives_first = true:warning
+dotnet_sort_system_directives_first = true
 
 [*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
 indent_size = 2

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-pub-dotnet-aspnetcore-65330ff" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-65330ff0/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-aspnetcore-605e6a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-605e6a3c/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
     <add key="darc-pub-dotnet-efcore-9cbf778" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9cbf7783/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,7 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-10f1d39" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-10f1d396/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-be8c0ef" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-be8c0ef3/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,9 +4,10 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
+    <add key="darc-pub-dotnet-aspnetcore-26e3dfc" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-26e3dfc7/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-9dbdfb6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9dbdfb6a/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-09261bb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-09261bb9/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-pub-dotnet-aspnetcore-b6bd323" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-b6bd3236/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-aspnetcore-65330ff" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-65330ff0/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
     <add key="darc-pub-dotnet-efcore-9cbf778" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9cbf7783/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,7 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-be8c0ef" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-be8c0ef3/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-7ff89d3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-7ff89d37/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
     <add key="darc-pub-dotnet-aspnetcore-b6bd323" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-b6bd3236/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-00e218a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-00e218a9/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-9cbf778" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9cbf7783/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,7 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-7ff89d3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-7ff89d37/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-9dbdfb6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9dbdfb6a/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-pub-dotnet-aspnetcore-605e6a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-605e6a3c/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
     <add key="darc-pub-dotnet-efcore-10f1d39" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-10f1d396/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
     <add key="darc-pub-dotnet-aspnetcore-605e6a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-605e6a3c/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-pub-dotnet-efcore-9cbf778" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-9cbf7783/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-efcore-10f1d39" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-10f1d396/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-efcore -->
     <!--  Package sources from dotnet-runtime -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,17 +7,17 @@
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
+      <Sha>09261bb997c0d82e121cd348d2e43f2b37a65848</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
+    <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.1">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
+      <Sha>09261bb997c0d82e121cd348d2e43f2b37a65848</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
+    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
+      <Sha>09261bb997c0d82e121cd348d2e43f2b37a65848</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,15 +9,15 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
+      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
+      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
+      <Sha>9dbdfb6aa423900a3ff50cd2e014239bdcf04486</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,15 +9,15 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
+      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
+      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
+      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,15 +9,15 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>00e218a90498c21ec14bbaf730a8954c03b42a34</Sha>
+      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>00e218a90498c21ec14bbaf730a8954c03b42a34</Sha>
+      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>00e218a90498c21ec14bbaf730a8954c03b42a34</Sha>
+      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.23060.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22561.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac5977ebf05451c1adcf24a15d16263e4d25fd0c</Sha>
+      <Sha>f36ea231c234560514ede4c2747897a737ced28f</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,7 +29,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Identity.Stores" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b6bd3236cda202c27f0f8b40900ba49aa725519e</Sha>
+      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -53,7 +53,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b6bd3236cda202c27f0f8b40900ba49aa725519e</Sha>
+      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -73,15 +73,15 @@
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b6bd3236cda202c27f0f8b40900ba49aa725519e</Sha>
+      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b6bd3236cda202c27f0f8b40900ba49aa725519e</Sha>
+      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Identity.UI" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b6bd3236cda202c27f0f8b40900ba49aa725519e</Sha>
+      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,15 +9,15 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
+      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
+      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>9cbf7783bb3ed131881e9c0277287d17a6ed259f</Sha>
+      <Sha>10f1d396d4669de55b1e46899e353f4914bf2c85</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,15 +9,15 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
+      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
+      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>be8c0ef30cee3b78a6a9a48836a06c8d49aedff0</Sha>
+      <Sha>7ff89d37c9a1f89e584075406686496b6b93d395</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,7 +29,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Identity.Stores" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
+      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -53,7 +53,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
+      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -73,15 +73,15 @@
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
+      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
+      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Identity.UI" Version="7.0.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>65330ff0e2e88e7c4aa8751c1caceaf4da7a7b13</Sha>
+      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,9 +27,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha />
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Identity.Stores" Version="7.0.3">
+    <Dependency Name="Microsoft.Extensions.Identity.Stores" Version="7.0.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
+      <Sha>26e3dfc7f3f3a91ba445ec0f8b1598d12542fb9f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -51,9 +51,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha />
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.3">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
+      <Sha>26e3dfc7f3f3a91ba445ec0f8b1598d12542fb9f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="7.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -71,17 +71,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha />
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3">
+    <Dependency Name="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
+      <Sha>26e3dfc7f3f3a91ba445ec0f8b1598d12542fb9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.3">
+    <Dependency Name="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
+      <Sha>26e3dfc7f3f3a91ba445ec0f8b1598d12542fb9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Identity.UI" Version="7.0.3">
+    <Dependency Name="Microsoft.AspNetCore.Identity.UI" Version="7.0.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>605e6a3c4233a68e3f9ba168d727800f0b2bf4c8</Sha>
+      <Sha>26e3dfc7f3f3a91ba445ec0f8b1598d12542fb9f</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
     <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.1</MicrosoftAspNetCoreIdentityUIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>7.0.2</VersionPrefix>
+    <VersionPrefix>7.0.3</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     </MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <!-- Microsoft.Extensions.Identity.Stores -->
-    <MicrosoftExtensionsIdentityStoresPackageVersion>7.0.3</MicrosoftExtensionsIdentityStoresPackageVersion>
+    <MicrosoftExtensionsIdentityStoresPackageVersion>7.0.1</MicrosoftExtensionsIdentityStoresPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     </MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
@@ -34,7 +34,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>
     </MicrosoftExtensionsDependencyModelPackageVersion>
     <!-- Microsoft.Extensions.FileProviders.Embedded -->
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>7.0.3</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>7.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>
     </MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>
@@ -44,11 +44,11 @@
     <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     </MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <!-- Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore -->
-    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>7.0.3</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>7.0.1</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
     <!-- Microsoft.AspNetCore.Identity.EntityFrameworkCore -->
-    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>7.0.3</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>7.0.1</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <!-- Microsoft.AspNetCore.Identity.UI -->
-    <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.3</MicrosoftAspNetCoreIdentityUIPackageVersion>
+    <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.1</MicrosoftAspNetCoreIdentityUIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>7.0.2</VersionPrefix>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,11 +12,11 @@
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <!-- Ref packages from darc subscriptions-->
     <!-- Microsoft.EntityFrameworkCore.Design -->
-    <MicrosoftEntityFrameworkCoreDesignPackageVersion>7.0.3</MicrosoftEntityFrameworkCoreDesignPackageVersion>
+    <MicrosoftEntityFrameworkCoreDesignPackageVersion>7.0.1</MicrosoftEntityFrameworkCoreDesignPackageVersion>
     <!-- Microsoft.EntityFrameworkCore -->
-    <MicrosoftEntityFrameworkCorePackageVersion>7.0.3</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>7.0.1</MicrosoftEntityFrameworkCorePackageVersion>
     <!-- Microsoft.EntityFrameworkCore.SqlServer -->
-    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>7.0.3</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>7.0.1</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>
     </MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,17 +12,17 @@
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <!-- Ref packages from darc subscriptions-->
     <!-- Microsoft.EntityFrameworkCore.Design -->
-    <MicrosoftEntityFrameworkCoreDesignPackageVersion>7.0.1</MicrosoftEntityFrameworkCoreDesignPackageVersion>
+    <MicrosoftEntityFrameworkCoreDesignPackageVersion>7.0.2</MicrosoftEntityFrameworkCoreDesignPackageVersion>
     <!-- Microsoft.EntityFrameworkCore -->
-    <MicrosoftEntityFrameworkCorePackageVersion>7.0.1</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>7.0.2</MicrosoftEntityFrameworkCorePackageVersion>
     <!-- Microsoft.EntityFrameworkCore.SqlServer -->
-    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>7.0.1</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>7.0.2</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>
     </MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     </MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <!-- Microsoft.Extensions.Identity.Stores -->
-    <MicrosoftExtensionsIdentityStoresPackageVersion>7.0.1</MicrosoftExtensionsIdentityStoresPackageVersion>
+    <MicrosoftExtensionsIdentityStoresPackageVersion>7.0.2</MicrosoftExtensionsIdentityStoresPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     </MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
@@ -34,7 +34,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>
     </MicrosoftExtensionsDependencyModelPackageVersion>
     <!-- Microsoft.Extensions.FileProviders.Embedded -->
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>7.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>7.0.2</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>
     </MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>
@@ -44,11 +44,11 @@
     <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     </MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <!-- Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore -->
-    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>7.0.1</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>7.0.2</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
     <!-- Microsoft.AspNetCore.Identity.EntityFrameworkCore -->
-    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>7.0.1</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>7.0.2</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <!-- Microsoft.AspNetCore.Identity.UI -->
-    <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.1</MicrosoftAspNetCoreIdentityUIPackageVersion>
+    <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.2</MicrosoftAspNetCoreIdentityUIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>7.0.3</VersionPrefix>

--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -1,12 +1,5 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
 
-# reset platform variables (e.g. cmake 3.25 sets LINUX=1)
-unset(LINUX)
-unset(FREEBSD)
-unset(ILLUMOS)
-unset(ANDROID)
-unset(TIZEN)
-
 set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
   set(CMAKE_SYSTEM_NAME FreeBSD)

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.4.1" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.3.1" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -63,11 +63,6 @@ steps:
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
     fi
 
-    runtimeOsArgs=
-    if [ '${{ parameters.platform.runtimeOS }}' != '' ]; then
-      runtimeOsArgs='/p:RuntimeOS=${{ parameters.platform.runtimeOS }}'
-    fi
-
     publishArgs=
     if [ '${{ parameters.platform.skipPublishValidation }}' != 'true' ]; then
       publishArgs='--publish'
@@ -80,7 +75,6 @@ steps:
       $internalRuntimeDownloadArgs \
       $internalRestoreArgs \
       $targetRidArgs \
-      $runtimeOsArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
       /p:ArcadeBuildFromSource=true
   displayName: Build

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -365,8 +365,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=17.4.1&view=overview
-  $defaultXCopyMSBuildVersion = '17.4.1'
+  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=17.3.1view=overview
+  $defaultXCopyMSBuildVersion = '17.3.1'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -511,7 +511,7 @@ global_json_file="${repo_root}global.json"
 # determine if global.json contains a "runtimes" entry
 global_json_has_runtimes=false
 if command -v jq &> /dev/null; then
-  if jq -e '.tools | has("runtimes")' "$global_json_file" &> /dev/null; then
+  if jq -er '. | select(has("runtimes"))' "$global_json_file" &> /dev/null; then
     global_json_has_runtimes=true
   fi
 elif [[ "$(cat "$global_json_file")" =~ \"runtimes\"[[:space:]\:]*\{ ]]; then

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "7.0.102"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.23060.4"
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22561.2"
   },
   "sdk": {
-    "version": "7.0.102",
+    "version": "7.0.100",
     "allowPrerelease": true
   }
 }

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,11 +1,11 @@
-set VERSION=8.0.0-dev
+set VERSION=7.0.3
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/
 call taskkill /f /im dotnet.exe
 call rd /Q /S artifacts
 call build
-call dotnet tool uninstall -g dotnet-aspnet-codegenerator 
+call dotnet tool uninstall -g dotnet-aspnet-codegenerator
 
 call cd %DEFAULT_NUPKG_PATH%
 call C:
@@ -18,7 +18,7 @@ call rd /Q /S microsoft.visualstudio.web.codegeneration.templating
 call rd /Q /S microsoft.visualstudio.web.codegeneration.utils
 call rd /Q /S microsoft.visualstudio.web.codegenerators.mvc
 call D:
-call cd  %SRC_DIR%/%NUPKG% 
+call cd  %SRC_DIR%/%NUPKG%
 call dotnet tool install -g dotnet-aspnet-codegenerator --add-source %SRC_DIR%\%NUPKG% --version %VERSION%
 call cd %SRC_DIR%
 call taskkill /f /im dotnet.exe

--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -20,6 +20,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
+        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        public bool UseSqlite2 { get; set; }
+
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }
@@ -72,7 +76,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite)
+            if (model.UseSqlite || model.UseSqlite2)
             {
 #pragma warning restore CS0618 // Type or member is obsolete
                 //instead of throwing an error, letting the devs know that its obsolete.

--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
-using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
         //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]

--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
+using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
         [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             {
                 EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, controllerGeneratorModel.DatabaseProvider);
             }
-            
+
             string outputPath = ValidateAndGetOutputPath(controllerGeneratorModel);
             _areaName = GetAreaName(ApplicationInfo.ApplicationBasePath, outputPath);
 
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
 
             if (modelTypeAndContextModel.ContextProcessingResult.ContextProcessingStatus == ContextProcessingStatus.ContextAddedButRequiresConfig)
             {
-                throw new Exception(string.Format("{0} {1}" ,MessageStrings.ScaffoldingSuccessful_unregistered,
+                throw new Exception(string.Format("{0} {1}", MessageStrings.ScaffoldingSuccessful_unregistered,
                     MessageStrings.Scaffolding_additionalSteps));
             }
         }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -1,6 +1,6 @@
-using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
+using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 {
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
         [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -1,6 +1,7 @@
+using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
-using System;
+
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 {
@@ -15,7 +16,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
         //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -13,6 +13,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
+        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        public bool UseSqlite2 { get; set; }
+
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         internal string UserClassNamespace { get; private set; }
 
         private Type _userType;
-        internal Type UserType 
+        internal Type UserType
         {
             get
             {
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             {
                 NamedFiles = _commandlineModel.Files.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
-            else if(!string.IsNullOrEmpty(_commandlineModel.ExcludeFiles))
+            else if (!string.IsNullOrEmpty(_commandlineModel.ExcludeFiles))
             {
                 string contentVersion;
                 if (templateModel is IdentityGeneratorTemplateModel2 templateModel2)
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 {
                     throw new InvalidOperationException(string.Join(Environment.NewLine, errors));
                 }
-                
+
                 //get files to overwrite
                 NamedFiles = allFiles.Except(excludedFiles);
             }
@@ -448,12 +448,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             }
         }
 
-        private void ValidateIndividualFileOptions() 
+        private void ValidateIndividualFileOptions()
         {
             //Both options should not be selected. Users should either scaffold a particular set of files OR exclude a particular set of files.
-            if(IsFilesSpecified && IsExcludeSpecificed)
+            if (IsFilesSpecified && IsExcludeSpecificed)
             {
-                throw new InvalidOperationException(string.Format(MessageStrings.InvalidOptionCombination,"--files", "--excludeFiles"));
+                throw new InvalidOperationException(string.Format(MessageStrings.InvalidOptionCombination, "--files", "--excludeFiles"));
             }
         }
         private void ValidateDefaultUIOption()
@@ -462,12 +462,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
             if (IsFilesSpecified)
             {
-                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--files", "--useDefaultUI"));
+                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination, "--files", "--useDefaultUI"));
             }
 
-            if(IsExcludeSpecificed)
+            if (IsExcludeSpecificed)
             {
-                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--excludeFiles", "--useDefaultUI"));
+                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination, "--excludeFiles", "--useDefaultUI"));
             }
 
             if (IsUsingExistingDbContext)
@@ -533,7 +533,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
         private string GetClassNameFromTypeName(string dbContext)
         {
-            return dbContext.Split(new char[] {'.'}, StringSplitOptions.RemoveEmptyEntries).Last();
+            return dbContext.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Last();
         }
 
         private void ValidateExistingDbContext(Type existingDbContext)
@@ -669,7 +669,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                             Environment.NewLine,
                             string.Join(Environment.NewLine, _reflectedTypesProvider.GetCompilationErrors())));
                 }
-              
+
             }
             //get all types and return the one with the same name. There should be no duplicates so only one should match.
             return _reflectedTypesProvider.GetAllTypesInProject().FirstOrDefault(
@@ -691,7 +691,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite)
+            if (model.UseSqlite || model.UseSqlite2)
             {
 #pragma warning restore CS0618 // Type or member is obsolete
                 //instead of throwing an error, letting the devs know that its obsolete. 
@@ -710,7 +710,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 errorStrings.Add(string.Format(MessageStrings.InvalidDatabaseProvider, model.DatabaseProviderString));
                 errorStrings.Add($"Supported database providers include : {dbList}");
             }
-            
+
             if (!string.IsNullOrEmpty(model.RootNamespace) && !RoslynUtilities.IsValidNamespace(model.RootNamespace))
             {
                 errorStrings.Add(string.Format(MessageStrings.InvalidNamespaceName, model.RootNamespace));
@@ -718,7 +718,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
             if (!string.IsNullOrEmpty(model.Layout) && model.GenerateLayout)
             {
-                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination,"--layout", "--generateLayout"));
+                errorStrings.Add(string.Format(MessageStrings.InvalidOptionCombination, "--layout", "--generateLayout"));
             }
 
             if (!string.IsNullOrEmpty(model.BootstrapVersion) && !IdentityGenerator.ValidBootstrapVersions.Contains(model.BootstrapVersion.Trim(' ', '\n')))

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -1,6 +1,6 @@
+using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
-using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
 {
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
 
         //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }
 
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -28,6 +28,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
+        [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
+        public bool UseSqlite2 { get; set; }
+
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }
@@ -66,7 +70,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite)
+            if (model.UseSqlite || model.UseSqlite2)
             {
 #pragma warning restore CS0618 // Type or member is obsolete
                 //instead of throwing an error, letting the devs know that its obsolete.

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -1,6 +1,6 @@
-using System;
 using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
+using System;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
 {
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite { get; set; }
 
+        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
         [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
         [Option(Name = "useSqlite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
         public bool UseSqlite2 { get; set; }

--- a/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/EFModelBasedRazorPageScaffolder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/RazorPage/EFModelBasedRazorPageScaffolder.cs
@@ -137,13 +137,14 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             }
 
             ModelTypeAndContextModel modelTypeAndContextModel = null;
+            razorPageGeneratorModel.ValidateCommandline(_logger);
             string outputPath = ValidateAndGetOutputPath(razorPageGeneratorModel, string.Empty);
 
             if (CalledFromCommandline)
             {
                 EFValidationUtil.ValidateEFDependencies(_projectContext.PackageDependencies, razorPageGeneratorModel.DatabaseProvider);
             }
-            
+
             modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(
                 razorPageGeneratorModel,
                 _entityFrameworkService,

--- a/src/Scaffolding/VS.Web.CG.Mvc/View/EFModelBasedViewScaffolder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/View/EFModelBasedViewScaffolder.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Shared;
-using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.DotNet.Scaffolding.Shared.Project;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
+using Microsoft.VisualStudio.Web.CodeGeneration;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
-using Microsoft.DotNet.Scaffolding.Shared.Project;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 {
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
         private IModelTypesLocator _modelTypesLocator;
         private IFileSystem _fileSystem;
         private bool CalledFromCommandline => !(_fileSystem is SimulationModeFileSystem);
-        
+
         public EFModelBasedViewScaffolder(
             IProjectContext projectContext,
             IApplicationInfo applicationInfo,
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             ICodeGeneratorActionsService codeGeneratorActionsService,
             IServiceProvider serviceProvider,
             ILogger logger,
-            IFileSystem fileSystem) 
+            IFileSystem fileSystem)
             : base(projectContext, applicationInfo, codeGeneratorActionsService, serviceProvider, logger)
         {
             _modelTypesLocator = modelTypesLocator ?? throw new ArgumentNullException(nameof(modelTypesLocator));
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             {
                 EFValidationUtil.ValidateEFDependencies(_projectContext.PackageDependencies, viewGeneratorModel.DatabaseProvider);
             }
-            
+
 
             modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(
                 viewGeneratorModel,
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 _modelTypesLocator,
                 _logger,
                 string.Empty);
- 
+
             await GenerateView(viewGeneratorModel, modelTypeAndContextModel, outputPath);
 
             if (modelTypeAndContextModel.ContextProcessingResult.ContextProcessingStatus == ContextProcessingStatus.ContextAddedButRequiresConfig)

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/EFValidationUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/EFValidationUtil.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
                 throw new InvalidOperationException(
                     string.Format(MessageStrings.InstallEfPackages, $"{EfConstants.EfDesignPackageName}"));
             }
+
             if (EfConstants.EfPackagesDict.TryGetValue(dataContextType, out var dbProviderPackageName))
             {
                 ValidateDependency(dbProviderPackageName, dependencies);


### PR DESCRIPTION
- reverting all auto updates for upgrading aspnetcore, efcore, and runtimes changes from 7.0.3 to previous GA versions.
- added `UseSqlite2` with option name `useSqlite`
  - for backwards compat. for VS Mac scenarios.
- whitespace fixes based on new .editorconfig file.
- bumping `dotnet-aspnet-codegenerator` version to 7.0.3