### PR TITLE
Change dotnet-scaffold version back

### DIFF
--- a/eng/Versions.Scaffold.props
+++ b/eng/Versions.Scaffold.props
@@ -5,16 +5,6 @@
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
   </PropertyGroup>
-  <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
-    <!--
-        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
-    -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-  </PropertyGroup>
   
   <PropertyGroup>
     <SpectreConsoleFlowVersion>0.5.638</SpectreConsoleFlowVersion>

--- a/scripts/install-scaffold.cmd
+++ b/scripts/install-scaffold.cmd
@@ -1,4 +1,4 @@
-set VERSION=0.1.0-dev
+set VERSION=9.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/


### PR DESCRIPTION
There are already versions of the microsoft.dotnet-scaffold package on both internal and external nuget package feeds with versions higher than 0.1.0-preview, so using that version scheme - while consistent with the other new dotnet-scaffold-* tools - will make it hard to get the right versions installed while we're doing previews. Removing this picks up the default, which goes back to the 9.0.0 previews at the moment.

This technically also impacts the versions of Microsoft.DotNet.Scaffolding.Helpers and Microsoft.DotNet.Scaffolding.ComponentModel, but we probably want those to be versioned the same as dotnet-scaffold anyway (since they're effectively the object model/api/component model for dotnet-scaffold). @deepchoudhery thoughts on that?