### PR TITLE
supporting netstandard2.0 for Microsoft.DotNet.Scaffolding.Shared

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextTemplateModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Controller/ControllerWithContextTemplateModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.Project;
 using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/DotnetCommands.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/DotnetCommands.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Cli.Utils
             }
 
             arguments.AddRange(additionalArgs);
-            string argumentsString = string.Join(' ', arguments);
+            string argumentsString = string.Join(" ", arguments);
             consoleLogger.LogMessage($"{MessageStrings.ExecuteDotnetNew} {argumentsString}", LogMessageLevel.Information);
             //check for minimum dotnet version
             string dotnetVersion = GetDotnetCommandVersion(consoleLogger);

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
+namespace Microsoft.DotNet.Scaffolding.Shared
 {
     internal static class StringUtil
     {
@@ -19,6 +19,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                 return input.Substring(0, length: 1).ToLowerInvariant() + input.Substring(1);
             }
             return input;
+        }
+
+        public static bool ContainsIgnoreCase(this string input, string value)
+        {
+            return input.ToLowerInvariant().Equals(value.ToLowerInvariant());
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
@@ -21,9 +21,13 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             return input;
         }
 
+        /// <summary>
+        /// since netstandard2.0 does not have a Contains that allows StringOrdinal param, using lower invariant comparison.
+        /// </summary>
+        /// <returns>true if lower invariants are equal, false otherwise. false for any null scenario.</returns>
         public static bool ContainsIgnoreCase(this string input, string value)
         {
-            return input.ToLowerInvariant().Equals(value.ToLowerInvariant());
+            return (input?.ToLowerInvariant().Equals(value?.ToLowerInvariant())).GetValueOrDefault();
         }
     }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.DotNet.Scaffolding.Shared</AssemblyName>
     <RootNamespace>Microsoft.DotNet.Scaffolding.Shared</RootNamespace>
     <Description>Contains interfaces for Project Model and messaging for scaffolding.</Description>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -115,7 +115,11 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                             //change the keys from TargetFramework to $(TargetFramework) and so forth for nested variable analysis.
                             //eg. analysing <TargetFramework>$(X)</TargetFramework> and getting the value for $(X).
                             //makes for a easy string comparison without using regex and splitting.
-                            csprojVariables.TryAdd(string.Format("$({0})", elem.Name.LocalName), elem.Value);
+                            string tfmKey = string.Format("$({0})", elem.Name.LocalName);
+                            if (!csprojVariables.ContainsKey(tfmKey))
+                            {
+                                csprojVariables.Add(tfmKey, elem.Value);
+                            }
                         }
                     }
                 }
@@ -134,7 +138,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 {
                     string processedTfm = ProcessTfm(tfms.Trim(), csprojVariables);
                     //tfms should be separated by ;
-                    var splitTfms = processedTfm.Split(";");
+                    var splitTfms = processedTfm.Split(';');
                     foreach (var tfm in splitTfms)
                     {
                         if (!string.IsNullOrEmpty(tfm) && ProjectModelHelper.ShortTfmDictionary.Values.ToList().Contains(tfm, StringComparer.OrdinalIgnoreCase))
@@ -219,7 +223,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             string formattedClassName = string.Empty;
             if (!string.IsNullOrEmpty(className))
             {
-                string[] blocks = className.Split(".cs");
+                //switched to using string[] for netstandard2.0 compatibility.
+                string[] blocks = className.Split(new string[] { ".cs" }, StringSplitOptions.None);
                 if (blocks.Length > 1)
                 {
                     return blocks[0];
@@ -618,7 +623,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 {
                     foreach (var key in csprojVariables.Keys)
                     {
-                        if (tfm.Contains(key, StringComparison.OrdinalIgnoreCase) && csprojVariables.TryGetValue(key, out string val))
+                        if (tfm.ContainsIgnoreCase(key) && csprojVariables.TryGetValue(key, out string val))
                         {
                             tfm = tfm.Replace(key, val);
                         }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectContextHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             foreach (var item in dependencies)
             {
                 //only add Microsoft.EntityFrameworkCore.* or Microsoft.AspNetCore.Identity.* assemblies. Any others might be duplicates which cause in-memory compilation errors and those are the assemblies we care about.
-                if (item.Name.Contains(EntityFrameworkCore, StringComparison.OrdinalIgnoreCase) || item.Name.Contains(AspNetCoreIdentity, StringComparison.OrdinalIgnoreCase))
+                if (item.Name.ContainsIgnoreCase(EntityFrameworkCore) || item.Name.ContainsIgnoreCase(AspNetCoreIdentity))
                 {
                     var name = $"{item.Name}.dll";
                     //costly search but we're only doing it a handful of times.
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             Tuple<string, string> nameAndVersion = null;
             if (!string.IsNullOrEmpty(fullName))
             {
-                string[] splitName = fullName.Split("/");
+                string[] splitName = fullName.Split('/');
                 if (splitName.Length > 1)
                 {
                     nameAndVersion = new Tuple<string, string>(splitName[0], splitName[1]);
@@ -140,9 +140,9 @@ namespace Microsoft.DotNet.Scaffolding.Shared
                     {
                         var dependencyTypeValue = type.ToString();
                         var DependencyTypeEnum = DependencyType.Unknown;
-                        if (Enum.TryParse(typeof(DependencyType), dependencyTypeValue, true, out var dependencyType))
+                        if (Enum.TryParse<DependencyType>(dependencyTypeValue, true, out var dependencyType))
                         {
-                            DependencyTypeEnum = (DependencyType)dependencyType;
+                            DependencyTypeEnum = dependencyType;
                         }
 
                         string packagePath = GetPath(path, nameAndVersion);

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.DotNet.Scaffolding.Shared.Tests
+{
+    public class StringUtilTests
+    {
+        [Fact]
+        public void ContainsIgnoreCase_ShouldReturnCorrectResults()
+        {
+            // Arrange
+            string input1 = "Hello";
+            string input2 = "World";
+            string input3 = "";
+            string input4 = "";
+            string input5 = "test";
+            string input6 = "Hello123";
+            string input7 = "123$%#Hello";
+
+            string value1 = "hello";
+            string value2 = "word";
+            string value3 = string.Empty;
+            string value4 = "test";
+            string value5 = "";
+            string value6 = "hello123";
+            string value7 = "123$%#hello";
+
+            // Act and Assert
+            Assert.True(input1.ContainsIgnoreCase(value1));
+            Assert.False(input2.ContainsIgnoreCase(value2));
+            Assert.True(input3.ContainsIgnoreCase(value3));
+            Assert.False(input4.ContainsIgnoreCase(value4));
+            Assert.False(input5.ContainsIgnoreCase(value5));
+            Assert.True(input6.ContainsIgnoreCase(value6));
+            Assert.True(input7.ContainsIgnoreCase(value7));
+        }
+    }
+}

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
             string input5 = "test";
             string input6 = "Hello123";
             string input7 = "123$%#Hello";
+            string input8 = null;
 
             string value1 = "hello";
             string value2 = "word";
@@ -26,6 +27,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
             string value5 = "";
             string value6 = "hello123";
             string value7 = "123$%#hello";
+            string value8 = null;
 
             // Act and Assert
             Assert.True(input1.ContainsIgnoreCase(value1));
@@ -35,6 +37,12 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
             Assert.False(input5.ContainsIgnoreCase(value5));
             Assert.True(input6.ContainsIgnoreCase(value6));
             Assert.True(input7.ContainsIgnoreCase(value7));
+            //null.ContainsIgnoreCase(string) should return false
+            Assert.False(input8.ContainsIgnoreCase(value7));
+            //null.ContainsIgnoreCase(null) should return false
+            Assert.False(input8.ContainsIgnoreCase(value8));
+            //string.ContainsIgnoreCase(null) should return false
+            Assert.False(input7.ContainsIgnoreCase(value8));
         }
     }
 }


### PR DESCRIPTION
adding support for netstandard2.0 for MIcrosoft.DotNet.Scaffolding.Shared so it can be consumed by VS.
- added `ContainsIgnoreCase` since netstandard2.0 does not have a string comparison with StringOrdinal parameters.