### PR TITLE
add project assembly to the workspace to detect BlazorApp objects.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Templating/RazorTemplating.cs
+++ b/src/Scaffolding/VS.Web.CG.Templating/RazorTemplating.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
             var fileSystem = RazorProjectFileSystem.Create(Directory.GetCurrentDirectory());
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, (builder) =>
             {
-                builder.SetCSharpLanguageVersion(LanguageVersion.CSharp11);
+                builder.SetCSharpLanguageVersion(LanguageVersion.Preview);
 
                 SectionDirective.Register(builder);
 

--- a/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
+++ b/src/Scaffolding/VS.Web.CG.Utils/Workspaces/RoslynWorkspace.cs
@@ -130,9 +130,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Utils
 
         private void AddMetadataReferences(IProjectContext projectContext, ProjectId id)
         {
-            var packages = projectContext.PackageDependencies;
             var resolvedReferences = projectContext.CompilationAssemblies;
-
+            //project main itself might have types defined (broke Blazor Web App scenarios)
+            resolvedReferences = resolvedReferences.Append(new ResolvedReference(projectContext.AssemblyName, projectContext.AssemblyFullPath));
             foreach (var reference in resolvedReferences)
             {
                 var metadataRef = GetMetadataReference(reference.ResolvedPath);


### PR DESCRIPTION
fixes https://github.com/dotnet/Scaffolding/issues/2508.
- adding the project assembly to the custom roslyn workspace helps detecting blazor built components.