### PR TITLE
Fork build pipeline for pr/ci

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,0 +1,114 @@
+pr:
+  branches:
+    include:
+    - '*'
+
+variables:
+  # Cannot use key:value syntax in root defined variables
+  - name: _TeamName
+    value: DotNetCore
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - template: /eng/common/templates/variables/pool-providers.yml
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableTelemetry: true
+      helixRepo: dotnet/scaffolding
+      codeSign: true
+      jobs:
+      - job: Windows_NT
+        timeoutInMinutes: 180
+        pool:
+          # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
+          # Will eventually change this to two BYOC pools.
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals 1es-windows-2019-open
+
+        variables:
+        - _Script: eng\common\cibuild.cmd
+        - _ValidateSdkArgs: ''
+        - _InternalBuildArgs: ''
+
+        strategy:
+          matrix:
+            Build_Release:
+              _BuildConfig: Release
+              # PRs or external builds are not signed.
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                _PublishType: none
+                _SignType: test
+                _DotNetPublishToBlobFeed : false
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              Build_Debug:
+                _BuildConfig: Debug
+                _PublishType: none
+                _SignType: test
+                _DotNetPublishToBlobFeed : false
+        steps:
+        - checkout: self
+          clean: true
+        # Use utility script to run script command dependent on agent OS.
+        - script: $(_Script)
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            $(_InternalBuildArgs)
+            $(_ValidateSdkArgs)
+          displayName: Windows Build / Publish
+
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        - job: OSX
+          timeoutInMinutes: 180
+          pool:
+            vmImage: macOS-11
+          strategy:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                debug_configuration:
+                  _BuildConfig: Debug
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+            name: Build
+            displayName: Build
+            condition: succeeded()
+
+        - job: Linux
+          timeoutInMinutes: 180
+          pool:
+            ${{ if or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+              vmImage: ubuntu-22.04
+          strategy:
+            matrix:
+              release_configuration:
+                _BuildConfig: Release
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                debug_configuration:
+                  _BuildConfig: Debug
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+            name: Build
+            displayName: Build
+            condition: succeeded()
+


### PR DESCRIPTION
This is just the first step of getting the build pipelines ready for 1ES pipeline template migration. Here we create a copy of the build pipeline that will be used for public/pr builds. Modifications to the file after copy are limited to removing conditionals that were relevant only to internal/ci builds. For review purposes its better to compare this new file with azure-pipelines.yml since its treated as a new file here.

Note that the PR build for this PR will still run against the old yml file. I'll swap over the public build to the new file once this PR completes.