### PR TITLE
fix cosmosdb templates for endpoints scaffolding.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -1,6 +1,7 @@
 @inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
 @{
     string modelName = Model.ModelType.Name;
+    string dbProvider = Model.DatabaseProvider.ToString();
     string modelList = $"List<{@modelName}>";
     string routePrefix = "/api/" + modelName;
     string endPointsClassName = Model.EndpointsName;
@@ -26,6 +27,7 @@
     string resultsExtension = Model.UseTypedResults ? "TypedResults" : "Results";
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
+    string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
     string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
@@ -99,24 +101,43 @@ public static class @endPointsClassName
         @:@builderExtensions;
 }
 
-        group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
-        {
-            var affected = await db.@entitySetName
-                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
-                .ExecuteUpdateAsync(setters => setters
-@{
+@if (dbProvider == "CosmosDb")
+{
+          @:group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+          @:{
+              @:var foundModel = await db.@findModel;
+
+              @:if (foundModel is null)
+              @:{
+                  @:return @resultsNotFound;
+              @:}
+            
+              @:db.Update(@Model.ModelVariable);
+              @:await db.SaveChangesAsync();
+
+              @:return @resultsNoContent;
+          @:})
+}
+@if (dbProvider != "CosmosDb")
+{
+          @:group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+            @:{
+              @:var affected = await db.@entitySetName
+                  @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+                  @:.ExecuteUpdateAsync(setters => setters
     //should be atleast one property (primary key)
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;
         string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName})";
-                  @:@setPropertyString
+                    @:@setPropertyString
     }
-}
-                );
+              @:);
 
-            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
-        })
+              @:return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
+          @:})
+}
+
 @{
         builderExtensions = $".WithName(\"{@updateModel}\")";
         if(Model.OpenAPI)
@@ -150,15 +171,33 @@ public static class @endPointsClassName
         }
         @:@builderExtensions;
 }
+@if(dbProvider == "CosmosDb")
+{
+      @:group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+      @:{
+      @:    if (await db.@findModel is @modelName @Model.ModelVariable)
+      @:    {
+      @:        db.@remove;
+      @:        await db.SaveChangesAsync();
+      @:        return @resultsOkModelVariable;
+      @:    }
 
-        group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
-        {
-            var affected = await db.@entitySetName
-                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
-                .ExecuteDeleteAsync();
+      @:    return @resultsNotFound;
+      @:})
+}
 
-            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
-        })
+@if (dbProvider != "CosmosDb")
+{
+      @:group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+      @:{
+      @:    var affected = await db.@entitySetName
+      @:        .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+      @:        .ExecuteDeleteAsync();
+
+      @:    return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
+      @:})
+}
+
 @{
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -88,24 +88,43 @@
         @:@builderExtensions;
 }
 
-        group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
-        {
-            var affected = await db.@entitySetName
-                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
-                .ExecuteUpdateAsync(setters => setters
-@{
+@if (dbProvider == "CosmosDb")
+{
+      @:group.MapPut("/{id}", async @typedTaskWithNoContent (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+      @:{
+          @:var foundModel = await db.@findModel;
+
+          @:if (foundModel is null)
+          @:{
+              @:return @resultsNotFound;
+          @:}
+            
+          @:db.Update(@Model.ModelVariable);
+          @:await db.SaveChangesAsync();
+
+          @:return @resultsNoContent;
+      @:})
+}
+@if (dbProvider != "CosmosDb")
+{
+      @:group.MapPut("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @modelName @Model.ModelVariable, @dbContextName db) =>
+      @:{
+          @:var affected = await db.@entitySetName
+              @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+              @:.ExecuteUpdateAsync(setters => setters
     //should be atleast one property (primary key)
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;
         string setPropertyString = $".SetProperty(m => m.{modelPropertyName}, {Model.ModelVariable}.{modelPropertyName})";
-                  @:@setPropertyString
+              @:@setPropertyString
     }
-}
-                );
+            @:);
 
-            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
-        })
+            @:return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
+      @:})
+}
+
 @{
         builderExtensions = $".WithName(\"{@updateModel}\")";
         if(Model.OpenAPI)
@@ -140,14 +159,32 @@
         @:@builderExtensions;
 }
 
-        group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
-        {
-            var affected = await db.@entitySetName
-                .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
-                .ExecuteDeleteAsync();
+@if (dbProvider == "CosmosDb")
+{
+        @:group.MapDelete("/{id}", async @typedTaskWithNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+        @:{
+        @:    if (await db.@findModel is @modelName @Model.ModelVariable)
+        @:    {
+        @:        db.@remove;
+        @:        await db.SaveChangesAsync();
+        @:        return @resultsOkModelVariable;
+        @:    }
 
-            return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
-        })
+        @:    return @resultsNotFound;
+        @:})
+}
+
+@if (dbProvider != "CosmosDb")
+{
+        @:group.MapDelete("/{id}", async @typedTaskOkNotFound (@primaryKeyShortTypeName @primaryKeyNameLowerCase, @dbContextName db) =>
+        @:{
+        @:    var affected = await db.@entitySetName
+        @:        .Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
+        @:        .ExecuteDeleteAsync();
+
+        @:    return affected == 1 ? @resultsOkEmpty : @resultsNotFound;
+        @:})
+}
 @{
     builderExtensions = $".WithName(\"{@deleteModel}\")";
     if(Model.OpenAPI)


### PR DESCRIPTION
fix following templates:
- MinimalApiEf.cshtml
- MinimalApiEfNoClass.cshtml

remove and revert relational extension calls for MapPut and MapDelete methods generated in the endpoints scaffolder.