### PR TITLE
Consolidate LangVersion on 'latest'

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -4,9 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.0.31423.177
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4057ACF-27F0-4724-963B-44548B6BC4E9}"
-	ProjectSection(SolutionItems) = preProject
-		src\Directory.Build.props = src\Directory.Build.props
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{81B64EBF-613D-43AE-82DA-B375FB751921}"
 EndProject
@@ -122,7 +119,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffoldin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffolding.ComponentModel", "src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj", "{A31A0E2D-F990-413C-91F6-8B5B8E570EC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Scaffolding.ComponentModel.Tests", "test\Shared\Microsoft.DotNet.Scaffolding.ComponentModel.Tests\Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj", "{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffolding.ComponentModel.Tests", "test\Shared\Microsoft.DotNet.Scaffolding.ComponentModel.Tests\Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj", "{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <OutputType>Library</OutputType>
     <SignAssembly>true</SignAssembly>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <!-- package settings -->

--- a/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
@@ -7,7 +7,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/dotnet-msidentity/dotnet-msidentity.csproj
+++ b/tools/dotnet-msidentity/dotnet-msidentity.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <SignAssembly>true</SignAssembly>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
    <Import Project="$(RepoRoot)eng\Versions.MSIdentity.props" />
   <!-- package settings -->

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Scaffolding tool for .NET projects. </Description>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,7 +8,6 @@
     <PackageTags>dotnet;scaffold</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold</RootNamespace>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
We have several different LangVersions specified in different places and overridden in others (including defaulting to an old old version 7.3 in D.B.props). Just a quick attempt to consolidate on `latest`, which appears to work for all projects currently.