### PR TITLE
add code modification when running 'caching --type redis' 

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Extensions/StringExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Extensions/StringExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Extensions
         /// basePath to fullPath. Note that if either path is null, fullPath will be returned.
         /// Note that two paths that are equal return ".\".
         /// </summary>
-        public static string MakeRelativePath(this string fullPath, string basePath)
+        public static string? MakeRelativePath(this string? fullPath, string? basePath)
         {
             if (string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(fullPath))
             {

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/CodeService.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/CodeService.cs
@@ -115,10 +115,10 @@ public class CodeService : ICodeService, IDisposable
         await OpenProjectAsync(projectPath!);
     }
 
+    //TODO add a debug option to logging.
     private void OnWorkspaceFailed(object? sender, WorkspaceDiagnosticEventArgs e)
     {
         var diagnostic = e.Diagnostic!;
-        _logger.LogMessage($"[{diagnostic.Kind}] Problem loading file in MSBuild workspace {diagnostic.Message}");
     }
 
     public void Dispose()

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -1,31 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
+using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 {
-    public class CachingCommand : Command<CachingCommand.CachingCommandSettings>
+    public class CachingCommand : AsyncCommand<CachingCommand.CachingCommandSettings>
     {
         private readonly ILogger _logger;
         private readonly IFileSystem _fileSystem;
-        private readonly IAppSettings _appSettings;
-        public CachingCommand(IFileSystem fileSystem, ILogger logger, IAppSettings appSettings)
+        private readonly IEnvironmentService _environmentService;
+        public CachingCommand(IFileSystem fileSystem, ILogger logger, IEnvironmentService environmentService)
         {
-            _appSettings = appSettings;
+            _environmentService = environmentService;
             _fileSystem = fileSystem;
             _logger = logger;
         }
 
-        public override int Execute([NotNull] CommandContext context, [NotNull] CachingCommandSettings settings)
+        public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] CachingCommandSettings settings)
         {
             if (!ValidateCachingCommandSettings(settings))
             {
@@ -33,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             }
 
             InstallPackages(settings);
-            return 0;
+            return await UpdateAppHostAsync(settings) && await UpdateWebAppAsync(settings) ? 0 : 1;
         }
 
         public class CachingCommandSettings : CommandSettings
@@ -48,9 +51,72 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             public required string WebProject { get; set; }
         }
 
+        internal async Task<bool> UpdateAppHostAsync(CachingCommandSettings commandSettings)
+        {
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+
+            CodeModifierConfig? config = ProjectModifierHelper.GetCodeModifierConfig("redis-apphost.json", System.Reflection.Assembly.GetExecutingAssembly());
+            var workspaceSettings = new WorkspaceSettings
+            {
+                InputPath = commandSettings.Project
+            };
+
+            var hostAppSettings = new AppSettings();
+            hostAppSettings.AddSettings("workspace", workspaceSettings);
+            var codeService = new CodeService(hostAppSettings, _logger);
+            CodeChangeOptions options = new()
+            {
+                IsMinimalApp = await ProjectModifierHelper.IsMinimalApp(codeService),
+                UsingTopLevelsStatements = await ProjectModifierHelper.IsUsingTopLevelStatements(codeService)
+            };
+
+            var projectModifier = new ProjectModifier(
+                _environmentService,
+                hostAppSettings,
+                codeService,
+                _logger,
+                options,
+                config);
+            return await projectModifier.RunAsync();
+        }
+
+        internal async Task<bool> UpdateWebAppAsync(CachingCommandSettings commandSettings)
+        {
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+
+            CodeModifierConfig? config = ProjectModifierHelper.GetCodeModifierConfig("redis-webapp.json", System.Reflection.Assembly.GetExecutingAssembly());
+            var workspaceSettings = new WorkspaceSettings
+            {
+                InputPath = commandSettings.WebProject
+            };
+
+            var hostAppSettings = new AppSettings();
+            hostAppSettings.AddSettings("workspace", workspaceSettings);
+            var codeService = new CodeService(hostAppSettings, _logger);
+            CodeChangeOptions options = new()
+            {
+                IsMinimalApp = await ProjectModifierHelper.IsMinimalApp(codeService),
+                UsingTopLevelsStatements = await ProjectModifierHelper.IsUsingTopLevelStatements(codeService)
+            };
+
+            var projectModifier = new ProjectModifier(
+            _environmentService,
+            hostAppSettings,
+            codeService,
+            _logger,
+            options,
+            config);
+            return await projectModifier.RunAsync();
+        }
+
         internal bool ValidateCachingCommandSettings(CachingCommandSettings commandSettings)
         {
-            InitializeCommand();
             if (string.IsNullOrEmpty(commandSettings.Type) || !GetCmdsHelper.CachingTypeCustomValues.Contains(commandSettings.Type, StringComparer.OrdinalIgnoreCase))
             {
                 string cachingTypeDisplayList = string.Join(", ", GetCmdsHelper.CachingTypeCustomValues.GetRange(0, GetCmdsHelper.CachingTypeCustomValues.Count - 1)) +
@@ -62,7 +128,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
             if (string.IsNullOrEmpty(commandSettings.Project))
             {
-                _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+                _logger.LogMessage("Missing/Invalid --apphost-project option.", LogMessageType.Error);
                 return false;
             }
 
@@ -75,19 +141,6 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             return true;
         }
 
-        internal void InitializeCommand()
-        {
-            AnsiConsole.Status()
-            .WithSpinner()
-            .Start("Initializing dotnet-scaffold", statusContext =>
-            {
-                statusContext.Refresh();
-                //add 'workspace' settings
-                var workspaceSettings = new WorkspaceSettings();
-                _appSettings.AddSettings("workspace", workspaceSettings);
-            });
-        }
-
         internal void InstallPackages(CachingCommandSettings commandSettings)
         {
             if (_fileSystem.FileExists(commandSettings.Project))
@@ -97,6 +150,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                     logger: _logger,
                     projectFile: commandSettings.Project);
             }
+
             PackageConstants.CachingPackages.CachingPackagesDict.TryGetValue(commandSettings.Type, out string? webAppPackageName);
             if (_fileSystem.FileExists(commandSettings.WebProject) && !string.IsNullOrEmpty(webAppPackageName))
             {

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             }
 
             InstallPackages(settings);
-            return await UpdateAppHostAsync(settings) && await UpdateWebAppAsync(settings) ? 0 : 1;
+            return await UpdateAppHostAsync(settings) && await UpdateWebAppAsync(settings) ? 0 : -1;
         }
 
         public class CachingCommandSettings : CommandSettings

--- a/tools/dotnet-scaffold-aspire/Commands/CodeModificationConfigs/Caching/redis-apphost.json
+++ b/tools/dotnet-scaffold-aspire/Commands/CodeModificationConfigs/Caching/redis-apphost.json
@@ -1,0 +1,20 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertAfter": "var builder = DistributedApplication.CreateBuilder(args);",
+              "Block": "var redis = builder.AddRedis(\"redis\")",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tools/dotnet-scaffold-aspire/Commands/CodeModificationConfigs/Caching/redis-webapp.json
+++ b/tools/dotnet-scaffold-aspire/Commands/CodeModificationConfigs/Caching/redis-webapp.json
@@ -1,0 +1,20 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertAfter": "builder.AddServiceDefaults()",
+              "Block": "builder.AddRedisClient(\"redis\")",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tools/dotnet-scaffold-aspire/Program.cs
+++ b/tools/dotnet-scaffold-aspire/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.AppBuilder;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Commands;
 using Spectre.Console.Cli;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.Tools.Scaffold.Aspire;
 public static class Program
@@ -25,13 +26,10 @@ public static class Program
     private static ITypeRegistrar? GetDefaultServices()
     {
         var registrar = new TypeRegistrar();
-        registrar.Register(typeof(IAppSettings), typeof(AppSettings));
         registrar.Register(typeof(IFileSystem), typeof(FileSystem));
         registrar.Register(typeof(IEnvironmentService), typeof(EnvironmentService));
         registrar.Register(typeof(IDotNetToolService), typeof(DotNetToolService));
         registrar.Register(typeof(ILogger), typeof(AnsiConsoleLogger));
-        registrar.Register(typeof(IHostService), typeof(HostService));
-        registrar.Register(typeof(ICodeService), typeof(CodeService));
         return registrar;
     }
 }

--- a/tools/dotnet-scaffold-aspire/Program.cs
+++ b/tools/dotnet-scaffold-aspire/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.AppBuilder;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Commands;
 using Spectre.Console.Cli;
-using System.Diagnostics;
 
 namespace Microsoft.DotNet.Tools.Scaffold.Aspire;
 public static class Program

--- a/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Commands\CodeModificationConfigs\Caching\*.json">
-      <PackagePath>lib\net8.0\</PackagePath>
       <Pack>true</Pack>
     </EmbeddedResource>
   </ItemGroup>

--- a/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/tools/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -25,4 +25,11 @@
     <ProjectReference Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.ComponentModel\Microsoft.DotNet.Scaffolding.ComponentModel.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Commands\CodeModificationConfigs\Caching\*.json">
+      <PackagePath>lib\net8.0\</PackagePath>
+      <Pack>true</Pack>
+    </EmbeddedResource>
+  </ItemGroup>
+  
 </Project>

--- a/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
+++ b/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
@@ -1,6 +1,5 @@
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;

--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                         exitCode = cliRunner.ExecuteAndCaptureOutput(out stdOut, out stdErr);
                     });
 
-                if (exitCode != null && (string.IsNullOrEmpty(stdOut) || string.IsNullOrEmpty(stdErr)))
+                if (exitCode != null)
                 {
                     AnsiConsole.Console.WriteLine($"\nCommand executed : '{componentExecutionString}'");
                     AnsiConsole.Console.WriteLine($"\nCommand exit code - {exitCode}");

--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                         exitCode = cliRunner.ExecuteAndCaptureOutput(out stdOut, out stdErr);
                     });
 
-                if (exitCode != null && (!string.IsNullOrEmpty(stdOut) || string.IsNullOrEmpty(stdErr)))
+                if (exitCode != null && (string.IsNullOrEmpty(stdOut) || string.IsNullOrEmpty(stdErr)))
                 {
                     AnsiConsole.Console.WriteLine($"\nCommand executed : '{componentExecutionString}'");
                     AnsiConsole.Console.WriteLine($"\nCommand exit code - {exitCode}");

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Diagnostics;
 using Microsoft.DotNet.Tools.Scaffold;
 
 var builder = new ScaffoldCommandAppBuilder(args);

--- a/tools/dotnet-scaffold/Program.cs
+++ b/tools/dotnet-scaffold/Program.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics;
 using Microsoft.DotNet.Tools.Scaffold;
 
 var builder = new ScaffoldCommandAppBuilder(args);


### PR DESCRIPTION
adding to `dotnet-scaffold-aspire caching --type redis` scenario.
- added `UpdateAppHostAsync` and `UpdateWebAppAsync` to `CachingCommand.ExecuteAsync`
- flow for code modification is as follows in the above methods:
  1. Get `CodeModifierConfig` from `ProjectModifierHelper.GetCodeModifierConfig`
  2. Initialize `ICodeService` with a given project path (in `IAppSettings`)
  3. Initialize `CodeChangeOptions`
  4. Initialize `ProjectModifier` and then call `RunAsync`
- added `MSBuildLocator.RegisterDefaults()` before any roslyn workspace setup (when using `CodeService`. Missing MSBuild assemblies otherwise and exceptions are thrown when loading the `MSBuildWorkspace`. Currently a controlled initialization before any roslyn modifications.
- removed unnecessary `CachingCommand.InitializeCommand()`
- removed console logging for `CodeService.OnWorkspaceFailed`. Lot of noise output that's better for debug logging (logs every warning and huge call stack with it)