### PR TITLE
removed useSqlite and fixed minimalapi.json

### DIFF
--- a/src/Scaffolding/VS.Web.CG.EFCore/ConnectionStringsWriter.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/ConnectionStringsWriter.cs
@@ -27,11 +27,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
-        public void AddConnectionString(string connectionStringName, string dataBaseName, bool useSqlite)
-        {
-            AddConnectionString(connectionStringName, dataBaseName, useSqlite ? DbProvider.SQLite : DbProvider.SqlServer);
-        }
-
         public void AddConnectionString(string connectionStringName, string databaseName, DbProvider databaseProvider)
         {
             var appSettingsFile = Path.Combine(_applicationInfo.ApplicationBasePath, "appsettings.json");

--- a/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -119,30 +119,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             return safeName;
         }
 
-        public EditSyntaxTreeResult EditStartupForNewContext(
-            ModelType startUp,
-            string dbContextTypeName,
-            string dbContextNamespace,
-            string dataBaseName,
-            bool useSqlite,
-            bool useTopLevelStatements)
-        {
-            Contract.Assert(startUp != null && startUp.TypeSymbol != null);
-            Contract.Assert(!string.IsNullOrEmpty(dbContextTypeName));
-            Contract.Assert(!string.IsNullOrEmpty(dataBaseName));
-
-            var parameters = new Dictionary<string, string>
-            {
-                { nameof(NewDbContextTemplateModel.DbContextTypeName),  dbContextTypeName },
-                { nameof(NewDbContextTemplateModel.DbContextNamespace),  dbContextNamespace },
-                { "dataBaseName", dataBaseName},
-                { "databaseProvider", useSqlite ? EfConstants.SQLite : EfConstants.SqlServer },
-                { "useTopLevelStatements", useTopLevelStatements.ToString() }
-            };
-
-            return EditStartupForNewContext(startUp, parameters);
-        }
-
         /// <summary>
         /// Get the StatementSyntax that adds the db context to the WebApplicationBuilder.
         /// </summary>

--- a/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkServices.cs
@@ -101,11 +101,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             _fileSystem = fileSystem;
         }
 
-        public async Task<ContextProcessingResult> GetModelMetadata(string dbContextFullTypeName, ModelType modelTypeSymbol, string areaName, bool useSqlite)
-        {
-            return await GetModelMetadata(dbContextFullTypeName, modelTypeSymbol, areaName, useSqlite ? DbProvider.SQLite : DbProvider.SqlServer);
-        }
-
         public async Task<ContextProcessingResult> GetModelMetadata(string dbContextFullTypeName, ModelType modelTypeSymbol, string areaName, DbProvider databaseProvider)
         {
             if (string.IsNullOrEmpty(dbContextFullTypeName))

--- a/src/Scaffolding/VS.Web.CG.EFCore/IConnectionStringsWriter.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/IConnectionStringsWriter.cs
@@ -8,8 +8,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 {
     public interface IConnectionStringsWriter
     {
-        [Obsolete]
-        void AddConnectionString(string connectionStringName, string dataBaseName, bool useSqlite);
         void AddConnectionString(string connectionStringName, string databaseName, DbProvider databaseProvider);
     }
 }

--- a/src/Scaffolding/VS.Web.CG.EFCore/IDbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/IDbContextEditorServices.cs
@@ -12,13 +12,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
     public interface IDbContextEditorServices
     {
         Task<SyntaxTree> AddNewContext(NewDbContextTemplateModel dbContextTemplateModel);
-
-        [Obsolete]
-        EditSyntaxTreeResult AddModelToContext(ModelType dbContext, ModelType modelType, bool nullableEnabled);
-
-        [Obsolete]
-        EditSyntaxTreeResult EditStartupForNewContext(ModelType startup, string dbContextTypeName, string dbContextNamespace, string dataBaseName, bool useSqlite, bool useTopLevelStatements);
-
         EditSyntaxTreeResult AddModelToContext(ModelType dbContext, ModelType modelType, IDictionary<string, string> parameters);
         EditSyntaxTreeResult EditStartupForNewContext(ModelType startup, IDictionary<string, string> parameters);
     }

--- a/src/Scaffolding/VS.Web.CG.EFCore/IEntityFrameworkService.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/IEntityFrameworkService.cs
@@ -10,8 +10,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 {
     public interface IEntityFrameworkService
     {
-        [Obsolete]
-        Task<ContextProcessingResult> GetModelMetadata(string dbContextFullTypeName, ModelType modelTypeName, string areaName, bool useSqlite);
         /// <summary>
         /// Gets the EF metadata for given context and model.
         /// Method takes in full type name of context and if there is no context with that name,

--- a/src/Scaffolding/VS.Web.CG.EFCore/baseline.netcore.json
+++ b/src/Scaffolding/VS.Web.CG.EFCore/baseline.netcore.json
@@ -222,10 +222,6 @@
             {
               "Name": "dataBaseName",
               "Type": "System.String"
-            },
-            {
-              "Name": "useSQLite",
-              "Type": "System.Boolean"
             }
           ],
           "ReturnType": "System.Void",
@@ -651,10 +647,6 @@
             {
               "Name": "dataBaseName",
               "Type": "System.String"
-            },
-            {
-              "Name": "useSQLite",
-              "Type": "System.Boolean"
             }
           ],
           "ReturnType": "System.Void",

--- a/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Common/CommonCommandLineModel.cs
@@ -16,15 +16,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
         [Option(Name = "dataContext", ShortName = "dc", Description = "DbContext class to use")]
         public string DataContextClass { get; set; }
 
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite { get; set; }
-
-        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite2 { get; set; }
-
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }
@@ -76,25 +67,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
                 throw new ArgumentNullException(nameof(model));
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite || model.UseSqlite2)
+            if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
             {
-#pragma warning restore CS0618 // Type or member is obsolete
-                //instead of throwing an error, letting the devs know that its obsolete.
-                logger.LogMessage(MessageStrings.SqliteObsoleteOption, LogMessageLevel.Information);
-                //Setting DatabaseProvider to SQLite if --databaseProvider|-dbProvider is not provided.
-                if (string.IsNullOrEmpty(model.DatabaseProviderString))
-                {
-                    model.DatabaseProvider = DbProvider.SQLite;
-                    model.DatabaseProviderString = EfConstants.SQLite;
-                }
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
-                {
-                    model.DatabaseProvider = dbProvider;
-                }
+                model.DatabaseProvider = dbProvider;
             }
         }
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorCommandLineModel.cs
@@ -13,15 +13,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         [Option(Name = "rootNamespace", ShortName = "rn", Description = "Root namesapce to use for generating identity code.")]
         public string RootNamespace { get; set; }
 
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite { get; set; }
-
-        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite2 { get; set; }
-
         [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }

--- a/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -690,27 +690,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 errorStrings.Add(string.Format(MessageStrings.InvalidDbContextClassName, model.DbContext));
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite || model.UseSqlite2)
-            {
-#pragma warning restore CS0618 // Type or member is obsolete
-                //instead of throwing an error, letting the devs know that its obsolete.
-                _logger.LogMessage(MessageStrings.SqliteObsoleteOption, LogMessageLevel.Information);
-                //Setting DatabaseProvider to SQLite if --databaseProvider|-dbProvider is not provided.
-                if (string.IsNullOrEmpty(model.DatabaseProviderString))
-                {
-                    model.DatabaseProvider = DbProvider.SQLite;
-                    model.DatabaseProviderString = EfConstants.SQLite;
-                }
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
-                {
-                    model.DatabaseProvider = dbProvider;
-                }
-            }
-
             if (!string.IsNullOrEmpty(model.DatabaseProviderString) && !EfConstants.IdentityDbProviders.Keys.Contains(model.DatabaseProviderString, StringComparer.OrdinalIgnoreCase))
             {
                 string dbList = $"'{string.Join("', ", EfConstants.IdentityDbProviders.ToArray(), 0, EfConstants.IdentityDbProviders.Count - 1)}' and '{EfConstants.IdentityDbProviders.LastOrDefault()}'";

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -27,16 +27,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
         [Option(Name = "endpointsNamespace", ShortName = "namespace", Description = "Specify the name of the namespace to use for the generated controller")]
         public string EndpointsNamespace { get; set; }
 
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqLite", ShortName = "sqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite { get; set; }
-
-        //adding UseSqlite2 for backwards compat. for VS Mac scenarios (casing issue).
-        [Obsolete("Use --databaseProvider or -dbProvider to configure database type instead")]
-        [Option(Name = "useSqlite", Description = "Flag to specify if DbContext should use SQLite instead of SQL Server.")]
-        public bool UseSqlite2 { get; set; }
-
-        [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'.")]
+        [Option(Name = "databaseProvider", ShortName = "dbProvider", Description = "Database provider to use. Options (without quotes) include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'. Example: -dbProvider sqlite")]
         public string DatabaseProviderString { get; set; }
         public DbProvider DatabaseProvider { get; set; }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Minimal Api/MinimalApiGeneratorCommandLineModel.cs
@@ -64,25 +64,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.MinimalApi
                 throw new ArgumentNullException(nameof(model));
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (model.UseSqlite || model.UseSqlite2)
+            if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
             {
-#pragma warning restore CS0618 // Type or member is obsolete
-                //instead of throwing an error, letting the devs know that its obsolete.
-                logger.LogMessage(MessageStrings.SqliteObsoleteOption, LogMessageLevel.Information);
-                //Setting DatabaseProvider to SQLite if --databaseProvider|-dbProvider is not provided.
-                if (string.IsNullOrEmpty(model.DatabaseProviderString))
-                {
-                    model.DatabaseProvider = DbProvider.SQLite;
-                    model.DatabaseProviderString = EfConstants.SQLite;
-                }
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(model.DatabaseProviderString) && EfConstants.AllDbProviders.TryGetValue(model.DatabaseProviderString, out var dbProvider))
-                {
-                    model.DatabaseProvider = dbProvider;
-                }
+                model.DatabaseProvider = dbProvider;
             }
         }
     }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/controller.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/controller.json
@@ -74,11 +74,6 @@
       "Name": "databaseProvider",
       "ShortName": "dbProvider",
       "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-    },
-    {
-      "Name": "useSqLite",
-      "ShortName": "sqlite",
-      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/identity.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/identity.json
@@ -52,11 +52,6 @@
       "Name": "bootstrapVersion",
       "ShortName": "b",
       "Description": "Specify the bootstrap version. Valid values: '3', '4'. Default is 4."
-    },
-    {
-      "Name": "useSqLite",
-      "ShortName": "sqlite",
-      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
@@ -1,35 +1,42 @@
 {
   "Alias": "minimalapi",
   "Description": "Generates an endpoints file (with CRUD API endpoints) given a model and optional DbContext.",
-  "Arguments": [
+  "Arguments" :  [],
+  "Options": [
     {
-      "Name": "-e|--endpoints",
+      "Name": "endpoints",
+      "ShortName": "e",
       "Description": "Endpoints class to use. (not file name)"
     },
     {
-      "Name": "-m|--model",
+      "Name": "model",
+      "ShortName": "m",
       "Description": "Model class to use"
     },
     {
-      "Name": "-dc|--dataContext",
+      "Name": "dataContext",
+      "ShortName": "dc",
       "Description": "DbContext class to use"
     },
     {
-      "Name": "-outDir|--relativeFolderPath",
+      "Name": "relativeFolderPath",
+      "ShortName": "outDir",
       "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
     },
     {
-      "Name": "-o|--open",
+      "Name": "open",
+      "ShortName": "o",
       "Description": "Use this option to enable OpenAPI"
     },
     {
-      "Name": "-namespace|--endpointsNamespace",
+      "Name": "endpointsNamespace",
+      "ShortName": "namespace",
       "Description": "Specify the name of the namespace to use for the generated Endpoints file"
     },
     {
-      "Name": "-dbProvider|--databaseProvider",
-      "Description": "Database provider to use. Options (without quotes) include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'. Example: -dbProvider sqlite" 
+      "Name": "databaseProvider",
+      "ShortName": "dbProvider",
+      "Description": "Database provider to use. Options (without quotes) include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'. Example: -dbProvider sqlite"
     }
-  ],
-  "Options": []
+  ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/minimalapi.json
@@ -27,13 +27,8 @@
       "Description": "Specify the name of the namespace to use for the generated Endpoints file"
     },
     {
-      "Name": "databaseProvider",
-      "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-    },
-    {
-      "Name": "useSqLite",
-      "ShortName": "sqlite",
-      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
+      "Name": "-dbProvider|--databaseProvider",
+      "Description": "Database provider to use. Options (without quotes) include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'. Example: -dbProvider sqlite" 
     }
   ],
   "Options": []

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/razorpage.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/razorpage.json
@@ -61,16 +61,6 @@
       "Name": "noPageModel",
       "ShortName": "npm",
       "Description": "Switch to not generate a PageModel class for Empty template"
-    },
-    {
-      "Name": "databaseProvider",
-      "ShortName": "dbProvider",
-      "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-    },
-    {
-      "Name": "useSqLite",
-      "ShortName": "sqlite",
-      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ]
 }

--- a/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/view.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/ParameterDefinitions/view.json
@@ -61,11 +61,6 @@
       "Name": "databaseProvider",
       "ShortName": "dbProvider",
       "Description": "Database provider to use. Options include 'sqlserver' (default), 'sqlite', 'cosmos', 'postgres'."
-    },
-    {
-      "Name": "useSqLite",
-      "ShortName": "sqlite",
-      "Description": "Flag to specify if DbContext should use SQLite instead of SQL Server."
     }
   ]
 }

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/ConnectionStringsWriterTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/ConnectionStringsWriterTests.cs
@@ -28,8 +28,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             var fs = new MockFileSystem();
             var testObj = GetTestObject(fs);
 
-            //Act, test obsolete AddConnectionString
-            testObj.AddConnectionString("MyDbContext", "MyDbContext-NewGuid", false);
             //test SqlServer
             testObj.AddConnectionString("MyDbContext2", "MyDbContext-SqlServerDb", DbProvider.SqlServer);
             //test SqlServer
@@ -41,7 +39,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             //Assert
             string expected = @"{
   ""ConnectionStrings"": {
-    ""MyDbContext"": ""Server=(localdb)\\mssqllocaldb;Database=MyDbContext-NewGuid;Trusted_Connection=True;MultipleActiveResultSets=true"",
     ""MyDbContext2"": ""Server=(localdb)\\mssqllocaldb;Database=MyDbContext-SqlServerDb;Trusted_Connection=True;MultipleActiveResultSets=true"",
     ""MyDbContext3"": ""Data Source=MyDbContext-SqliteDb.db"",
     ""MyDbContext4"": ""AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="",
@@ -58,14 +55,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
         [Theory]
         // Local Db Tests
         // Empty appsettings.json
-        [InlineData(false, "{}",
+        [InlineData(DbProvider.SqlServer, "{}",
                     @"{
   ""ConnectionStrings"": {
     ""MyDbContext"": ""Server=(localdb)\\mssqllocaldb;Database=MyDbContext-NewGuid;Trusted_Connection=True;MultipleActiveResultSets=true""
   }
 }")]
         // File with no node for connection name
-        [InlineData(false, @"{
+        [InlineData(DbProvider.SqlServer, @"{
   ""ConnectionStrings"": {
   }
 }",
@@ -76,7 +73,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 }")]
         // File with node for connection name and also existing ConnectionString property
         // modification should be skipped in this case
-        [InlineData(false, @"{
+        [InlineData(DbProvider.SqlServer, @"{
   ""ConnectionStrings"": {
     ""MyDbContext"": ""SomeExistingValue""
   }
@@ -87,14 +84,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
   }
 }")]
         // SQLite tests
-        [InlineData(true, "{}",
+        [InlineData(DbProvider.SQLite, "{}",
                     @"{
   ""ConnectionStrings"": {
     ""MyDbContext"": ""Data Source=MyDbContext-NewGuid.db""
   }
 }")]
         // File with no node for connection name
-        [InlineData(true, @"{
+        [InlineData(DbProvider.SQLite, @"{
   ""ConnectionStrings"": {
   }
 }",
@@ -105,7 +102,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 }")]
         // File with node for connection name and also existing ConnectionString property
         // modification should be skipped in this case
-        [InlineData(true, @"{
+        [InlineData(DbProvider.SQLite, @"{
   ""ConnectionStrings"": {
     ""MyDbContext"": ""SomeExistingValue""
   }
@@ -115,7 +112,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     ""MyDbContext"": ""SomeExistingValue""
   }
 }")]
-        public void AddConnectionString_Modifies_App_Settings_File_As_Required(bool useSqLite, string previousContent, string newContent)
+        public void AddConnectionString_Modifies_App_Settings_File_As_Required(DbProvider dbProvider, string previousContent, string newContent)
         {
             //Arrange
             var fs = new MockFileSystem();
@@ -124,7 +121,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             var testObj = GetTestObject(fs);
 
             //Act
-            testObj.AddConnectionString("MyDbContext", "MyDbContext-NewGuid", useSqLite);
+            testObj.AddConnectionString("MyDbContext", "MyDbContext-NewGuid", dbProvider);
 
             //Assert
             Assert.Equal(newContent, fs.ReadAllText(appSettingsPath), ignoreCase: false, ignoreLineEndingDifferences: true);

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/DbContextEditorServicesTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/DbContextEditorServicesTests.cs
@@ -136,8 +136,16 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             var types = RoslynUtilities.GetDirectTypesInCompilation(compilation);
             var startupType = ModelType.FromITypeSymbol(types.Where(ts => ts.Name == "Startup").First());
             var contextType = ModelType.FromITypeSymbol(types.Where(ts => ts.Name == "MyContext").First());
+            var parameters = new Dictionary<string, string>
+            {
+                { nameof(NewDbContextTemplateModel.DbContextTypeName),  "MyContext" },
+                { nameof(NewDbContextTemplateModel.DbContextNamespace),  "ContextNamespace" },
+                { "dataBaseName", "MyContext" + "-" + Guid.NewGuid().ToString()},
+                { "databaseProvider", DbProvider.SqlServer.ToString() },
+                { "useTopLevelStatements", "false" }
+            };
 
-            var result = testObj.EditStartupForNewContext(startupType, "MyContext", "ContextNamespace", "MyContext-NewGuid", false, false);
+            var result = testObj.EditStartupForNewContext(startupType, parameters);
 
             Assert.True(result.Edited);
             Assert.Equal(afterStartupText, result.NewTree.GetText().ToString(), ignoreCase: false, ignoreLineEndingDifferences: true);

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/EntityFrameworkServicesTests.cs
@@ -104,8 +104,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
                 var efServicesSqlite = GetEfServices(path, appName, true);
 
                 var modelType = _modelTypesLocator.GetType("Library1.Models.Car").First();
-                var metadata = await efServices.GetModelMetadata("TestProject.Models.CarContext", modelType, string.Empty, false);
-                var metadataSqlite = await efServicesSqlite.GetModelMetadata("TestProject.Models.CarContext", modelType, string.Empty, true);
+                var metadata = await efServices.GetModelMetadata("TestProject.Models.CarContext", modelType, string.Empty, DbProvider.SqlServer);
+                var metadataSqlite = await efServicesSqlite.GetModelMetadata("TestProject.Models.CarContext", modelType, string.Empty, DbProvider.SQLite);
 
                 Assert.Equal(ContextProcessingStatus.ContextAvailable, metadata.ContextProcessingStatus);
                 Assert.Equal(3, metadata.ModelMetadata.Properties.Length);


### PR DESCRIPTION
addressing #2602
- removed `useSqLite` and `useSqlite` options from the `minimalapi` scaffolder completely.
- minor edits to minimalapi.json to reflect that.
- used feedback from the aforementioned issue.
- this will be for .NET 9 Preview 1+
