### PR TITLE
Remove references to Azure AD

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -109,7 +109,8 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         ///    &lt;NotAuthorized&gt;
         ///        &lt;a href=&quot;authentication/login&quot;&gt;Log in&lt;/a&gt;
         ///    &lt;/NotAuthorized&gt;
-        ///&lt;/AuthorizeView&gt;        /// [rest of string was truncated]&quot;;.
+        ///&lt;/AuthorizeView&gt;
+        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string add_blazorwasm_LoginDisplay_razor {
             get {
@@ -743,7 +744,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find app registration with matching ID (ID: {0}).
+        ///   Looks up a localized string similar to Could not find an app registration with matching ID (ID: {0}).
         /// </summary>
         internal static string NotFound {
             get {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.Designer.cs
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An Azure AD tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant..
+        ///   Looks up a localized string similar to A Microsoft identity platform tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant..
         /// </summary>
         internal static string ClientDoesNotExist {
             get {
@@ -590,7 +590,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to add client secret for Azure AD app : {0}({1}).
+        ///   Looks up a localized string similar to Failed to add client secret for app registration : {0}({1}).
         /// </summary>
         internal static string FailedClientSecretWithApp {
             get {
@@ -608,7 +608,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to create Azure AD/AD B2C app registration..
+        ///   Looks up a localized string similar to Failed to create remote app registration..
         /// </summary>
         internal static string FailedToCreateApp {
             get {
@@ -644,7 +644,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to retrieve all Azure AD/AD B2C objects (apps/service principals), exception: {0}.
+        ///   Looks up a localized string similar to Failed to retrieve all graph objects (apps/service principals), exception: {0}.
         /// </summary>
         internal static string FailedToRetrieveADObjectsError {
             get {
@@ -662,7 +662,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update Azure AD app registration {0} ({1}).
+        ///   Looks up a localized string similar to Failed to update remote app registration {0} ({1}).
         /// </summary>
         internal static string FailedToUpdateApp {
             get {
@@ -671,7 +671,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update Azure AD app, null {0}.
+        ///   Looks up a localized string similar to Failed to update remote app registration, null {0}.
         /// </summary>
         internal static string FailedToUpdateAppNull {
             get {
@@ -743,7 +743,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find app registration with matching ID in Azure AD (ID: {0}).
+        ///   Looks up a localized string similar to Could not find app registration with matching ID (ID: {0}).
         /// </summary>
         internal static string NotFound {
             get {
@@ -752,7 +752,7 @@ namespace Microsoft.DotNet.MSIdentity.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Azure AD app {0} ({1}) did not require any remote updates.
+        ///   Looks up a localized string similar to App registration {0} ({1}) did not require any remote updates.
         /// </summary>
         internal static string NoUpdateNecessary {
             get {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -163,7 +163,7 @@
     <value>Authentication is not enabled yet in this project. An app registration will be created, but the tool does not add the code yet (work in progress).</value>
   </data>
   <data name="ClientDoesNotExist" xml:space="preserve">
-    <value>An Azure AD tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant.</value>
+    <value>A Microsoft identity platform tenant, and a user in that tenant, needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant.</value>
   </data>
   <data name="ClientSecret" xml:space="preserve">
     <value>Client secret - {0}.</value>
@@ -250,13 +250,14 @@
     <value>Failed to add client secret.</value>
   </data>
   <data name="FailedClientSecretWithApp" xml:space="preserve">
-    <value>Failed to add client secret for Azure AD app : {0}({1})</value>
+    <value>Failed to add client secret for app registration : {0}({1})</value>
+    <comment>0: Display Name, 1: Client ID</comment>
   </data>
   <data name="FailedToAcquireToken" xml:space="preserve">
     <value>Failed to acquire a token.</value>
   </data>
   <data name="FailedToCreateApp" xml:space="preserve">
-    <value>Failed to create Azure AD/AD B2C app registration.</value>
+    <value>Failed to create remote app registration.</value>
   </data>
   <data name="FailedToGetServicePrincipal" xml:space="preserve">
     <value>Failed to get or create service principal.</value>
@@ -269,18 +270,18 @@
     <value>Failed to provision Client Application for Blazor WASM hosted project</value>
   </data>
   <data name="FailedToRetrieveADObjectsError" xml:space="preserve">
-    <value>Failed to retrieve all Azure AD/AD B2C objects (apps/service principals), exception: {0}</value>
+    <value>Failed to retrieve all graph objects (apps/service principals), exception: {0}</value>
     <comment>0 = error message</comment>
   </data>
   <data name="FailedToRetrieveApplicationParameters" xml:space="preserve">
     <value>Failed to retrieve application parameters.</value>
   </data>
   <data name="FailedToUpdateApp" xml:space="preserve">
-    <value>Failed to update Azure AD app registration {0} ({1})</value>
+    <value>Failed to update remote app registration {0} ({1})</value>
     <comment>0 = Display Name, 1 = App Id</comment>
   </data>
   <data name="FailedToUpdateAppNull" xml:space="preserve">
-    <value>Failed to update Azure AD app, null {0}</value>
+    <value>Failed to update remote app registration, null {0}</value>
     <comment>0 = null object</comment>
   </data>
   <data name="FailedToUpdateClientAppCode" xml:space="preserve">
@@ -308,11 +309,11 @@
     <value>No project found in {0}.</value>
   </data>
   <data name="NotFound" xml:space="preserve">
-    <value>Could not find app registration with matching ID in Azure AD (ID: {0})</value>
+    <value>Could not find app registration with matching ID (ID: {0})</value>
     <comment>0 = App Id</comment>
   </data>
   <data name="NoUpdateNecessary" xml:space="preserve">
-    <value>Azure AD app {0} ({1}) did not require any remote updates</value>
+    <value>App registration {0} ({1}) did not require any remote updates</value>
     <comment>0 = Display Name, 1 = App Id</comment>
   </data>
   <data name="PermissionExists" xml:space="preserve">

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Properties/Resources.resx
@@ -309,7 +309,7 @@
     <value>No project found in {0}.</value>
   </data>
   <data name="NotFound" xml:space="preserve">
-    <value>Could not find app registration with matching ID (ID: {0})</value>
+    <value>Could not find an app registration with matching ID (ID: {0})</value>
     <comment>0 = App Id</comment>
   </data>
   <data name="NoUpdateNecessary" xml:space="preserve">


### PR DESCRIPTION
Removing references to "Azure AD" for the Microsoft Entra ID rebranding