### PR TITLE
normalize line endings for blazor-identity changes

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -417,7 +417,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
             //write to Program.cs file
             var changedDocument = docEditor.GetChangedDocument();
             var classFileTxt = await changedDocument.GetTextAsync();
-            FileSystem.WriteAllText(programDocument.Name, classFileTxt.ToString());
+            var classFileString = classFileTxt.ToString();
+            classFileString = StringUtil.NormalizeLineEndings(classFileString);
+            FileSystem.WriteAllText(programDocument.Name, classFileString);
             Logger.LogMessage($"Modified {programDocument.Name}.\n");
         }
 
@@ -446,6 +448,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
                         FileSystem.CreateDirectory(folderName);
                     }
 
+                    templatedString = StringUtil.NormalizeLineEndings(templatedString);
                     FileSystem.WriteAllText(templatedFilePath, templatedString);
                     Logger.LogMessage($"Added Blazor identity file : {templatedFilePath}");
                 }
@@ -477,6 +480,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
                 }
 
                 string templatedFilePath = Path.Combine(identityDataPath, $"{model.UserClassName}.cs");
+                templatedString = StringUtil.NormalizeLineEndings(templatedString);
                 FileSystem.WriteAllText(templatedFilePath, templatedString);
                 Logger.LogMessage($"Added IdentityUser class : {templatedFilePath}");
             }
@@ -507,6 +511,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
                 }
 
                 string templatedFilePath = Path.Combine(identityDataPath, $"{model.DbContextName}.cs");
+                templatedString = StringUtil.NormalizeLineEndings(templatedString);
                 FileSystem.WriteAllText(templatedFilePath, templatedString);
                 Logger.LogMessage($"Added IdentityDbContext class : {templatedFilePath}");
             }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeAnalysisHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/CodeAnalysisHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
@@ -126,5 +126,11 @@ namespace Microsoft.DotNet.Scaffolding.Shared
             string[] parts = templateName.Split('.');
             return parts[parts.Length - 1];
         }
+
+        internal static string NormalizeLineEndings(string text)
+        {
+            //change all line endings to "\n" and then replace them with the appropriate ending
+            return text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", Environment.NewLine);
+        }
     }
 }


### PR DESCRIPTION
normalizes line endings to the appropriate ones regardless of OS (Environment.NewLine takes care of it).