### PR TITLE
minimal api templates update

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
     <MicrosoftAspNetCoreIdentityUIPackageVersion>7.0.3</MicrosoftAspNetCoreIdentityUIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=8.0.0-dev
+set VERSION=7.0.4
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=8.0.0-dev
+VERSION=7.0.4
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -744,13 +744,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             var dependencies = new HashSet<string>()
             {
                 "Microsoft.AspNetCore.Identity.UI",
-                "Microsoft.EntityFrameworkCore.Design"
+                EfConstants.EfToolsPackageName
             };
-
-            const string EfDesignPackageName = "Microsoft.EntityFrameworkCore.Design";
-            var isEFDesignPackagePresent = _projectContext
-                .PackageDependencies
-                .Any(package => package.Name.Equals(EfDesignPackageName, StringComparison.OrdinalIgnoreCase));
 
             var missingPackages = dependencies.Where(d => !_projectContext.PackageDependencies.Any(p => p.Name.Equals(d, StringComparison.OrdinalIgnoreCase)));
             if (CalledFromCommandline && missingPackages.Any())

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         private IModelTypesLocator ModelTypesLocator { get; set; }
         private IFileSystem FileSystem { get; set; }
         private IProjectContext ProjectContext { get; set; }
-        private IEntityFrameworkService EntityFrameworkService { get; set;}
+        private IEntityFrameworkService EntityFrameworkService { get; set; }
         private ICodeGeneratorActionsService CodeGeneratorActionsService { get; set; }
         private Workspace Workspace { get; set; }
         private ConsoleLogger ConsoleLogger { get; set; }
@@ -66,6 +66,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         /// <returns></returns>
         public async Task GenerateCode(MinimalApiGeneratorCommandLineModel model)
         {
+            System.Diagnostics.Debugger.Launch();
             model.ValidateCommandline(Logger);
             var namespaceName = NameSpaceUtilities.GetSafeNameSpaceFromPath(model.RelativeFolderPath, AppInfo.ApplicationName);
             //get model and dbcontext
@@ -74,7 +75,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 EntityFrameworkService,
                 ModelTypesLocator,
                 Logger,
-                areaName : string.Empty);
+                areaName: string.Empty);
+
+            var allpops = modelTypeAndContextModel.ContextProcessingResult?.ModelMetadata.Properties;
 
             if (!string.IsNullOrEmpty(modelTypeAndContextModel.DbContextFullName) && CalledFromCommandline)
             {
@@ -85,7 +88,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
             {
                 ValidateOpenApiDependencies(ProjectContext.PackageDependencies);
             }
-            
+
             var templateModel = new MinimalApiModel(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName, model.EndpintsClassName)
             {
                 EndpointsName = model.EndpintsClassName,
@@ -116,7 +119,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 }
             }
             //execute CodeGeneratorActionsService.AddFileFromTemplateAsync to add endpoints file.
-            else 
+            else
             {
                 //Add endpoints file with endpoints class since it does not exist.
                 ValidateModel(model);
@@ -178,7 +181,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     {
                         usings.Add("Microsoft.AspNetCore.Http.HttpResults");
                     }
-                    var endpointsCodeFile = new CodeFile { Usings = usings.ToArray()};
+                    var endpointsCodeFile = new CodeFile { Usings = usings.ToArray() };
                     var docBuilder = new DocumentBuilder(docEditor, endpointsCodeFile, ConsoleLogger);
                     var newRoot = docBuilder.AddUsings(new CodeChangeOptions());
                     var classNode = newRoot.DescendantNodes().FirstOrDefault(node => node is ClassDeclarationSyntax classDeclarationSyntax && classDeclarationSyntax.Identifier.ValueText.Contains(className));
@@ -196,7 +199,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                             classDeclaration = SyntaxFactory.ClassDeclaration($"{templateModel.ModelType.Name}Endpoints")
                                 .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
                                 .NormalizeWhitespace()
-                                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);  
+                                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
                         }
                         var modifiedClass = classDeclaration.AddMembers(
                             SyntaxFactory.GlobalStatement(SyntaxFactory.ParseStatement(membersBlockText)).WithLeadingTrivia(SyntaxFactory.Tab));
@@ -212,7 +215,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                         {
                             newRoot = newRoot.ReplaceNode(classNode, modifiedClass);
                         }
-                        
+
                         docEditor.ReplaceNode(docRoot, newRoot);
                         var classFileSourceTxt = await docEditor.GetChangedDocument()?.GetTextAsync();
                         var classFileTxt = classFileSourceTxt?.ToString();
@@ -323,7 +326,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                             newRoot = newRoot?.ReplaceNode(mainMethod.Body, updatedMethod);
                         }
                     }
-                                        
+
                     if (templateModel.OpenAPI)
                     {
                         var builderVariable = ProjectModifierHelper.GetBuilderVariableIdentifierTransformation(newRoot.Members);
@@ -336,7 +339,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                             {
                                 filteredChanges = DocumentBuilder.AddLeadingTriviaSpaces(filteredChanges, spaces: 12);
                                 var mainMethod = DocumentBuilder.GetMethodFromSyntaxRoot(newRoot, Main);
-                                { 
+                                {
                                     var updatedMethod = DocumentBuilder.ApplyChangesToMethod(mainMethod.Body, filteredChanges);
                                     newRoot = newRoot?.ReplaceNode(mainMethod.Body, updatedMethod);
                                 }
@@ -390,7 +393,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     string.Format(MessageStrings.InstallPackagesForScaffoldingIdentity, string.Join(",", missingPackages)));
             }
         }
-        
+
         private string GetMinimalApiCodeModifierConfig()
         {
             string jsonText = string.Empty;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -76,8 +76,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 Logger,
                 areaName: string.Empty);
 
-            var allpops = modelTypeAndContextModel.ContextProcessingResult?.ModelMetadata.Properties;
-
             if (!string.IsNullOrEmpty(modelTypeAndContextModel.DbContextFullName) && CalledFromCommandline)
             {
                 EFValidationUtil.ValidateEFDependencies(ProjectContext.PackageDependencies, model.DatabaseProvider);

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -66,7 +66,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         /// <returns></returns>
         public async Task GenerateCode(MinimalApiGeneratorCommandLineModel model)
         {
-            System.Diagnostics.Debugger.Launch();
             model.ValidateCommandline(Logger);
             var namespaceName = NameSpaceUtilities.GetSafeNameSpaceFromPath(model.RelativeFolderPath, AppInfo.ApplicationName);
             //get model and dbcontext

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -13,6 +13,7 @@
     string updateModel = $"Update{@modelName}";
     string dbContextName = Model.ContextTypeName;
     var entitySetName = Model.ModelMetadata.EntitySetName;
+    var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
     var entityProperties = Model.ModelMetadata.Properties;
     var primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
@@ -24,7 +25,7 @@
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.UseTypedResults ? "TypedResults" : "Results";
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
-    string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
+    string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
@@ -78,7 +79,7 @@ public static class @endPointsClassName
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
-            return await db.@findModel.AsNoTracking()
+            return await db.@entitySetNoTracking
                 .FirstOrDefaultAsync(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 is @modelName model
                     ? @resultsOkModel
@@ -98,36 +99,23 @@ public static class @endPointsClassName
         @:@builderExtensions;
 }
 
-        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
             var affected = await db.@entitySetName
                 .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 .ExecuteUpdateAsync(setters => setters
-                    .SetProperty(t => t.Title, todo.Title)
 @{
     //should be atleast one property (primary key)
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;
-        string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName}";
-                  @:.SetProperty(@setPropertyString)
+        string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName})";
+                  @:@setPropertyString
     }
 }
-                    .SetProperty(t => t.IsComplete, todo.IsComplete)
                 );
 
             return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
-            var foundModel = await db.@findModel;
-
-            if (foundModel is null)
-            {
-                return @resultsNotFound;
-            }
-            
-            db.Update(@Model.ModelVariable);
-            await db.SaveChangesAsync();
-
-            return @resultsNoContent;
         })
 @{
         builderExtensions = $".WithName(\"{@updateModel}\")";
@@ -163,7 +151,7 @@ public static class @endPointsClassName
         @:@builderExtensions;
 }
 
-        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
             var affected = await db.@entitySetName
                 .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -13,6 +13,7 @@
     string updateModel = $"Update{@modelName}";
     string dbContextName = Model.ContextTypeName;
     var entitySetName = Model.ModelMetadata.EntitySetName;
+    var entityProperties = Model.ModelMetadata.Properties;
     var primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
@@ -26,6 +27,7 @@
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
+    string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
     string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
@@ -76,7 +78,8 @@ public static class @endPointsClassName
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
-            return await db.@findModel
+            return await db.@findModel.AsNoTracking()
+                .FirstOrDefaultAsync(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 is @modelName model
                     ? @resultsOkModel
                     : @resultsNotFound;
@@ -97,6 +100,23 @@ public static class @endPointsClassName
 
         group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
+            var affected = await db.@entitySetName
+                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(t => t.Title, todo.Title)
+@{
+    //should be atleast one property (primary key)
+    foreach(var modelProperty in entityProperties)
+    {
+        string modelPropertyName = modelProperty.PropertyName;
+        string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName}";
+                  @:.SetProperty(@setPropertyString)
+    }
+}
+                    .SetProperty(t => t.IsComplete, todo.IsComplete)
+                );
+
+            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
             var foundModel = await db.@findModel;
 
             if (foundModel is null)
@@ -145,14 +165,11 @@ public static class @endPointsClassName
 
         group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
-            if (await db.@findModel is @modelName @Model.ModelVariable)
-            {
-                db.@remove;
-                await db.SaveChangesAsync();
-                return @resultsOkModelVariable;
-            }
+            var affected = await db.@entitySetName
+                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+                .ExecuteDeleteAsync();
 
-            return @resultsNotFound;
+            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
         })
 @{
     builderExtensions = $".WithName(\"{@deleteModel}\")";

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -3,6 +3,7 @@
     string modelName = Model.ModelType.Name;
     string routePrefix = "/api/" + modelName;
     string endPointsClassName = Model.EndpointsName;
+    string methodName = $"Map{@modelName}Endpoints";
     string pluralModel = $"{@modelName}s";
     string getAllModels = $"GetAll{@pluralModel}";
     string getModelById = $"Get{@modelName}ById";
@@ -11,6 +12,8 @@
     string updateModel = $"Update{@modelName}";
     string dbContextName = Model.ContextTypeName;
     var entitySetName = Model.ModelMetadata.EntitySetName;
+    var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
+    var entityProperties = Model.ModelMetadata.Properties;
     var primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
@@ -22,9 +25,10 @@
     var remove = $"{@entitySetName}.Remove({@Model.ModelVariable})";
     string resultsExtension = Model.UseTypedResults ? "TypedResults" : "Results";
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
-    string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
+    string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
+    string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";
     string resultsOkModelVariable = $"{resultsExtension}.Ok({@Model.ModelVariable})";
     string createdApiVar = string.Format("$\"{0}/{{{1}.{2}}}\",{3}", @routePrefix, @Model.ModelVariable, @primaryKeyName, @Model.ModelVariable);
@@ -64,7 +68,8 @@
 
         group.MapGet("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
-            return await db.@findModel
+            return await db.@entitySetNoTracking
+                .FirstOrDefaultAsync(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 is @modelName model
                     ? @resultsOkModel
                     : @resultsNotFound;
@@ -83,19 +88,23 @@
         @:@builderExtensions;
 }
 
-        group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+        group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
         {
-            var foundModel = await db.@findModel;
+            var affected = await db.@entitySetName
+                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+                .ExecuteUpdateAsync(setters => setters
+@{
+    //should be atleast one property (primary key)
+    foreach(var modelProperty in entityProperties)
+    {
+        string modelPropertyName = modelProperty.PropertyName;
+        string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName})";
+                  @:@setPropertyString
+    }
+}
+                );
 
-            if (foundModel is null)
-            {
-                return @resultsNotFound;
-            }
-            
-            db.Update(@Model.ModelVariable);
-            await db.SaveChangesAsync();
-
-            return @resultsNoContent;
+            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
         })
 @{
         builderExtensions = $".WithName(\"{@updateModel}\")";
@@ -131,16 +140,13 @@
         @:@builderExtensions;
 }
 
-        group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+        group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
         {
-            if (await db.@findModel is @modelName @Model.ModelVariable)
-            {
-                db.@remove;
-                await db.SaveChangesAsync();
-                return @resultsOkModelVariable;
-            }
+            var affected = await db.@entitySetName
+                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+                .ExecuteDeleteAsync();
 
-            return @resultsNotFound;
+            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
         })
 @{
     builderExtensions = $".WithName(\"{@deleteModel}\")";

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/EFValidationUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/EFValidationUtil.cs
@@ -13,12 +13,12 @@ namespace Microsoft.DotNet.Scaffolding.Shared
         internal static void ValidateEFDependencies(IEnumerable<DependencyDescription> dependencies, DbProvider dataContextType)
         {
             var isEFDesignPackagePresent = dependencies
-                .Any(package => package.Name.Equals(EfConstants.EfDesignPackageName, StringComparison.OrdinalIgnoreCase));
+                .Any(package => package.Name.Equals(EfConstants.EfToolsPackageName, StringComparison.OrdinalIgnoreCase));
 
             if (!isEFDesignPackagePresent)
             {
                 throw new InvalidOperationException(
-                    string.Format(MessageStrings.InstallEfPackages, $"{EfConstants.EfDesignPackageName}"));
+                    string.Format(MessageStrings.InstallEfPackages, $"{EfConstants.EfToolsPackageName}"));
             }
 
             if (EfConstants.EfPackagesDict.TryGetValue(dataContextType, out var dbProviderPackageName))

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/SharedConstants.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/SharedConstants.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
         public static string SQLite = DbProvider.SQLite.ToString();
         public static string CosmosDb = DbProvider.CosmosDb.ToString();
         public static string Postgres = DbProvider.Postgres.ToString();
-        public const string EfDesignPackageName = "Microsoft.EntityFrameworkCore.Design";
+        public const string EfToolsPackageName = "Microsoft.EntityFrameworkCore.Tools";
         public const string SqlServerPackageName = "Microsoft.EntityFrameworkCore.SqlServer";
         public const string SqlitePackageName = "Microsoft.EntityFrameworkCore.Sqlite";
         public const string CosmosPakcageName = "Microsoft.EntityFrameworkCore.Cosmos";


### PR DESCRIPTION
Addressing #2134 

- changed default EF scenario package validation to checking `Microsoft.EntityFrameworkCore.Tools` than `Microsoft.EntityFrameworkCore.Design`
- Applied all template changes mentioned in the related issue above.
  - using `ModelMetadata.Properties` to apply changes to all model properties, will be handy in future scenarios as well.