### PR TITLE
Change AppHost verbiage

### DIFF
--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             [CommandOption("--type <TYPE>")]
             public required string Type { get; set; }
 
-            [CommandOption("--host-project <PROJECT>")]
+            [CommandOption("--apphost-project <PROJECT>")]
             public required string Project { get; set; }
 
             [CommandOption("--web-project <WEBPROJECT>")]

--- a/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             [CommandOption("--type <TYPE>")]
             public required string Type { get; set; }
 
-            [CommandOption("--host-project <PROJECT>")]
+            [CommandOption("--apphost-project <PROJECT>")]
             public required string Project { get; set; }
 
             [CommandOption("--api-project <APIPROJECT>")]

--- a/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
     public static class GetCmdsHelper
     {
-        internal static Parameter AppHostProjectParameter = new() { Name = "--host-project", DisplayName = "Aspire Host project file", Description = "Aspire host app for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
+        internal static Parameter AppHostProjectParameter = new() { Name = "--apphost-project", DisplayName = "Aspire AppHost project file", Description = "Aspire AppHost project for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
         internal static Parameter ApiProjectParameter = new() { Name = "--api-project", DisplayName = "API project file", Description = "API project associated with the Aspire Starter App", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
         internal static Parameter WebProjectParameter = new() { Name = "--web-project", DisplayName = "Web project file", Description = "Web project associated with the Aspire Starter App", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
         internal static List<string> CachingTypeCustomValues = ["redis", "redis-with-output-caching"];

--- a/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
@@ -38,7 +38,7 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
         [CommandOption("--type <TYPE>")]
         public required string Type { get; set; }
 
-        [CommandOption("--host-project <PROJECT>")]
+        [CommandOption("--apphost-project <PROJECT>")]
         public required string Project { get; set; }
 
         [CommandOption("--api-project <APIPROJECT>")]


### PR DESCRIPTION
My comment on a prior PR (https://github.com/dotnet/Scaffolding/pull/2744#discussion_r1600715024) was too brief and didn't convey what I intended. So just a quick PR to make the full change here. We can get the PM/docs folks later on whether it should be `App host` (like in the docs) or `AppHost` (like in the project name) or what, but it should probably have both parts (see [Aspire docs](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview#app-host-project) for reference).