### PR TITLE
fixed bug caused by missing input types for blazor CRUD templates

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Blazor/BlazorModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Blazor/BlazorModel.cs
@@ -59,48 +59,40 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
         public string DbContextNamespace { get; private set; }
         public string Template { get; set; }
 
-        public Dictionary<string, string> _inputTypeDict;
-        //used for Create page for the Blazor CRUD scenario
-        public Dictionary<string, string> InputTypeDict
+        //used for Create and Edit pages for the Blazor CRUD scenario
+        public string GetInputType(string inputType)
         {
-            get
+            if (string.IsNullOrEmpty(inputType))
             {
-                if (_inputTypeDict == null)
-                {
-                    _inputTypeDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        { "string", "InputText" },
-                        { "DateTime", "InputDate" },
-                        { "double", "InputNumber" },
-                        { "int", "InputNumber" },
-                        { "bool", "InputCheckbox" }
-                    };
-                }
+                return "InputText";
+            }
 
-                return _inputTypeDict;
+            switch (inputType)
+            { 
+                case "string":
+                    return "InputText";
+                case "DateTime":
+                    return "InputDate";
+                case "double":
+                case "decimal":
+                case "int":
+                    return "InputNumber";
+                case "bool":
+                    return "InputCheckbox";
+                default:
+                    return "InputText";
             }
         }
 
-        public Dictionary<string, string> _inputClassDict;
-        //used for Create page for the Blazor CRUD scenario
-        public Dictionary<string, string> InputClassDict
+        //used for Create and Edit pages for the Blazor CRUD scenario
+        public string GetInputClassType(string inputType)
         {
-            get
+            if (string.Equals(inputType, "bool", StringComparison.OrdinalIgnoreCase))
             {
-                if (_inputClassDict == null)
-                {
-                    _inputClassDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        { "string", "form-control" },
-                        { "DateTime", "form-control" },
-                        { "double", "form-control" },
-                        { "int", "form-control" },
-                        { "bool", "form-check-input" }
-                    };
-                }
-
-                return _inputClassDict;
+                return "form-check-input";
             }
+
+            return "form-control";
         }
 
         //namespaces to add in Endpoints file.

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.cs
@@ -62,8 +62,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
                     string modelPropertyName = property.PropertyName;
                     string modelPropertyNameLowercase = modelPropertyName.ToLowerInvariant();
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
-                    Model.InputTypeDict.TryGetValue(propertyShortTypeName, out var inputTypeName);
-                    Model.InputClassDict.TryGetValue(propertyShortTypeName, out var inputClass);
+                    var inputTypeName = Model.GetInputType(propertyShortTypeName);
+                    var inputClass = Model.GetInputClassType(propertyShortTypeName);
             
             this.Write("<div class=\"mb-3\">\r\n                <label for=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.tt
@@ -38,8 +38,8 @@
                     string modelPropertyName = property.PropertyName;
                     string modelPropertyNameLowercase = modelPropertyName.ToLowerInvariant();
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
-                    Model.InputTypeDict.TryGetValue(propertyShortTypeName, out var inputTypeName);
-                    Model.InputClassDict.TryGetValue(propertyShortTypeName, out var inputClass);
+                    var inputTypeName = Model.GetInputType(propertyShortTypeName);
+                    var inputClass = Model.GetInputClassType(propertyShortTypeName);
             #>
 <div class="mb-3">
                 <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label> 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.cs
@@ -67,8 +67,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
                     string modelPropertyName = property.PropertyName;
                     string modelPropertyNameLowercase = modelPropertyName.ToLowerInvariant();
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
-                    Model.InputTypeDict.TryGetValue(propertyShortTypeName, out var inputTypeName);
-                    Model.InputClassDict.TryGetValue(propertyShortTypeName, out var inputClass);
+                    var inputTypeName = Model.GetInputType(propertyShortTypeName);
+                    var inputClass = Model.GetInputClassType(propertyShortTypeName);
 
             this.Write("                <div class=\"mb-3\">\r\n                    <label for=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.tt
@@ -44,8 +44,8 @@ else
                     string modelPropertyName = property.PropertyName;
                     string modelPropertyNameLowercase = modelPropertyName.ToLowerInvariant();
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
-                    Model.InputTypeDict.TryGetValue(propertyShortTypeName, out var inputTypeName);
-                    Model.InputClassDict.TryGetValue(propertyShortTypeName, out var inputClass);
+                    var inputTypeName = Model.GetInputType(propertyShortTypeName);
+                    var inputClass = Model.GetInputClassType(propertyShortTypeName);
 #>
                 <div class="mb-3">
                     <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>


### PR DESCRIPTION
- Create.tt and Edit.tt template html blazor code based on the input type for properties.
- only certain input types were hardcoded in BlazorModel with no generic fallbacks, added now.