### PR TITLE
fix AddDbContext statement for cosmos db.

### DIFF
--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=7.0.3
+set VERSION=8.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/src/Scaffolding/VS.Web.CG.EFCore/ConnectionStringsWriter.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/ConnectionStringsWriter.cs
@@ -60,11 +60,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             {
                 if (EfConstants.ConnectionStringsDict.TryGetValue(databaseProvider, out var connectionString))
                 {
-                    if (!databaseProvider.Equals(DbProvider.CosmosDb))
-                    {
-                        connectionString = string.Format(connectionString, databaseName);
-                    }
-
+                    connectionString = string.Format(connectionString, databaseName);
                     writeContent = true;
                     content[connectionStringNodeName][connectionStringName] = connectionString;
                 }

--- a/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -15,7 +15,6 @@ using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.CodeModifier;
 using Microsoft.DotNet.Scaffolding.Shared.Project;
 using Microsoft.DotNet.Scaffolding.Shared.ProjectModel;
-using Microsoft.VisualBasic;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating;
 using Newtonsoft.Json.Linq;
@@ -46,7 +45,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             IFilesLocator filesLocator,
             ITemplating templatingService,
             IConnectionStringsWriter connectionStringsWriter)
-            : this (projectContext, applicationInfo, filesLocator, templatingService, connectionStringsWriter, DefaultFileSystem.Instance)
+            : this(projectContext, applicationInfo, filesLocator, templatingService, connectionStringsWriter, DefaultFileSystem.Instance)
         {
         }
 
@@ -103,7 +102,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 
         public EditSyntaxTreeResult AddModelToContext(ModelType dbContext, ModelType modelType, bool nullableEnabled)
         {
-            return AddModelToContext(dbContext, modelType, new Dictionary<string, string>() { { nameof(nullableEnabled), nullableEnabled.ToString() }});
+            return AddModelToContext(dbContext, modelType, new Dictionary<string, string>() { { nameof(nullableEnabled), nullableEnabled.ToString() } });
         }
 
         private string GetSafeModelName(string name, ITypeSymbol dbContext)
@@ -206,24 +205,24 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             string leadingTrivia = minimalHostingTemplate ? string.Empty : statementLeadingTrivia;
             switch (databaseProvider)
             {
-                case DbProvider.SQLite: 
+                case DbProvider.SQLite:
                     textToAddAtEnd =
                         leadingTrivia + "{0}.AddDbContext<{1}>(options =>" + additionalNewline +
                         statementLeadingTrivia + additionalLeadingTrivia + "    options.UseSqlite({2}.GetConnectionString(\"{1}\"){3}));" + Environment.NewLine;
                     break;
-            
+
                 case DbProvider.SqlServer:
                     textToAddAtEnd =
                         leadingTrivia + "{0}.AddDbContext<{1}>(options =>" + additionalNewline +
                         statementLeadingTrivia + additionalLeadingTrivia + "    options.UseSqlServer({2}.GetConnectionString(\"{1}\"){3}));" + Environment.NewLine;
                     break;
-                
+
                 case DbProvider.CosmosDb:
                     textToAddAtEnd =
                         leadingTrivia + "{0}.AddDbContext<{1}>(options =>" + additionalNewline +
-                        statementLeadingTrivia + additionalLeadingTrivia + "    options.UseCosmos({2}.GetConnectionString(\"{1}\"), \"DATABASE_NAME\"));" + Environment.NewLine;
+                        statementLeadingTrivia + additionalLeadingTrivia + "    options.UseCosmos({2}.GetConnectionString(\"{1}\"){3}, \"DATABASE_NAME\"));" + Environment.NewLine;
                     break;
-                
+
                 case DbProvider.Postgres:
                     textToAddAtEnd =
                         leadingTrivia + "{0}.AddDbContext<{1}>(options =>" + additionalNewline +
@@ -248,7 +247,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 if (namedType != null &&
                     namedType.ContainingAssembly.Name == "Microsoft.Extensions.Configuration.Abstractions" &&
                     namedType.ContainingNamespace.ToDisplayString() == "Microsoft.Extensions.Configuration" &&
-                    namedType.Name == "IConfiguration") 
+                    namedType.Name == "IConfiguration")
                 {
                     return pSymbol;
                 }
@@ -289,7 +288,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                     string.Format("Server=(localdb)\\mssqllocaldb;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true",
                         dataBaseName);
             }
-            
+
             // Json.Net loses comments so the above code if requires any changes loses
             // comments in the file. The writeContent bool is for saving
             // a specific case without losing comments - when no changes are needed.
@@ -340,7 +339,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         {
             if (!IsModelPropertyExists(dbContext.TypeSymbol, modelType.FullName))
             {
-                // Todo : Consider using DeclaringSyntaxtReference 
+                // Todo : Consider using DeclaringSyntaxtReference
                 var sourceLocation = dbContext.TypeSymbol.Locations.Where(l => l.IsInSource).FirstOrDefault();
                 if (sourceLocation != null)
                 {
@@ -391,7 +390,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 parameters.TryGetValue("dataBaseName", out var dataBaseName);
                 parameters.TryGetValue("databaseProvider", out var dataContextTypeString);
                 DbProvider dataContextType = DbProvider.SqlServer;
-                if (Enum.TryParse(typeof(DbProvider), dataContextTypeString, ignoreCase:true, out var dataContextTypeObj))
+                if (Enum.TryParse(typeof(DbProvider), dataContextTypeString, ignoreCase: true, out var dataContextTypeObj))
                 {
                     dataContextType = (DbProvider)dataContextTypeObj;
                 }
@@ -409,7 +408,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 var startUpClassNode = rootNode.FindNode(declarationReference.Span);
 
                 var configRootProperty = TryGetIConfigurationRootProperty(startUp.TypeSymbol);
-                //if using Startup.cs, the ConfigureServices method should exist. 
+                //if using Startup.cs, the ConfigureServices method should exist.
                 if (startUpClassNode.ChildNodes()
                     .FirstOrDefault(n =>
                         n is MethodDeclarationSyntax syntax &&

--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -89,6 +89,13 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                     model.DatabaseProviderString = EfConstants.SQLite;
                 }
             }
+            else
+            {
+                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
+                {
+                    model.DatabaseProvider = dbProvider;
+                }
+            }
         }
     }
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -703,8 +703,15 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                     model.DatabaseProviderString = EfConstants.SQLite;
                 }
             }
+            else
+            {
+                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
+                {
+                    model.DatabaseProvider = dbProvider;
+                }
+            }
 
-            if (!string.IsNullOrEmpty(model.DatabaseProviderString) && !EfConstants.IdentityDbProviders.Contains(model.DatabaseProviderString, StringComparer.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(model.DatabaseProviderString) && !EfConstants.IdentityDbProviders.Keys.Contains(model.DatabaseProviderString, StringComparer.OrdinalIgnoreCase))
             {
                 string dbList = $"'{string.Join("', ", EfConstants.IdentityDbProviders.ToArray(), 0, EfConstants.IdentityDbProviders.Count - 1)}' and '{EfConstants.IdentityDbProviders.LastOrDefault()}'";
                 errorStrings.Add(string.Format(MessageStrings.InvalidDatabaseProvider, model.DatabaseProviderString));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -83,6 +83,13 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     model.DatabaseProviderString = EfConstants.SQLite;
                 }
             }
+            else
+            {
+                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
+                {
+                    model.DatabaseProvider = dbProvider;
+                }
+            }
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/SharedConstants.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/SharedConstants.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Scaffolding.Shared
@@ -38,7 +39,18 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             { DbProvider.Postgres, PostgresPackageName }
         };
 
-        public static readonly IList<string> IdentityDbProviders = new List<string> { SqlServer, SQLite };
-        public static readonly IList<string> AllDbProviders = new List<string> { SqlServer, SQLite, CosmosDb, Postgres };
+        public static readonly IDictionary<string, DbProvider> IdentityDbProviders = new Dictionary<string, DbProvider>(StringComparer.OrdinalIgnoreCase)
+        {
+            { SqlServer, DbProvider.SqlServer },
+            { SQLite, DbProvider.SQLite }
+        };
+
+        public static readonly IDictionary<string, DbProvider> AllDbProviders = new Dictionary<string, DbProvider>(StringComparer.OrdinalIgnoreCase)
+        {
+            { SqlServer, DbProvider.SqlServer },
+            { SQLite, DbProvider.SQLite },
+            { CosmosDb, DbProvider.CosmosDb },
+            { Postgres, DbProvider.Postgres }
+        };
     }
 }


### PR DESCRIPTION
fixes issue with the AddDbContext statement for cosmos db scenarios to have a nullable warning.
- changed `IdentityDbProviders` and `AllDbProviders` to Dictionary<string, DbProvider> from List<string>