### PR TITLE
edited minimal api templates for correct encoding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
     <MicrosoftAspNetCoreIdentityUIPackageVersion>8.0.0-preview.3.23128.9</MicrosoftAspNetCoreIdentityUIPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>8.0.0</VersionPrefix>
+    <VersionPrefix>8.0.1</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.1.23115.2",
+    "dotnet": "8.0.100-preview.1.23109.10",
     "runtimes": {
       "aspnetcore": [
         "7.0.3"
@@ -14,7 +14,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23128.1"
   },
   "sdk": {
-    "version": "8.0.100-preview.1.23115.2",
+    "version": "8.0.100-preview.1.23109.10",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.1.23109.10",
+    "dotnet": "8.0.100-preview.1.23115.2",
     "runtimes": {
       "aspnetcore": [
         "7.0.3"
@@ -14,7 +14,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23128.1"
   },
   "sdk": {
-    "version": "8.0.100-preview.1.23109.10",
+    "version": "8.0.100-preview.1.23115.2",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   }

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=8.0.0-dev
+set VERSION=8.0.1-dev
 set DEFAULT_NUPKG_PATH=%userprofile%\.nuget\packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApi.cshtml
@@ -46,11 +46,11 @@ public static class @endPointsClassName
     string builderExtensions = $".WithName(\"{@getAllModels}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if(!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
 }
@@ -63,11 +63,11 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@getModelById}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if(!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
 }
@@ -80,11 +80,11 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@updateModel}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
     }
         @:@builderExtensions;
 }
@@ -106,11 +106,11 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@createModel}\")";
     if(Model.OpenAPI)
     {
-    builderExtensions+= $"\n{builderExtensionSpaces}.WithOpenApi()";
+    builderExtensions+= $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-    builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
+    builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
     }
         @:@builderExtensions;
 }
@@ -132,11 +132,11 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -67,11 +67,11 @@ public static class @endPointsClassName
         string builderExtensions = $".WithName(\"{@getAllModels}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if (!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
         }
 
         @:@builderExtensions;
@@ -89,12 +89,12 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@getModelById}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
     }
         @:@builderExtensions;
 }
@@ -121,12 +121,12 @@ public static class @endPointsClassName
         builderExtensions = $".WithName(\"{@updateModel}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if (!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
         }
 
         @:@builderExtensions;
@@ -142,11 +142,11 @@ public static class @endPointsClassName
         builderExtensions = $".WithName(\"{@createModel}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if(!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
         }
         @:@builderExtensions;
 }
@@ -163,12 +163,12 @@ public static class @endPointsClassName
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
     }
         @:@builderExtensions;
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -56,11 +56,11 @@
         string builderExtensions = $".WithName(\"{@getAllModels}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if (!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelList}>(StatusCodes.Status200OK)";
         }
 
         @:@builderExtensions;
@@ -78,12 +78,12 @@
     builderExtensions = $".WithName(\"{@getModelById}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
     }
         @:@builderExtensions;
 }
@@ -110,12 +110,12 @@
         builderExtensions = $".WithName(\"{@updateModel}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if (!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
         }
 
         @:@builderExtensions;
@@ -131,11 +131,11 @@
         builderExtensions = $".WithName(\"{@createModel}\")";
         if(Model.OpenAPI)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
         }
         if(!Model.UseTypedResults)
         {
-            builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
+            builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
         }
         @:@builderExtensions;
 }
@@ -152,12 +152,12 @@
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status404NotFound)";
     }
         @:@builderExtensions;
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiNoClass.cshtml
@@ -37,11 +37,11 @@
     string builderExtensions = $".WithName(\"{@getAllModels}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if(!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelArray}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
 }
@@ -54,11 +54,11 @@
     builderExtensions = $".WithName(\"{@getModelById}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if(!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
 }
@@ -71,11 +71,11 @@
     builderExtensions = $".WithName(\"{@updateModel}\")";
     if(Model.OpenAPI)
     {
-    builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+    builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-    builderExtensions += $"\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
+    builderExtensions += $"\r\n{builderExtensionSpaces}.Produces(StatusCodes.Status204NoContent)";
     }
         @:@builderExtensions;
 }
@@ -97,11 +97,11 @@
     builderExtensions = $".WithName(\"{@createModel}\")";
     if(Model.OpenAPI)
     {
-    builderExtensions+= $"\n{builderExtensionSpaces}.WithOpenApi()";
+    builderExtensions+= $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-    builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
+    builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status201Created)";
     }
         @:@builderExtensions;
 }
@@ -123,11 +123,11 @@
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.WithOpenApi()";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.WithOpenApi()";
     }
     if (!Model.UseTypedResults)
     {
-        builderExtensions += $"\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
+        builderExtensions += $"\r\n{builderExtensionSpaces}.Produces<{@modelName}>(StatusCodes.Status200OK)";
     }
         @:@builderExtensions;
     }


### PR DESCRIPTION
been trying to fix this issue and didn't realize the newline characters needed line feed chars
- `\n` --> `\r\n`
- fixes issue with consistent line endings being created in the scaffolded minimal endpoints file
- will be ported over to .NET 6/7 as well.