### PR TITLE
adding 'dotnet-scaffold-aspire' and 'dotnet-scaffold-aspnet'

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -122,7 +122,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffoldin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffolding.ComponentModel", "src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj", "{A31A0E2D-F990-413C-91F6-8B5B8E570EC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Scaffolding.ComponentModel.Tests", "test\Shared\Microsoft.DotNet.Scaffolding.ComponentModel.Tests\Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj", "{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffolding.ComponentModel.Tests", "test\Shared\Microsoft.DotNet.Scaffolding.ComponentModel.Tests\Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj", "{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-scaffold-aspnet", "tools\dotnet-scaffold-aspnet\dotnet-scaffold-aspnet.csproj", "{289D2898-EC15-4496-9AF8-E20FAB151BFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-scaffold-aspire", "tools\dotnet-scaffold-aspire\dotnet-scaffold-aspire.csproj", "{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -749,6 +753,42 @@ Global
 		{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}.Release|x64.Build.0 = Release|Any CPU
 		{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}.Release|x86.ActiveCfg = Release|Any CPU
 		{F85BABAD-4C0B-419C-AE6A-BA95D259AB53}.Release|x86.Build.0 = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|x64.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|x64.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|x86.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.debug_x86|x86.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|x64.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Debug|x86.Build.0 = Debug|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|x64.ActiveCfg = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|x64.Build.0 = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|x86.ActiveCfg = Release|Any CPU
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE}.Release|x86.Build.0 = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|x64.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|x64.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|x86.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.debug_x86|x86.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|x64.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Debug|x86.Build.0 = Debug|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|x64.ActiveCfg = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|x64.Build.0 = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|x86.ActiveCfg = Release|Any CPU
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -795,6 +835,8 @@ Global
 		{E1F14286-FA19-47F2-8AB4-51B9DFA9EA27} = {06E6C642-BB9B-4946-8AAA-8A8A463CBA48}
 		{A31A0E2D-F990-413C-91F6-8B5B8E570EC5} = {06E6C642-BB9B-4946-8AAA-8A8A463CBA48}
 		{F85BABAD-4C0B-419C-AE6A-BA95D259AB53} = {CA1DAC77-5D18-4986-A4BB-F6171DEE5A52}
+		{289D2898-EC15-4496-9AF8-E20FAB151BFE} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
+		{E86098F3-69EF-4530-8ADD-D49EB8BBFA92} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {26BCDDB3-5505-4903-9D87-C942ED0D03E6}

--- a/eng/Versions.Scaffold.AspNet.props
+++ b/eng/Versions.Scaffold.AspNet.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Opt out of certain Arcade features -->
+  <PropertyGroup>
+    <UsingToolXliff>false</UsingToolXliff>
+    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
+    <!--
+        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
+    -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <SpectreConsoleVersion>0.47.0</SpectreConsoleVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/Versions.Scaffold.Aspire.props
+++ b/eng/Versions.Scaffold.Aspire.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Opt out of certain Arcade features -->
+  <PropertyGroup>
+    <UsingToolXliff>false</UsingToolXliff>
+    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
+    <!--
+        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
+    -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <SpectreConsoleVersion>0.47.0</SpectreConsoleVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/CommandInfo.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/CommandInfo.cs
@@ -11,6 +11,7 @@ public class CommandInfo
 {
     public required string Name { get; init; }
     public required string DisplayName { get; init; }
+    public required string DisplayCategory { get; init; }
     public string? Description { get; set; }
     public required Parameter[] Parameters { get; init; }
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Parameter.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Parameter.cs
@@ -52,5 +52,6 @@ public enum InteractivePickerType
 {
     ClassPicker,
     FilePicker,
-    DbProviderPicker
+    DbProviderPicker,
+    ProjectPicker
 }

--- a/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/CommandInfoTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/CommandInfoTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
             {
                 Name = "command1",
                 DisplayName = "Command 1",
+                DisplayCategory = "General",
                 Description = "Description 1",
                 Parameters = [ValidParameter]
             };
@@ -56,6 +57,7 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
             {
                 Name = "command2",
                 DisplayName = "Command 2",
+                DisplayCategory = "General",
                 Parameters =
                 [
                     ValidParameter, PartialParameter
@@ -66,6 +68,7 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
             {
                 Name = "command3",
                 DisplayName = "Command 3",
+                DisplayCategory = "General",
                 Description = null,
                 Parameters =
                 [

--- a/tools/dotnet-scaffold-aspire/AnsiConsoleLogger.cs
+++ b/tools/dotnet-scaffold-aspire/AnsiConsoleLogger.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire
+{
+    internal class AnsiConsoleLogger : ILogger
+    {
+        private readonly bool _jsonOutput;
+        private readonly bool _silent;
+        private static bool isTrace = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("codegen_trace"));
+        public bool IsTracing => isTrace;
+
+        private string CommandName { get; }
+
+        public AnsiConsoleLogger(string? commandName = null, bool jsonOutput = false, bool silent = false)
+        {
+            CommandName = commandName ?? string.Empty;
+            _jsonOutput = jsonOutput;
+            _silent = silent;
+            AnsiConsole.Console.Profile.Encoding = Encoding.UTF8;
+        }
+
+        public void LogMessage(string? message, LogMessageType level, bool removeNewLine = false)
+        {
+            //if json output is enabled, don't write to console at all.
+            if (!_silent && !_jsonOutput && !string.IsNullOrEmpty(message))
+            {
+                switch (level)
+                {
+                    case LogMessageType.Error:
+                        if (removeNewLine)
+                        {
+                            AnsiConsole.Console.Markup($"[red]{message}");
+                        }
+                        else
+                        {
+                            AnsiConsole.Console.MarkupLine($"[red]{message}");
+                        }
+                        break;
+                    case LogMessageType.Information:
+                        if (removeNewLine)
+                        {
+                            AnsiConsole.Console.Write(message);
+                        }
+                        else
+                        {
+                            AnsiConsole.Console.WriteLine(message);
+                        }
+                        break;
+                }
+            }
+        }
+
+        public void LogJsonMessage(string? state = null, object? content = null, string? output = null)
+        {
+            if (!_silent)
+            {
+                if (_jsonOutput)
+                {
+                    var jsonMessage = new JsonResponse(CommandName, state, content, output);
+                    AnsiConsole.WriteLine(jsonMessage.ToJsonString());
+                }
+                else
+                {
+                    if (state == State.Fail)
+                    {
+                        LogMessage(output, LogMessageType.Error);
+                    }
+                    else
+                    {
+                        LogMessage(output);
+                    }
+                }
+            }
+        }
+
+        public void LogMessage(string? message, bool removeNewLine = false)
+        {
+            if (!_silent && !_jsonOutput)
+            {
+                LogMessage(message, LogMessageType.Information, removeNewLine);
+            }
+        }
+
+        public void LogFailureAndExit(string failureMessage)
+        {
+            if (_jsonOutput)
+            {
+                LogJsonMessage(State.Fail, output: failureMessage);
+            }
+            else
+            {
+                LogMessage(failureMessage, LogMessageType.Error);
+            }
+
+            Environment.Exit(1);
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspire/AppBuilder/TypeRegistrar.cs
+++ b/tools/dotnet-scaffold-aspire/AppBuilder/TypeRegistrar.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire.AppBuilder;
+
+internal sealed class TypeRegistrar : ITypeRegistrar
+{
+    private readonly IServiceCollection _services;
+
+    public TypeRegistrar()
+    {
+        _services = new ServiceCollection();
+    }
+
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(_services.BuildServiceProvider());
+    }
+
+    public void Register(Type service, Type implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterInstance(Type service, object implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterLazy(Type service, Func<object> func)
+    {
+        if (func is null)
+        {
+            throw new ArgumentNullException(nameof(func));
+        }
+
+        _services.AddSingleton(service, (provider) => func());
+    }
+}

--- a/tools/dotnet-scaffold-aspire/AppBuilder/TypeResolver.cs
+++ b/tools/dotnet-scaffold-aspire/AppBuilder/TypeResolver.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire.AppBuilder;
+
+internal sealed class TypeResolver : ITypeResolver, IDisposable
+{
+    private readonly IServiceProvider _provider;
+
+    public TypeResolver(IServiceProvider serviceProvider)
+    {
+        _provider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    public object? Resolve(Type? type)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        return _provider.GetService(type);
+    }
+
+    public void Dispose()
+    {
+        if (_provider is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Scaffolding.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
+{
+    public class GetCmdsCommand : Command
+    {
+        public override int Execute(CommandContext context)
+        {
+            var commands = new List<CommandInfo>
+            {
+                new CommandInfo
+                {
+                    Name = "redis",
+                    DisplayName = "Redis",
+                    DisplayCategory = "Aspire",
+                    Description = "Modifies Aspire project to make it redis ready",
+                    Parameters = GetCmdsHelper.RedisParameters
+                }
+                // Add other commands here
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(commands);
+            AnsiConsole.WriteLine(json);
+            return 0;
+        }
+    }
+
+    public static class GetCmdsHelper
+    {
+        internal static Parameter ProjectParameter = new() { Name = "--project", DisplayName = "Project Name", Description = "Project of choice for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
+        internal static Parameter[] RedisParameters = [ProjectParameter];
+    }
+}

--- a/tools/dotnet-scaffold-aspire/Commands/RedisCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/RedisCommand.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Spectre.Console.Cli;
+using Spectre.Console;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
+{
+    public class RedisCommand : Command<RedisCommand.RedisCommandSettings>
+    {
+        public override int Execute([NotNull] CommandContext context, [NotNull] RedisCommandSettings settings)
+        {
+            AnsiConsole.MarkupLine("[green]Executing redis command...[/]");
+            AnsiConsole.MarkupLine("\nDONE!");
+            return 0;;
+        }
+
+        public class RedisCommandSettings : CommandSettings
+        {
+            [CommandOption("--project <PROJECT>")]
+            public string Project { get; set; } = default!;
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspire/Helpers/SpectreExtensions.cs
+++ b/tools/dotnet-scaffold-aspire/Helpers/SpectreExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers
+{
+    internal static class SpectreExtensions
+    {
+        public static Status WithSpinner(this Status status)
+        {
+            return status
+                .AutoRefresh(true)
+                .Spinner(Spinner.Known.Aesthetic)
+                .SpinnerStyle(Style.Parse("lightseagreen"));
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspire/Program.cs
+++ b/tools/dotnet-scaffold-aspire/Program.cs
@@ -1,0 +1,39 @@
+using Microsoft.DotNet.Scaffolding.Helpers.Environment;
+using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.DotNet.Tools.Scaffold.Aspire.AppBuilder;
+using Microsoft.DotNet.Tools.Scaffold.Aspire.Commands;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Aspire;
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var serviceRegistrations = GetDefaultServices();
+        var app = new CommandApp(serviceRegistrations);
+        app.Configure(config =>
+        {
+            config.AddCommand<RedisCommand>("redis");
+            config.AddCommand<GetCmdsCommand>("get-commands");
+        });
+
+        app.Run(args);
+    }
+
+    private static ITypeRegistrar? GetDefaultServices()
+    {
+        var registrar = new TypeRegistrar();
+        registrar.Register(typeof(IAppSettings), typeof(AppSettings));
+        registrar.Register(typeof(IFileSystem), typeof(FileSystem));
+        registrar.Register(typeof(IEnvironmentService), typeof(EnvironmentService));
+        registrar.Register(typeof(IDotNetToolService), typeof(DotNetToolService));
+        registrar.Register(typeof(ILogger), typeof(AnsiConsoleLogger));
+        registrar.Register(typeof(IEnvironmentVariableProvider), typeof(MacMsbuildEnvironmentVariableProvider));
+        registrar.Register(typeof(IEnvironmentVariableProvider), typeof(WindowsEnvironmentVariableProvider));
+        registrar.Register(typeof(IHostService), typeof(HostService));
+        registrar.Register(typeof(ICodeService), typeof(CodeService));
+        return registrar;
+    }
+}
+

--- a/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Scaffolding tool for .NET Aspire scenarios</Description>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>exe</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackAsTool>true</PackAsTool>
+    <PackageTags>dotnet;scaffold;aspire;</PackageTags>
+    <PackageId>Microsoft.dotnet-scaffold-aspire</PackageId>
+    <RootNamespace>Microsoft.DotNet.Tools.Scaffold.Aspire</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)eng\Versions.Scaffold.Aspire.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console" Version="$(SpectreConsoleVersion)" />
+    <PackageReference Include="Spectre.Console.Cli" Version="$(SpectreConsoleVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.Helpers\Microsoft.DotNet.Scaffolding.Helpers.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold.Aspire</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.Aspire.props" />

--- a/tools/dotnet-scaffold-aspnet/AnsiConsoleLogger.cs
+++ b/tools/dotnet-scaffold-aspnet/AnsiConsoleLogger.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet
+{
+    internal class AnsiConsoleLogger : ILogger
+    {
+        private readonly bool _jsonOutput;
+        private readonly bool _silent;
+        private static bool isTrace = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("codegen_trace"));
+        public bool IsTracing => isTrace;
+
+        private string CommandName { get; }
+
+        public AnsiConsoleLogger(string? commandName = null, bool jsonOutput = false, bool silent = false)
+        {
+            CommandName = commandName ?? string.Empty;
+            _jsonOutput = jsonOutput;
+            _silent = silent;
+            AnsiConsole.Console.Profile.Encoding = Encoding.UTF8;
+        }
+
+        public void LogMessage(string? message, LogMessageType level, bool removeNewLine = false)
+        {
+            //if json output is enabled, don't write to console at all.
+            if (!_silent && !_jsonOutput && !string.IsNullOrEmpty(message))
+            {
+                switch (level)
+                {
+                    case LogMessageType.Error:
+                        if (removeNewLine)
+                        {
+                            AnsiConsole.Console.Markup($"[red]{message}");
+                        }
+                        else
+                        {
+                            AnsiConsole.Console.MarkupLine($"[red]{message}");
+                        }
+                        break;
+                    case LogMessageType.Information:
+                        if (removeNewLine)
+                        {
+                            AnsiConsole.Console.Write(message);
+                        }
+                        else
+                        {
+                            AnsiConsole.Console.WriteLine(message);
+                        }
+                        break;
+                }
+            }
+        }
+
+        public void LogJsonMessage(string? state = null, object? content = null, string? output = null)
+        {
+            if (!_silent)
+            {
+                if (_jsonOutput)
+                {
+                    var jsonMessage = new JsonResponse(CommandName, state, content, output);
+                    AnsiConsole.WriteLine(jsonMessage.ToJsonString());
+                }
+                else
+                {
+                    if (state == State.Fail)
+                    {
+                        LogMessage(output, LogMessageType.Error);
+                    }
+                    else
+                    {
+                        LogMessage(output);
+                    }
+                }
+            }
+        }
+
+        public void LogMessage(string? message, bool removeNewLine = false)
+        {
+            if (!_silent && !_jsonOutput)
+            {
+                LogMessage(message, LogMessageType.Information, removeNewLine);
+            }
+        }
+
+        public void LogFailureAndExit(string failureMessage)
+        {
+            if (_jsonOutput)
+            {
+                LogJsonMessage(State.Fail, output: failureMessage);
+            }
+            else
+            {
+                LogMessage(failureMessage, LogMessageType.Error);
+            }
+
+            Environment.Exit(1);
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/AppBuilder/TypeRegistrar.cs
+++ b/tools/dotnet-scaffold-aspnet/AppBuilder/TypeRegistrar.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
+
+internal sealed class TypeRegistrar : ITypeRegistrar
+{
+    private readonly IServiceCollection _services;
+
+    public TypeRegistrar()
+    {
+        _services = new ServiceCollection();
+    }
+
+    public ITypeResolver Build()
+    {
+        return new TypeResolver(_services.BuildServiceProvider());
+    }
+
+    public void Register(Type service, Type implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterInstance(Type service, object implementation)
+    {
+        _services.AddSingleton(service, implementation);
+    }
+
+    public void RegisterLazy(Type service, Func<object> func)
+    {
+        if (func is null)
+        {
+            throw new ArgumentNullException(nameof(func));
+        }
+
+        _services.AddSingleton(service, (provider) => func());
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/AppBuilder/TypeResolver.cs
+++ b/tools/dotnet-scaffold-aspnet/AppBuilder/TypeResolver.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
+
+internal sealed class TypeResolver : ITypeResolver, IDisposable
+{
+    private readonly IServiceProvider _provider;
+
+    public TypeResolver(IServiceProvider serviceProvider)
+    {
+        _provider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    public object? Resolve(Type? type)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        return _provider.GetService(type);
+    }
+
+    public void Dispose()
+    {
+        if (_provider is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Commands/AreaCommand.cs
+++ b/tools/dotnet-scaffold-aspnet/Commands/AreaCommand.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Spectre.Console.Cli;
+using Spectre.Console;
+using System.IO;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
+{
+    public class AreaCommand : Command<AreaCommand.AreaSettings>
+    {
+        public override int Execute([NotNull] CommandContext context, [NotNull] AreaSettings settings)
+        {
+            AnsiConsole.MarkupLine("[green]Executing area command...[/]");
+            if (string.IsNullOrEmpty(settings.Name))
+            {
+                AnsiConsole.WriteException(new ArgumentNullException("'--name' parameter required for area"));
+            }
+
+            if (string.IsNullOrEmpty(settings.Project))
+            {
+                AnsiConsole.WriteException(new ArgumentNullException("'--project' parameter required for area"));
+            }
+
+            var projectDirectory = Path.GetDirectoryName(settings.Project);
+
+            EnsureFolderLayout(projectDirectory, settings.Name);
+            return 0;;
+        }
+
+        private void EnsureFolderLayout(string? basePath, string areaName)
+        {
+            var currDirectory = basePath ?? Environment.CurrentDirectory;
+            var areaBasePath = Path.Combine(currDirectory, "Areas");
+            if (!Directory.Exists(areaBasePath))
+            {
+                Directory.CreateDirectory(areaBasePath);
+            }
+
+            var areaPath = Path.Combine(areaBasePath, areaName);
+            if (!Directory.Exists(areaPath))
+            {
+                Directory.CreateDirectory(areaPath);
+            }
+
+            foreach (var areaFolder in AreaFolders)
+            {
+                var path = Path.Combine(areaPath, areaFolder);
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(path);
+                }
+            }
+        }
+
+        private static readonly string[] AreaFolders =
+        [
+            "Controllers",
+            "Models",
+            "Data",
+            "Views"
+        ];
+
+        public class AreaSettings : CommandSettings
+        {
+            [CommandOption("--project <PROJECT>")]
+            public string Project { get; set; } = default!;
+
+            [CommandOption("--name <NAME>")]
+            public string Name { get; set; } = default!;
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Commands/GetCommands.cs
+++ b/tools/dotnet-scaffold-aspnet/Commands/GetCommands.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Microsoft.DotNet.Scaffolding.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
+{
+    public class GetCmdsCommand : Command
+    {
+        public override int Execute(CommandContext context)
+        {
+            var commands = new List<CommandInfo>
+            {
+                new CommandInfo
+                {
+                    Name = "minimalapi",
+                    DisplayName = "Minimal API",
+                    DisplayCategory = "API",
+                    Description = "Generates an endpoints file (with CRUD API endpoints) given a model and optional DbContext.",
+                    Parameters = GetCmdsHelper.MinimalApiParameters // Add parameters if any
+                },
+                new CommandInfo
+                {
+                    Name = "area",
+                    DisplayName = "Area",
+                    DisplayCategory = "MVC",
+                    Description = "Generates an Area folder structure.",
+                    Parameters = GetCmdsHelper.AreaParameters // Add parameters if any
+                }
+                // Add other commands here
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(commands);
+            AnsiConsole.WriteLine(json);
+            return 0;
+        }
+    }
+
+    public static class GetCmdsHelper
+    {
+        internal static Parameter ModelName = new()  { Name = "--model", DisplayName = "Model Name", Description = "Name for the model class to be used for scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ClassPicker };
+        internal static Parameter EndpointsClass = new()  { Name = "--endpoints", DisplayName = "Endpoints File Name", Description = "", Required = true, Type = BaseTypes.String };
+        internal static Parameter DataContextClass = new() { Name = "--dataContext", DisplayName = "Data Context Class", Description = "", Required = false, Type = BaseTypes.String, PickerType = InteractivePickerType.ClassPicker };
+        internal static Parameter RelativeFolderPath = new() { Name = "--relativeFolderPath", DisplayName = "Relative Folder Path", Description = "The relative folder path where scaffolded files will be added", Required = false, Type = BaseTypes.String };
+        internal static Parameter OpenApi = new() { Name = "--open", DisplayName = "Open API Enabled", Description = "", Required = false, Type = BaseTypes.Bool };
+        internal static Parameter DatabaseProvider = new() { Name = "--dbProvider", DisplayName = "Database Provider", Description = "", Required = false, Type = BaseTypes.String, PickerType = InteractivePickerType.DbProviderPicker };
+        internal static Parameter AreaName = new() { Name = "--name", DisplayName = "Area Name", Description = "Name for the area being created", Required = true, Type = BaseTypes.String };
+        internal static Parameter[] AreaParameters = [AreaName];
+        internal static Parameter[] MinimalApiParameters = [ModelName, EndpointsClass, DataContextClass, OpenApi, DatabaseProvider];
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiCommand.cs
+++ b/tools/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiCommand.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi
+{
+    public class MinimalApiCommand : Command<MinimalApiCommand.MinimalApiSettings>
+    {
+        private readonly IAppSettings _appSettings;
+        private readonly IFileSystem _fileSystem;
+        private readonly ILogger _logger;
+        private readonly IEnvironmentService _environmentService;
+        private readonly IHostService _hostService;
+        private readonly ICodeService _codeService;
+        private List<string> _excludeList;
+
+        public MinimalApiCommand(
+            IAppSettings appSettings,
+            IEnvironmentService environmentService,
+            IFileSystem fileSystem,
+            IHostService hostService,
+            ICodeService codeService,
+            ILogger logger)
+        {
+            _appSettings = appSettings;
+            _environmentService = environmentService;
+            _fileSystem = fileSystem;
+            _hostService = hostService;
+            _logger = logger;
+            _codeService = codeService;
+            _excludeList = [];
+        }
+
+        public override int Execute([NotNull] CommandContext context, [NotNull] MinimalApiSettings settings)
+        {
+            AnsiConsole.MarkupLine("[green]Executing minimalapi command...[/]");
+            //setup project settings
+            _appSettings.AddSettings("workspace", new WorkspaceSettings());
+            _appSettings.Workspace().InputPath = settings.Project;
+            AnsiConsole.MarkupLine("\n[green]DONE![/]");
+            return 0;
+        }
+
+        public class MinimalApiSettings : CommandSettings
+        {
+            [CommandOption("--project <PROJECT>")]
+            public string Project { get; set; } = default!;
+
+            [CommandOption("--model <MODEL>")]
+            public string Model { get; set; } = default!;
+
+            [CommandOption("--endpoints <ENDPOINTS>")]
+            public string Endpoints { get; set; } = default!;
+
+            [CommandOption("--dataContext <DATACONTEXT>")]
+            public string DataContext { get; set; } = default!;
+
+            [CommandOption("--relativeFolderPath <FOLDERPATH>")]
+            public string RelativeFolderPath { get; set; } = default!;
+
+            [CommandOption("--open")]
+            public bool Open { get; set; }
+
+            [CommandOption("--dbProvider <DBPROVIDER>")]
+            public string DatabaseProvider { get; set; } = default!;
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiModel.cs
+++ b/tools/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiModel.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi
+{
+    public class MinimalApiModel
+    {
+        //Endpoints class name
+        public string? EndpointsName { get; set; }
+        public string EndpointsFileName { get; set; } = default!;
+        public string? EndpointsPath { get; set; }
+        public string? DbContextClassName { get; set; }
+        public string? DbContextClassPath { get; set; }
+        public string? DatabaseProvider  { get; set; }
+        public string? EntitySetName { get; set; }
+        public string? PrimaryKeyName { get; set; }
+        public string? PrimaryKeyShortTypeName { get; set; }
+        public string? PrimaryKeyTypeName { get; set; }
+        public bool EfScenario { get; set; }
+        public bool NullableEnabled { get; set; }
+        public List<string>? ModelProperties { get; set; }
+        public string? ModelNamespace { get; set; }
+
+        //If CRUD endpoints support Open API
+        public bool OpenAPI { get; set; }
+
+        //Use TypedResults for minimal apis.
+        public bool UseTypedResults { get; set; }
+
+        //Generated namespace for a Endpoints class/file. If using an existing file, does not apply.
+        public string? EndpointsNamespace { get; set; }
+
+        //Method name for the new static method with the CRUD endpoints.
+        public string? MethodName { get; set; }
+
+        //Model class' name
+        public string ModelTypeName { get; set; } = default!;
+
+        private string? _modelTypePluralName;
+        public string ModelTypePluralName
+        {
+            get
+            {
+                if (_modelTypePluralName == null)
+                {
+                    _modelTypePluralName = "plurals";
+                }
+
+                return _modelTypePluralName;
+            }
+        }
+
+        //Model class' name but lower case
+        public string ModelVariable
+        {
+            get
+            {
+                return "";
+            }
+        }
+
+        //variable name holding the models in the DbContext class
+        public string EntitySetVariable
+        {
+            get
+            {
+                return "";
+            }
+        }
+
+        public string? DbContextNamespace { get; private set; }
+        public string? RelativeFolderPath { get; internal set; }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Helpers/SpectreExtensions.cs
+++ b/tools/dotnet-scaffold-aspnet/Helpers/SpectreExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers
+{
+    internal static class SpectreExtensions
+    {
+        public static Status WithSpinner(this Status status)
+        {
+            return status
+                .AutoRefresh(true)
+                .Spinner(Spinner.Known.Aesthetic)
+                .SpinnerStyle(Style.Parse("lightseagreen"));
+        }
+    }
+}

--- a/tools/dotnet-scaffold-aspnet/Program.cs
+++ b/tools/dotnet-scaffold-aspnet/Program.cs
@@ -1,0 +1,42 @@
+using Microsoft.DotNet.Scaffolding.Helpers.Environment;
+using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands;
+using Spectre.Console.Cli;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet;
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var serviceRegistrations = GetDefaultServices();
+        var app = new CommandApp(serviceRegistrations);
+        app.Configure(config =>
+        {
+            config.AddCommand<MinimalApiCommand>("minimalapi");
+            config.AddCommand<AreaCommand>("area");
+            config.AddCommand<GetCmdsCommand>("get-commands");
+        });
+
+        app.Run(args);
+    }
+
+    private static ITypeRegistrar? GetDefaultServices()
+    {
+        var registrar = new TypeRegistrar();
+        registrar.Register(typeof(IAppSettings), typeof(AppSettings));
+        registrar.Register(typeof(IFileSystem), typeof(FileSystem));
+        registrar.Register(typeof(IEnvironmentService), typeof(EnvironmentService));
+        registrar.Register(typeof(IDotNetToolService), typeof(DotNetToolService));
+        registrar.Register(typeof(ILogger), typeof(AnsiConsoleLogger));
+        registrar.Register(typeof(IEnvironmentVariableProvider), typeof(MacMsbuildEnvironmentVariableProvider));
+        registrar.Register(typeof(IEnvironmentVariableProvider), typeof(WindowsEnvironmentVariableProvider));
+        registrar.Register(typeof(IHostService), typeof(HostService));
+        registrar.Register(typeof(ICodeService), typeof(CodeService));
+        return registrar;
+    }
+}
+

--- a/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
+++ b/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold.AspNet</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.AspNet.props" />

--- a/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
+++ b/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Scaffolding tool with specific components</Description>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>exe</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackAsTool>true</PackAsTool>
+    <PackageTags>dotnet;scaffold;aspnet;</PackageTags>
+    <PackageId>Microsoft.dotnet-scaffold-aspnet</PackageId>
+    <RootNamespace>Microsoft.DotNet.Tools.Scaffold.AspNet</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)eng\Versions.Scaffold.AspNet.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console" Version="$(SpectreConsoleVersion)" />
+    <PackageReference Include="Spectre.Console.Cli" Version="$(SpectreConsoleVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.Helpers\Microsoft.DotNet.Scaffolding.Helpers.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
adding mostly hollow dotnet-scaffold-aspire and dotnet-scaffold-aspnet
- there is duplicate code for Specter.Console helpers. Currently do not want to add a dependency of Spectre.Console onto the Shared helper projects (Will abstract this work to a Spectre.Console.Helper project).
- Mostly hollow cmdline apps that execute 'get-commands' and will be filled out soon.