### PR TITLE
Restore CI trigger for PR pipeline

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,3 +1,10 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - 'main'
+    - 'release/*'
+
 pr:
   branches:
     include:


### PR DESCRIPTION
Quick fix from #2665 - I removed the trigger altogether, which actually made CI _always_ run. On second thought I'll just put it back as it was.