### PR TITLE
added CategoryPickerFlowStep and FirstPartComponentInitializer

### DIFF
--- a/scripts/install-scaffold-aspire.cmd
+++ b/scripts/install-scaffold-aspire.cmd
@@ -1,0 +1,17 @@
+set VERSION=0.1.0-dev
+set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
+set SRC_DIR=%cd%
+set NUPKG=artifacts/packages/Debug/Shipping/
+call taskkill /f /im dotnet.exe
+call rd /Q /S artifacts
+call dotnet pack tools\dotnet-scaffold-aspire\dotnet-scaffold-aspire.csproj -c Debug
+call dotnet tool uninstall -g Microsoft.dotnet-scaffold-aspire
+
+call cd %DEFAULT_NUPKG_PATH%
+call rd /Q /S Microsoft.dotnet-scaffold-aspire
+call rd /Q /S Microsoft.DotNet.Scaffolding.Helpers
+call rd /Q /S Microsoft.DotNet.Scaffolding.ComponentModel
+
+call cd  %SRC_DIR%/%NUPKG% 
+call dotnet tool install -g Microsoft.dotnet-scaffold-aspire --add-source %SRC_DIR%\%NUPKG% --version %VERSION%
+call cd %SRC_DIR%

--- a/scripts/install-scaffold-aspnet.cmd
+++ b/scripts/install-scaffold-aspnet.cmd
@@ -1,0 +1,17 @@
+set VERSION=0.1.0-dev
+set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
+set SRC_DIR=%cd%
+set NUPKG=artifacts/packages/Debug/Shipping/
+call taskkill /f /im dotnet.exe
+call rd /Q /S artifacts
+call dotnet pack tools\dotnet-scaffold-aspnet\dotnet-scaffold-aspnet.csproj -c Debug
+call dotnet tool uninstall -g Microsoft.dotnet-scaffold-aspnet
+
+call cd %DEFAULT_NUPKG_PATH%
+call rd /Q /S Microsoft.dotnet-scaffold-aspnet
+call rd /Q /S Microsoft.DotNet.Scaffolding.Helpers
+call rd /Q /S Microsoft.DotNet.Scaffolding.ComponentModel
+
+call cd  %SRC_DIR%/%NUPKG% 
+call dotnet tool install -g Microsoft.dotnet-scaffold-aspnet --add-source %SRC_DIR%\%NUPKG% --version %VERSION%
+call cd %SRC_DIR%

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -100,6 +100,25 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services
             return commands.ToList();
         }
 
+        public bool InstallDotNetTool(string toolName, string? version = null)
+        {
+            if (string.IsNullOrEmpty(toolName))
+            {
+                return false;
+            }
+
+            var installParams = new List<string> { "install", "-g", toolName };
+            if (!string.IsNullOrEmpty(version))
+            {
+                installParams.Add("-v");
+                installParams.Add(version);
+            }
+            
+            var runner = DotnetCliRunner.CreateDotNet("tool", installParams);
+            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
+            return exitCode == 0;
+        }
+
         private static IList<DotNetToolInfo> GetDotNetTools()
         {
             var dotnetToolList = new List<DotNetToolInfo>();

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
@@ -9,5 +9,6 @@ public interface IDotNetToolService
     IList<DotNetToolInfo> GlobalDotNetTools { get; }
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
+    bool InstallDotNetTool(string toolName, string? version = null);
     List<CommandInfo> GetCommands(string dotnetToolName);
 }

--- a/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
+++ b/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
@@ -54,9 +54,11 @@ public class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
+        Debugger.Launch();
         IEnumerable<IFlowStep> flowSteps =
         [
             new StartupFlowStep(_appSettings, _dotnetToolService, _environmentService, _fileSystem, _hostService, _logger),
+            new CategoryPickerFlowStep(_logger, _dotnetToolService),
             new SourceProjectFlowStep(_appSettings, _environmentService, _fileSystem, _logger),
             new CommandPickerFlowStep(_logger, _dotnetToolService),
             new CommandExecuteFlowStep()

--- a/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
+++ b/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
@@ -54,7 +54,6 @@ public class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
-        Debugger.Launch();
         IEnumerable<IFlowStep> flowSteps =
         [
             new StartupFlowStep(_appSettings, _dotnetToolService, _environmentService, _fileSystem, _hostService, _logger),

--- a/tools/dotnet-scaffold/Flow/FlowContextProperties.cs
+++ b/tools/dotnet-scaffold/Flow/FlowContextProperties.cs
@@ -30,4 +30,5 @@ internal static class FlowContextProperties
     public const string TargetFrameworkName = nameof(TargetFrameworkName);
     public const string RemainingArgs = nameof(RemainingArgs);
     public const string DotnetToolComponents = nameof(DotnetToolComponents);
+    public const string ScaffoldingCategory = nameof(ScaffoldingCategory);
 }

--- a/tools/dotnet-scaffold/Flow/FlowExtensions.cs
+++ b/tools/dotnet-scaffold/Flow/FlowExtensions.cs
@@ -33,6 +33,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow
             return context.GetValueOrThrow<IList<KeyValuePair<string, CommandInfo>>>(FlowContextProperties.CommandInfos, throwIfEmpty);
         }
 
+        public static string? GetScaffoldingCategory(this IFlowContext context, bool throwIfEmpty = false)
+        {
+            return context.GetValueOrThrow<string>(FlowContextProperties.ScaffoldingCategory, throwIfEmpty);
+        }
+
         public static string? GetSourceProjectPath(this IFlowContext context, bool throwIfEmpty = false)
         {
             return context.GetValueOrThrow<string>(FlowContextProperties.SourceProjectPath, throwIfEmpty);

--- a/tools/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Scaffolding.ComponentModel;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Flow;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
+{
+    /// <summary>
+    /// IFlowStep that deals with the selection of the component(DotnetToolInfo) and the associated command(CommandInfo).
+    /// if provided by the user, verify if the component is installed and the command is supported.
+    /// </summary>
+    internal class CategoryPickerFlowStep : IFlowStep
+    {
+        private readonly ILogger _logger;
+        private readonly IDotNetToolService _dotnetToolService;
+        public CategoryPickerFlowStep(ILogger logger, IDotNetToolService dotnetToolService)
+        {
+            _logger = logger;
+            _dotnetToolService = dotnetToolService;
+        }
+
+        public string Id => nameof(CategoryPickerFlowStep);
+
+        public string DisplayName => "Scaffolding Category";
+
+        public ValueTask ResetAsync(IFlowContext context, CancellationToken cancellationToken)
+        {
+            context.Unset(FlowContextProperties.ScaffoldingCategory);
+            context.Unset(FlowContextProperties.ComponentName);
+            context.Unset(FlowContextProperties.ComponentObj);
+            context.Unset(FlowContextProperties.CommandName);
+            context.Unset(FlowContextProperties.CommandObj); 
+            return new ValueTask();
+        }
+
+        public ValueTask<FlowStepResult> RunAsync(IFlowContext context, CancellationToken cancellationToken)
+        {
+            var settings = context.GetCommandSettings();
+            var componentName = settings?.ComponentName;
+            var commandName = settings?.CommandName;
+            string? displayCategory = null;
+            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+
+            CategoryDiscovery categoryDiscovery = new(_dotnetToolService, dotnetToolComponent);
+            displayCategory = categoryDiscovery.Discover(context);
+            if (categoryDiscovery.State.IsNavigation())
+            {
+                return new ValueTask<FlowStepResult>(new FlowStepResult { State = categoryDiscovery.State });
+            }
+
+            if (string.IsNullOrEmpty(displayCategory))
+            {
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any component categories!"));
+            }
+            else
+            {
+                SelectCategory(context, displayCategory);
+            }
+
+            return new ValueTask<FlowStepResult>(FlowStepResult.Success);
+        }
+
+        public ValueTask<FlowStepResult> ValidateUserInputAsync(IFlowContext context, CancellationToken cancellationToken)
+        {
+            var settings = context.GetCommandSettings();
+            var componentName = settings?.ComponentName;
+            var commandName = settings?.CommandName;
+            CommandInfo? commandInfo = null;
+
+            //check if user input included a component name.
+            //if included, check for a command name, and get the CommandInfo object.
+            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+            if (dotnetToolComponent != null)
+            {
+                var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent.Command);
+                commandInfo = allCommands.FirstOrDefault(x => x.Name.Equals(commandName, StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("No component (dotnet tool) provided!"));
+            }
+
+            if (commandInfo is null)
+            {
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure($"Invalid or empty command provided for component '{componentName}'"));
+            }
+
+            SelectComponent(context, dotnetToolComponent);
+            SelectCommand(context, commandInfo);
+            SelectCategory(context, commandInfo.DisplayCategory);
+            return new ValueTask<FlowStepResult>(FlowStepResult.Success);
+        }
+
+        private void SelectCategory(IFlowContext context, string categoryName)
+        {
+            context.Set(new FlowProperty(
+                FlowContextProperties.ScaffoldingCategory,
+                categoryName,
+                "Scaffolding Category",
+                isVisible: true));
+        }
+
+        private void SelectCommand(IFlowContext context, CommandInfo command)
+        {
+            context.Set(new FlowProperty(
+                FlowContextProperties.CommandName,
+                command.Name,
+                "Command Name",
+                isVisible: true));
+
+            context.Set(new FlowProperty(
+                FlowContextProperties.CommandObj,
+                command,
+                isVisible: false));
+        }
+
+        private void SelectComponent(IFlowContext context, DotNetToolInfo dotnetToolInfo)
+        {
+            context.Set(new FlowProperty(
+                FlowContextProperties.ComponentName,
+                dotnetToolInfo.Command,
+                "Component Name",
+                isVisible: true));
+
+            context.Set(new FlowProperty(
+                FlowContextProperties.ComponentObj,
+                dotnetToolInfo,
+                isVisible: false));
+        }
+    }
+}

--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var parameterValues = GetAllParameterValues(context, commandObj);
             if (!string.IsNullOrEmpty(componentName) && parameterValues.Count != 0 && !string.IsNullOrEmpty(commandObj.Name))
             {
-                var componentExecutionString = $"{componentName} {commandObj.Name} {string.Join(" ", parameterValues)}";
+                var componentExecutionString = $"{componentName} {string.Join(" ", parameterValues)}";
                 string? stdOut = null, stdErr = null;
                 int? exitCode = null;
                 AnsiConsole.Status().WithSpinner()

--- a/tools/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Scaffolding.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
+using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
@@ -67,7 +67,7 @@ public class StartupFlowStep : IFlowStep
                 //add 'workspace' settings
                 var workspaceSettings = new WorkspaceSettings();
                 _appSettings.AddSettings("workspace", workspaceSettings);
-
+                //initialize msbuild
                 if (_initializeMsbuild)
                 {
                     statusContext.Status = "Initializing msbuild!";
@@ -79,7 +79,10 @@ public class StartupFlowStep : IFlowStep
                 var environmentVariableProvider = new EnvironmentVariablesStartup(_hostService, _environmentService, _appSettings);
                 await environmentVariableProvider.StartupAsync();
                 statusContext.Status = "DONE\n";
-
+                //initialize 1st party components (dotnet tools)
+                statusContext.Status = "Initializing 1st party components (dotnet tools)";
+                new FirstPartyComponentInitializer(_logger, _dotnetToolService).Initialize();
+                statusContext.Status = "DONE\n";
                 //parse args passed
                 statusContext.Status = "Parsing args!";
                 var remainingArgs = context.GetRemainingArgs();

--- a/tools/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/tools/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services;
+
+internal class FirstPartyComponentInitializer
+{
+    private readonly ILogger _logger;
+    private readonly IDotNetToolService _dotnetToolService;
+    private readonly List<string> _firstPartyTools = ["dotnet-scaffold-aspnet", "dotnet-scaffold-aspire"];
+    public FirstPartyComponentInitializer(ILogger logger, IDotNetToolService dotnetToolService)
+    {
+        _logger = logger;
+        _dotnetToolService = dotnetToolService;
+    }
+
+    public void Initialize()
+    {
+        List<string> toolsToInstall = [];
+        foreach (var tool in _firstPartyTools)
+        {
+            if (_dotnetToolService.GetDotNetTool(tool) is null)
+            {
+                toolsToInstall.Add(tool);
+            }
+        }
+
+        foreach (var tool in toolsToInstall)
+        {
+            _logger.LogMessage($"Installing {tool}!");
+            var successfullyInstalled = _dotnetToolService.InstallDotNetTool(tool);
+            if (!successfullyInstalled)
+            {
+                _logger.LogMessage($"Failed to install {tool}!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- added `CategoryPickerFlowStep`
  - Each `CommandInfo` has a `DisplayCategory` property. These are going to be presented in a selection flow before the project picker.
  - Then all applicable `CommandInfo`s are presented
  - Only applicable in the interactive mode
  - The order of steps **was** : StartupFlowStep --> SourceProjectFlowStep --> CommandPickerFlowStep --> CommandExecuteFlowStep
  - The order of steps **is** : StartupFlowStep --> CategoryPickerFlowStep --> SourceProjectFlowStep --> CommandPickerFlowStep --> CommandExecuteFlowStep

- added `IDotNetToolService.InstallDotNetTool`
  - install a dotnet tool globally using `dotnet tool install -g`

Sample gif (ignore the debugger and Redis scaffolder details)
![dotnet-scaffold](https://github.com/dotnet/Scaffolding/assets/54324771/7473e8a0-bfd0-47b6-a8c7-7ae3698ed49b)



  