### PR TITLE
Invert nullable default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/Microsoft.DotNet.MSIdentity.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <OutputType>Library</OutputType>
     <SignAssembly>true</SignAssembly>
@@ -22,7 +21,7 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.MSIdentity.props" />
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />

--- a/src/Scaffolding/VS.Web.CG.Core/VS.Web.CG.Core.csproj
+++ b/src/Scaffolding/VS.Web.CG.Core/VS.Web.CG.Core.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/Scaffolding/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -11,8 +11,9 @@
     <PackageId>Microsoft.VisualStudio.Web.CodeGeneration.Design</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\Shared\Microsoft.DotNet.Scaffolding.Shared\Microsoft.DotNet.Scaffolding.Shared.csproj" />
   </ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
+++ b/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
+++ b/src/Scaffolding/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Msbuild</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Msbuild</RootNamespace>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
+++ b/src/Scaffolding/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;aspnetcoremvc;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <!-- This embedded resource is also packaged in order to allow VS to inspect the file. -->
@@ -64,7 +65,7 @@
     <None Pack="true" Include="Templates\Identity\Bootstrap3\wwwroot\lib\jquery-validation\*" PackagePath="Templates\Identity_Versioned\Bootstrap3\wwwroot\lib\jquery-validation\" />
     <None Pack="true" Include="Templates\Identity\Bootstrap3\wwwroot\lib\jquery-validation\dist\*" PackagePath="Templates\Identity_Versioned\Bootstrap3\wwwroot\lib\jquery-validation\dist\" />
     <None Pack="true" Include="Templates\Identity\Bootstrap3\wwwroot\lib\jquery-validation-unobtrusive\*" PackagePath="Templates\Identity_Versioned\Bootstrap3\wwwroot\lib\jquery-validation-unobtrusive\" />
-    
+
     <!-- Identity Bootstrap4 -->
     <None Pack="true" Include="Templates\Identity\Bootstrap4\*" PackagePath="Templates\Identity_Versioned\Bootstrap4\" />
     <None Pack="true" Include="Templates\Identity\Bootstrap4\Data\*" PackagePath="Templates\Identity_Versioned\Bootstrap4\Data\" />

--- a/src/Scaffolding/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
+++ b/src/Scaffolding/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/Scaffolding/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Scaffolding/VS.Web.CG/VS.Web.CG.csproj
+++ b/src/Scaffolding/VS.Web.CG/VS.Web.CG.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.props" />
-  
+
 </Project>

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
@@ -3,11 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.props" />
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" />

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Microsoft.DotNet.Scaffolding.Shared.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/Microsoft.DotNet.MSIdentity.Tests.csproj
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/Microsoft.DotNet.MSIdentity.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.UnitTests.Tests/Microsoft.DotNet.MSIdentity.UnitTests.Tests.csproj
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.UnitTests.Tests/Microsoft.DotNet.MSIdentity.UnitTests.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/E2E_Test/E2E_Test.Tests.csproj
+++ b/test/Scaffolding/E2E_Test/E2E_Test.Tests.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\src\Shared\Cli.Utils\*.cs" /> 
+    <Compile Include="..\..\src\Shared\Cli.Utils\*.cs" />
     <Compile Include="..\Shared\*.cs">
       <Link>Shared\%(RecursiveDir)%(FileName)</Link>
     </Compile>

--- a/test/Scaffolding/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
+++ b/test/Scaffolding/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <Import Project="$(RepoRoot)test\Scaffolding\TestPackage.props" />
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Core.FunctionalTest/VS.Web.CG.Core.FunctionalTests.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Core.FunctionalTest/VS.Web.CG.Core.FunctionalTests.Tests.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Core.FunctionalTest</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IncludeSymbols>true</IncludeSymbols>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Core.Test/VS.Web.CG.Core.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Core.Test/VS.Web.CG.Core.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Core.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Core</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.EFCore.Test/VS.Web.CG.EFCore.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.EFCore.Test/VS.Web.CG.EFCore.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.MSBuild.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.MSBuild</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Mvc.Test/VS.Web.CG.Mvc.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Mvc.Test/VS.Web.CG.Mvc.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGenerators.Mvc</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Sources.Test/VS.Web.CG.Sources.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Sources.Test/VS.Web.CG.Sources.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Sources.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Sources</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Templating.Test/VS.Web.CG.Templating.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Templating.Test/VS.Web.CG.Templating.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Templating.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Templating</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Scaffolding/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Tests.csproj
+++ b/test/Scaffolding/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Tools.Test</AssemblyName>
     <RootNamespace>Microsoft.VisualStudio.Web.CodeGeneration.Tools</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/Microsoft.DotNet.Scaffolding.ComponentModel.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/Microsoft.DotNet.Scaffolding.Shared.Tests.csproj
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/Microsoft.DotNet.Scaffolding.Shared.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(StandardTestTfms)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/tools/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -11,6 +11,7 @@
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
     <PackageTags>dotnet;aspnet-codegenerator</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <!-- workaround for https://github.com/dotnet/sdk/issues/2698 -->
@@ -34,9 +35,9 @@
   <ItemGroup>
     <None Include="$(RepoRoot)\src\Scaffolding\VS.Web.CG.Msbuild\Target\build\Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets" CopyToPublishDirectory="Always" Link="build\microsoft.visualstudio.web.codegeneration.tools.targets" />
     <None Include="$(RepoRoot)\src\Scaffolding\VS.Web.CG.Msbuild\Target\buildMultiTargeting\Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets" CopyToPublishDirectory="Always" Link="buildMultiTargeting\microsoft.visualstudio.web.codegeneration.tools.targets" />
-    <None Include="$(ArtifactsBinDir)\VS.Web.CG.Msbuild\$(Configuration)\net8.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" CopyToPublishDirectory="Always" Link="toolassets\net8.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" />  
+    <None Include="$(ArtifactsBinDir)\VS.Web.CG.Msbuild\$(Configuration)\net8.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" CopyToPublishDirectory="Always" Link="toolassets\net8.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll" />
     <None Include="$(RepoRoot)\src\Scaffolding\README.md" Pack="true" PackagePath="\"/>
-  </ItemGroup> 
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/tools/dotnet-msidentity/dotnet-msidentity.csproj
+++ b/tools/dotnet-msidentity/dotnet-msidentity.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.MSIdentity</RootNamespace>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -26,7 +25,7 @@
     <Description>
       This package is a dotnet global tool which registers new Azure AD or Azure AD B2C applications, and updates your code accordingly, or modifies/edits existing
       Azure AD or Azure AD B2C app registrations and updates the project. This tool automates the steps of going to the portal UI for app registration and also updates
-      the corresponding code for that application. With this tool, you can develop and register an ASP.NET Core web app, web API, gRPC service or Azure Function 
+      the corresponding code for that application. With this tool, you can develop and register an ASP.NET Core web app, web API, gRPC service or Azure Function
       protected with the Microsoft identity platform, which can call Microsoft Graph or downstream web APIs.
       For details see https://aka.ms/dotnet-msidentity. Works with ASP.NET Core 3.1 and .NET 5.0, 6.0 projects.
     </Description>
@@ -41,7 +40,7 @@
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\"/>
     <None Include="$(RepoRoot)\tools\dotnet-msidentity\README.md" Pack="true" PackagePath="\"/>
-  </ItemGroup> 
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="ProjectDescriptions\**" />

--- a/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -9,8 +9,6 @@
     <PackageTags>dotnet;scaffold;aspire;</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold-aspire</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold.Aspire</RootNamespace>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
@@ -21,7 +19,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="$(SpectreConsoleVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.Helpers\Microsoft.DotNet.Scaffolding.Helpers.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj" />

--- a/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
+++ b/tools/dotnet-scaffold-aspnet/dotnet-scaffold-aspnet.csproj
@@ -9,8 +9,6 @@
     <PackageTags>dotnet;scaffold;aspnet;</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold-aspnet</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold.AspNet</RootNamespace>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
@@ -21,7 +19,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="$(SpectreConsoleVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.Helpers\Microsoft.DotNet.Scaffolding.Helpers.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj" />

--- a/tools/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/tools/dotnet-scaffold/dotnet-scaffold.csproj
@@ -8,7 +8,6 @@
     <PackageTags>dotnet;scaffold</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold</RootNamespace>
-    <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
Related to #2732 

Previously the default for `<Nullable>` in the repo was not specified (thus making it `disable`). This meant that each time we added a new project we needed to remember to add `<Nullable>enable</Nullable>` to it, even though that really should be the default.

This PR inverts the default, setting `<Nullable>enable</Nullable>` at the root in D.B.props, removing the same from any existing projects that have it and adding `<Nullable>disable</Nullable>` to any projects that require code changes.

I intentionally did not make any code changes here to keep this PR clean (since it already touched a lot of files) even though some projects likely required minimal changes to support nullable types.

Note that I intentionally did not try to use deeper D.B.props files even when all or most of the projects within a subfolder needed nullable types disabled. This will make it easier for us to know how many projects are left and keep the changes isolated to one project at a time as we go through and do it. 

I also dropped a few `<LangVersion>latest</LangVersion>` that snuck in via #2737 since that was in flight already when I did #2736