### PR TITLE
Fix database apiservice package add

### DIFF
--- a/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                     projectFile: commandSettings.Project);
             }
 
-            PackageConstants.DatabasePackages.DatabasePackagesAppHostDict.TryGetValue(commandSettings.Type, out string? apiServicePackageName);
+            PackageConstants.DatabasePackages.DatabasePackagesApiServiceDict.TryGetValue(commandSettings.Type, out string? apiServicePackageName);
             if (_fileSystem.FileExists(commandSettings.ApiProject) && !string.IsNullOrEmpty(apiServicePackageName))
             {
                 DotnetCommands.AddPackage(


### PR DESCRIPTION
Looks like a simple copy/paste error here - seems to be using the AppHost dictionary for the ApiService reference install.