### PR TITLE
Various quick tweaks

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
@@ -25,7 +25,7 @@ public static class DotnetCommands
             }
 
             arguments.Add("--prerelease");
-            logger.LogMessage(string.Format("\nAdding package '{0}'.", packageName));
+            logger.LogMessage(string.Format("\nAdding package '{0}'", packageName));
 
             var runner = DotnetCliRunner.CreateDotNet("add", arguments);
             var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             CodeModifierConfig? config = ProjectModifierHelper.GetCodeModifierConfig("redis-apphost.json", System.Reflection.Assembly.GetExecutingAssembly());
             var workspaceSettings = new WorkspaceSettings
             {
-                InputPath = commandSettings.Project
+                InputPath = commandSettings.AppHostProject
             };
 
             var hostAppSettings = new AppSettings();
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             CodeModifierConfig? config = ProjectModifierHelper.GetCodeModifierConfig("redis-webapp.json", System.Reflection.Assembly.GetExecutingAssembly());
             var workspaceSettings = new WorkspaceSettings
             {
-                InputPath = commandSettings.WebProject
+                InputPath = commandSettings.Project
             };
 
             var hostAppSettings = new AppSettings();

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -41,11 +41,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             [CommandOption("--type <TYPE>")]
             public required string Type { get; set; }
 
-            [CommandOption("--apphost-project <PROJECT>")]
-            public required string Project { get; set; }
+            [CommandOption("--apphost-project <APPHOSTPROJECT>")]
+            public required string AppHostProject { get; set; }
 
-            [CommandOption("--web-project <WEBPROJECT>")]
-            public required string WebProject { get; set; }
+            [CommandOption("--project <PROJECT>")]
+            public required string Project { get; set; }
         }
 
         internal bool ValidateCachingCommandSettings(CachingCommandSettings commandSettings)
@@ -60,15 +60,15 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 return false;
             }
 
-            if (string.IsNullOrEmpty(commandSettings.Project))
+            if (string.IsNullOrEmpty(commandSettings.AppHostProject))
             {
-                _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+                _logger.LogMessage("Missing/Invalid --apphost-project option.", LogMessageType.Error);
                 return false;
             }
 
-            if (string.IsNullOrEmpty(commandSettings.WebProject))
+            if (string.IsNullOrEmpty(commandSettings.Project))
             {
-                _logger.LogMessage("Missing/Invalid --web-project option.", LogMessageType.Error);
+                _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
                 return false;
             }
 
@@ -90,20 +90,20 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
         internal void InstallPackages(CachingCommandSettings commandSettings)
         {
-            if (_fileSystem.FileExists(commandSettings.Project))
+            if (_fileSystem.FileExists(commandSettings.AppHostProject))
             {
                 DotnetCommands.AddPackage(
                     packageName: PackageConstants.CachingPackages.AppHostRedisPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.Project);
+                    projectFile: commandSettings.AppHostProject);
             }
-            PackageConstants.CachingPackages.CachingPackagesDict.TryGetValue(commandSettings.Type, out string? webAppPackageName);
-            if (_fileSystem.FileExists(commandSettings.WebProject) && !string.IsNullOrEmpty(webAppPackageName))
+            PackageConstants.CachingPackages.CachingPackagesDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
+            if (_fileSystem.FileExists(commandSettings.Project) && !string.IsNullOrEmpty(projectPackageName))
             {
                 DotnetCommands.AddPackage(
-                    packageName: webAppPackageName,
+                    packageName: projectPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.WebProject);
+                    projectFile: commandSettings.Project);
             }
         }
     }

--- a/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -37,11 +37,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             [CommandOption("--type <TYPE>")]
             public required string Type { get; set; }
 
-            [CommandOption("--apphost-project <PROJECT>")]
-            public required string Project { get; set; }
+            [CommandOption("--apphost-project <APPHOSTPROJECT>")]
+            public required string AppHostProject { get; set; }
 
-            [CommandOption("--api-project <APIPROJECT>")]
-            public required string ApiProject { get; set; }
+            [CommandOption("--project <PROJECT>")]
+            public required string Project { get; set; }
         }
 
         internal bool ValidateDatabaseCommandSettings(DatabaseCommandSettings commandSettings)
@@ -55,15 +55,15 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 return false;
             }
 
-            if (string.IsNullOrEmpty(commandSettings.Project))
+            if (string.IsNullOrEmpty(commandSettings.AppHostProject))
             {
-                _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+                _logger.LogMessage("Missing/Invalid --apphost-project option.", LogMessageType.Error);
                 return false;
             }
 
-            if (string.IsNullOrEmpty(commandSettings.ApiProject))
+            if (string.IsNullOrEmpty(commandSettings.Project))
             {
-                _logger.LogMessage("Missing/Invalid --api-project option.", LogMessageType.Error);
+                _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
                 return false;
             }
 
@@ -73,21 +73,21 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
         internal void InstallPackages(DatabaseCommandSettings commandSettings)
         {
             PackageConstants.DatabasePackages.DatabasePackagesAppHostDict.TryGetValue(commandSettings.Type, out string? appHostPackageName);
-            if (_fileSystem.FileExists(commandSettings.Project) && !string.IsNullOrEmpty(appHostPackageName))
+            if (_fileSystem.FileExists(commandSettings.AppHostProject) && !string.IsNullOrEmpty(appHostPackageName))
             {
                 DotnetCommands.AddPackage(
                     packageName: appHostPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.Project);
+                    projectFile: commandSettings.AppHostProject);
             }
 
-            PackageConstants.DatabasePackages.DatabasePackagesApiServiceDict.TryGetValue(commandSettings.Type, out string? apiServicePackageName);
-            if (_fileSystem.FileExists(commandSettings.ApiProject) && !string.IsNullOrEmpty(apiServicePackageName))
+            PackageConstants.DatabasePackages.DatabasePackagesApiServiceDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
+            if (_fileSystem.FileExists(commandSettings.Project) && !string.IsNullOrEmpty(projectPackageName))
             {
                 DotnetCommands.AddPackage(
-                    packageName: apiServicePackageName,
+                    packageName: projectPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.ApiProject);
+                    projectFile: commandSettings.Project);
             }
         }
     }

--- a/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
@@ -49,17 +49,16 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
     public static class GetCmdsHelper
     {
-        internal static Parameter AppHostProjectParameter = new() { Name = "--apphost-project", DisplayName = "Aspire AppHost project file", Description = "Aspire AppHost project for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
-        internal static Parameter ApiProjectParameter = new() { Name = "--api-project", DisplayName = "API project file", Description = "API project associated with the Aspire Starter App", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
-        internal static Parameter WebProjectParameter = new() { Name = "--web-project", DisplayName = "Web project file", Description = "Web project associated with the Aspire Starter App", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
+        internal static Parameter AppHostProjectParameter = new() { Name = "--apphost-project", DisplayName = "Aspire App host project file", Description = "Aspire App host project for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
+        internal static Parameter ProjectParameter = new() { Name = "--project", DisplayName = "Web or worker project file", Description = "Web or worker project associated with the Aspire App host", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
         internal static List<string> CachingTypeCustomValues = ["redis", "redis-with-output-caching"];
         internal static List<string> DatabaseTypeCustomValues = ["npgsql", "npgsql-efcore", "sqlserver-efcore", "cosmos-efcore"];
         internal static List<string> StorageTypeCustomValues = ["azure-storage-queues", "azure-storage-blobs", "azure-data-tables"];
         internal static Parameter CachingTypeParameter = new() { Name = "--type", DisplayName = "Caching type", Description = "Types of caching", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = CachingTypeCustomValues };
         internal static Parameter DatabaseTypeParameter = new() { Name = "--type", DisplayName = "Database type", Description = "Types of database", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = DatabaseTypeCustomValues };
         internal static Parameter StorageTypeParameter = new() { Name = "--type", DisplayName = "Storage type", Description = "Types of storage", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = StorageTypeCustomValues };
-        internal static Parameter[] CachingParameters = [CachingTypeParameter, AppHostProjectParameter, WebProjectParameter];
-        internal static Parameter[] DatabaseParameters = [DatabaseTypeParameter, AppHostProjectParameter, ApiProjectParameter];
-        internal static Parameter[] StorageParameters = [StorageTypeParameter, AppHostProjectParameter, ApiProjectParameter];
+        internal static Parameter[] CachingParameters = [CachingTypeParameter, AppHostProjectParameter, ProjectParameter];
+        internal static Parameter[] DatabaseParameters = [DatabaseTypeParameter, AppHostProjectParameter, ProjectParameter];
+        internal static Parameter[] StorageParameters = [StorageTypeParameter, AppHostProjectParameter, ProjectParameter];
     }
 }

--- a/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
@@ -38,11 +38,11 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
         [CommandOption("--type <TYPE>")]
         public required string Type { get; set; }
 
-        [CommandOption("--apphost-project <PROJECT>")]
-        public required string Project { get; set; }
+        [CommandOption("--apphost-project <APPHOSTPROJECT>")]
+        public required string AppHostProject { get; set; }
 
-        [CommandOption("--api-project <APIPROJECT>")]
-        public required string ApiProject { get; set; }
+        [CommandOption("--project <PROJECT>")]
+        public required string Project { get; set; }
     }
 
     internal bool ValidateStorageCommandSettings(StorageCommandSettings commandSettings)
@@ -56,15 +56,15 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
             return false;
         }
 
-        if (string.IsNullOrEmpty(commandSettings.Project))
+        if (string.IsNullOrEmpty(commandSettings.AppHostProject))
         {
-            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            _logger.LogMessage("Missing/Invalid --apphost-project option.", LogMessageType.Error);
             return false;
         }
 
-        if (string.IsNullOrEmpty(commandSettings.ApiProject))
+        if (string.IsNullOrEmpty(commandSettings.Project))
         {
-            _logger.LogMessage("Missing/Invalid --api-project option.", LogMessageType.Error);
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
             return false;
         }
 
@@ -73,21 +73,21 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
 
     internal void InstallPackages(StorageCommandSettings commandSettings)
     {
-        if (_fileSystem.FileExists(commandSettings.Project))
+        if (_fileSystem.FileExists(commandSettings.AppHostProject))
         {
             DotnetCommands.AddPackage(
                 packageName: PackageConstants.StoragePackages.AppHostStoragePackageName,
                 logger: _logger,
-                projectFile: commandSettings.Project);
+                projectFile: commandSettings.AppHostProject);
         }
 
-        PackageConstants.StoragePackages.StoragePackagesDict.TryGetValue(commandSettings.Type, out string? apiPackageName);
-        if (_fileSystem.FileExists(commandSettings.ApiProject) && !string.IsNullOrEmpty(apiPackageName))
+        PackageConstants.StoragePackages.StoragePackagesDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
+        if (_fileSystem.FileExists(commandSettings.Project) && !string.IsNullOrEmpty(projectPackageName))
         {
             DotnetCommands.AddPackage(
-                packageName: apiPackageName,
+                packageName: projectPackageName,
                 logger: _logger,
-                projectFile: commandSettings.ApiProject);
+                projectFile: commandSettings.Project);
         }
     }
 }

--- a/tools/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
+++ b/tools/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
@@ -14,7 +14,7 @@ public class ScaffoldCommandAppBuilder(string[] args)
 {
     private readonly string[] _args = args;
     //try to update this every release
-    private readonly string _backupDotNetScaffoldVersion = "0.1.0-dev";
+    private readonly string _backupDotNetScaffoldVersion = "9.0.0-dev";
 
     public ScaffoldCommandApp Build()
     {

--- a/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
+++ b/tools/dotnet-scaffold/Command/ScaffoldCommand.cs
@@ -58,7 +58,7 @@ public class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
             new CommandExecuteFlowStep()
         ];
 
-        return await RunFlowAsync(flowSteps, settings, context.Remaining, settings.NonInteractive);
+        return await RunFlowAsync(flowSteps, settings, context.Remaining, settings.NonInteractive, showSelectedOptions: false);
     }
 }
 

--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -53,17 +53,25 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                         exitCode = cliRunner.ExecuteAndCaptureOutput(out stdOut, out stdErr);
                     });
 
-                if (exitCode != null && (!string.IsNullOrEmpty(stdOut) || string.IsNullOrEmpty(stdErr)))
+                if (exitCode != null)
                 {
-                    AnsiConsole.Console.WriteLine($"\nCommand executed : '{componentExecutionString}'");
-                    AnsiConsole.Console.WriteLine($"\nCommand exit code - {exitCode}");
-                    if (exitCode == 0)
+                    // TODO: Put this behind a --verbose type flag. It's helpful for debugging but makes the 
+                    // demo noisy
+                    //AnsiConsole.Console.WriteLine($"\nCommand: '{componentExecutionString}'");
+
+                    // TODO: Long-term we probably want to pipe these out as we get them rather than
+                    // just collect them, otherwise they're out of order
+                    if (!string.IsNullOrWhiteSpace(stdOut))
                     {
-                        AnsiConsole.Console.MarkupLine($"\nCommand stdout :\n[lightgreen]{stdOut}[/]");
+                        AnsiConsole.Console.MarkupLine($"\n[lightgreen]{stdOut}[/]");
                     }
-                    else
+                    if (!string.IsNullOrWhiteSpace(stdErr))
                     {
-                        AnsiConsole.Console.MarkupLine($"\nCommand stderr :\n[lightred]{stdErr}[/]");
+                        AnsiConsole.Console.MarkupLine($"\n[lightred]{stdErr}[/]");
+                    }
+                    if (exitCode != 0)
+                    {
+                        AnsiConsole.Console.WriteLine($"\nCommand exit code: {exitCode}");
                     }
 
                     return new ValueTask<FlowStepResult>(FlowStepResult.Success);

--- a/tools/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                 projects = _fileSystem.EnumerateFiles(workingDirectory, "*.csproj", SearchOption.AllDirectories).ToList();
             }
             
-            return projects.Select(x => Tuple.Create(GetProjectDisplayName(x, workingDirectory), x)).ToList();
+            return projects.Select(x => Tuple.Create(GetProjectDisplayName(x), x)).ToList();
         }
 
         internal IList<string> GetProjectsFromSolutionFiles(List<string> solutionFiles, string workingDir)
@@ -267,7 +267,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             return projectPaths;
         }
 
-        internal string GetProjectDisplayName(string projectPath, string workingDir)
+        private static string GetProjectDisplayName(string projectPath)
         {
             return Path.GetFileNameWithoutExtension(projectPath);
         }


### PR DESCRIPTION
- More cleanup on App host project command argument and its naming relative to the other project argument.
- Consolidating the web/api project command arguments into one Project command argument. It really doesn't matter in Aspire what type of thing it is - it could be web, web api, worker, even a WPF app or something. I started to just call it `.NET Project` in the display name but that felt _too_ generic. Went with Brady's suggestion of Web or worker for now.
- Missed one place when changing the version from 0.1.0 back to 9.0.0
- Turned off showing the selected options on launch at least for now since we're rarely doing it and it just clutters the demo
- Changed the way we displayed the output from the commands so that we always display both stdout/stderr regardless of exit code (there can be both regardless of exit code) but only display the exit code if it is non-zero. 
- Hid the command being executed as it clutters the demo at the moment
- Left a few TODOs in the command execute flow step