### PR TITLE
Add helpful dev-time scripts

### DIFF
--- a/start-code.cmd
+++ b/start-code.cmd
@@ -1,0 +1,36 @@
+@ECHO OFF
+SETLOCAL
+
+:: This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
+
+FOR /f "delims=" %%a IN ('where.exe code') DO @SET vscode=%%a& GOTO break
+:break
+
+IF ["%vscode%"] == [""] (
+    echo [41m[ERROR][0m Visual Studio Code is not installed or can't be found.
+    echo.
+    exit /b 1
+)
+
+:: This tells .NET Core to use the same dotnet.exe that build scripts use
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
+
+:: This tells .NET Core not to go looking for .NET Core in other places
+SET DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
+    echo [41m[ERROR][0m .NET SDK has not yet been installed. Run [93m%~dp0build.cmd[0m once to install.
+    echo.
+    exit /b 1
+)
+
+IF ["%~1"] == [""] GOTO noargs
+"%vscode%" %*
+exit /b 1
+
+:noargs
+"%vscode%" "."

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,0 +1,23 @@
+@ECHO OFF
+SETLOCAL
+
+:: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
+
+:: This tells .NET Core to use the same dotnet.exe that build scripts use
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
+
+:: This tells .NET Core not to go looking for .NET Core in other places
+SET DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+SET sln=%~1
+
+IF "%sln%"=="" (
+    echo Solution not specified, using All.sln
+    SET sln=%~dp0All.sln
+)
+
+start "" "%sln%"


### PR DESCRIPTION
Pulls in a couple of scripts (slightly modified) we were using in [Aspire](https://github.com/dotnet/aspire) to help with the dev time experience.

Background:
- `.\build.cmd` will download and install the version of the .NET SDK specified in global.json to a local folder (the `.dotnet` folder). It then uses that SDK to build
- But if you open VS or VS Code directly, it doesn't know about that local version of the .NET SDK and will just use what is installed globally
- The new `.\startvs.cmd` and `.\start-code.cmd` will set the `DOTNET_ROOT` environment variable to the local installation of the .NET SDK before launching VS or VS Code so it'll be properly located

A couple notes:
- If `.sln` files aren't already associated with a particular instance of VS, the first launch of `.\startvs.cmd` may not work right (it seems to lose the environment variables when you have to select the instance of VS to launch). But subsequent launches should work
- You can still get into a mangled state if a) you have _some_ local installs of the .NET SDK b) the .NET SDK in global.json is _not_ installed locally, and c) the .NET SDK in global.json _is_ installed globally. In that case `.\build` won't install it locally, but VS/VSC won't see the global one because the local directory overrides the global one. In that case either delete the `.dotnet` folder or uninstall the global version.