### PR TITLE
Fix string for default Project Description

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescription/ProjectDescriptionReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescription/ProjectDescriptionReader.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.MSIdentity.Project
             }
 
             // If projectDescription cannot be inferred, default to Web App
-            return ProjectDescriptions.FirstOrDefault(p => string.Equals(ProjectTypes.WebApp, p.Identifier));
+            return ProjectDescriptions.FirstOrDefault(p => string.Equals($"{ProjectTypeIdPrefix}{ProjectTypes.WebApp}", p.Identifier));
         }
 
         static readonly JsonSerializerOptions serializerOptionsWithComments = new JsonSerializerOptions

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_webapp.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_webapp.json
@@ -4,6 +4,10 @@
   "BasedOnProjectDescription": "dotnet-web",
   "MatchesForProjectType": [
     {
+      "FileRelativePath": "Startup.cs",
+      "MatchAny": [ ".AddAzureAD", ".AddMicrosoftIdentityWebApp", ".AddMicrosoftIdentityWebAppAuthentication", "Microsoft.Owin" ]
+    },
+    {
       "FolderRelativePath": "Pages",
       "FileRelativePath": "Index.cshtml",
       "Sets": "IsWebApp"


### PR DESCRIPTION
- Fixes the string comparison for the project description, so that the default project description is set correctly.
- In the MVC Web App code modifier config PR, I had deleted the MatchesForProjectType entry for both the Views folder and for Startup.cs from the dotnet-webapp project description
-- We do not want the Views folder to set "Web app" because it should set MVC web app
-- But we do want the Startup.cs check, for .NET Framework projects, so I'm adding that back in

related bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1798608