### PR TITLE
fix minimal endpoints in minimal classes (w/ top level statements)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "7.0.100"
+    "dotnet": "7.0.102"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22630.1"
   },
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.102",
     "allowPrerelease": true
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "7.0.102"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22630.1"
   },
   "sdk": {
-    "version": "7.0.102",
+    "version": "7.0.100",
     "allowPrerelease": true
   }
 }

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=7.0.4
+set VERSION=8.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=7.0.4
+VERSION=8.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGenerator.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                         //TODO throw exception
                         return;
                     }
-                   
+
                     //Get class syntax node to add members to the class
                     var docRoot = docEditor.OriginalRoot as CompilationUnitSyntax;
                     //create CodeFile just to add usings
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     }
 
                     System.Diagnostics.Debugger.Launch();
-                    
+
                     var endpointsCodeFile = new CodeFile { Usings = usings.ToArray() };
                     var docBuilder = new DocumentBuilder(docEditor, endpointsCodeFile, ConsoleLogger);
                     var newRoot = docBuilder.AddUsings(new CodeChangeOptions());
@@ -233,12 +233,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                     //have to add the static class in addtion to the 
                     else
                     {
-                        //should be FileScopedNamespaceDeclarationSyntax as a normal NamespaceDeclarationSyntax would have had a ClassDeclarationSyntax
-                        if (namespaceSyntax == null)
-                        {
-                            Logger.LogMessage("wtf bro, bullshit");
-                            //throw exception
-                        }
 
                         //create a ClassDeclarationSyntax, add the static endpoints method to the class
                         var newClassDeclaration = SyntaxFactory.ClassDeclaration($"{templateModel.ModelType.Name}Endpoints")
@@ -248,10 +242,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                         newClassDeclaration = newClassDeclaration.AddMembers(
                             SyntaxFactory.GlobalStatement(SyntaxFactory.ParseStatement(membersBlockText)).WithLeadingTrivia(SyntaxFactory.Tab));
                         //add members at the end of the namespace node.
-                        Logger.LogMessage("do you thang 22");
-                        var newNamespaceNode = namespaceSyntax.InsertNodesAfter(namespaceSyntax.ChildNodes().Last(), new List<SyntaxNode>() { newClassDeclaration });
                         //replace namespace node in newRoot
-                        newRoot = newRoot.ReplaceNode(namespaceSyntax, newNamespaceNode);
+                        newRoot = newRoot.InsertNodesAfter(newRoot.ChildNodes().Last(), new List<SyntaxNode> { newClassDeclaration });
                         //replace docRoot with newRoot
                         docEditor.ReplaceNode(docRoot, newRoot);
                         //write text to file


### PR DESCRIPTION
`Program.cs` or similar classes with top level statements could not be used as an endpoints class for minimal api endpoints scenario.
- `Program.cs` or other (only 1 allowed currently but scaffolding does not care) can be used an endpoints class.
- Add a new static class at the end of `Program.cs` instead of creating a new file for the class.
- Add necessary usings and `IEndpointRouteBuilder` extension calls.
