### PR TITLE
Stream output from tools

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
@@ -23,9 +23,11 @@ public static class DotnetCommands
             }
 
             arguments.Add("--prerelease");
-            logger.LogMessage(string.Format("\nAdding package '{0}'", packageName));
+            logger.LogMessage(string.Format("\nAdding package '{0}'...", packageName));
 
             var runner = DotnetCliRunner.CreateDotNet("add", arguments);
+
+            // Buffer the output here because we'll only display it in the failure scenario
             var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
 
             if (exitCode != 0)
@@ -40,12 +42,10 @@ public static class DotnetCommands
                 }
 
                 logger.LogMessage("Failed!");
-                logger.LogMessage($"stdout :\n{stdOut}");
-                logger.LogMessage($"stderr :\n{stdErr}");
             }
             else
             {
-                logger.LogMessage("DONE");
+                logger.LogMessage("Done");
             }
         }
     }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Roslyn/ProjectModifier.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Roslyn/ProjectModifier.cs
@@ -54,7 +54,6 @@ public class ProjectModifier
             Document? originalDocument = roslynProject?.GetDocument(file.FileName);
             var modifiedDocument = await HandleCodeFileAsync(originalDocument, file, _codeChangeOptions);
             var relativeModifiedPath = modifiedDocument?.FilePath.MakeRelativePath(_environmentService.CurrentDirectory) ?? modifiedDocument?.Name.MakeRelativePath(_environmentService.CurrentDirectory);
-            _consoleLogger.LogMessage($"Modified '{relativeModifiedPath}'\n");
             roslynProject = modifiedDocument?.Project;
         }
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services
             if (GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(dotnetToolName, StringComparison.OrdinalIgnoreCase)) != null)
             {
                 var runner = DotnetCliRunner.Create(dotnetToolName, ["get-commands"]);
-                var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
+                var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
                 if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
                 {
                     try
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services
             }
             
             var runner = DotnetCliRunner.CreateDotNet("tool", installParams);
-            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
             return exitCode == 0;
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services
         {
             var dotnetToolList = new List<DotNetToolInfo>();
             var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);
-            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
+            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
             if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
             {
                 var stdOutByLine = stdOut.Split(System.Environment.NewLine);

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -41,8 +41,25 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 return -1;
             }
 
+            _logger.LogMessage("Installing packages...");
             InstallPackages(settings);
-            return await UpdateAppHostAsync(settings) && await UpdateWebAppAsync(settings) ? 0 : -1;
+
+            _logger.LogMessage("Updating App host project...");
+            var appHostResult = await UpdateAppHostAsync(settings);
+
+            _logger.LogMessage("Updating web/worker project...");
+            var workerResult = await UpdateWebAppAsync(settings);
+
+            if (appHostResult && workerResult)
+            {
+                _logger.LogMessage("Finished");
+                return 0;
+            }
+            else
+            {
+                _logger.LogMessage("An error occurred.");
+                return -1;
+            }
         }
 
         public class CachingCommandSettings : CommandSettings

--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -44,13 +44,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             if (!string.IsNullOrEmpty(componentName) && parameterValues.Count != 0 && !string.IsNullOrEmpty(commandObj.Name))
             {
                 var componentExecutionString = $"{componentName} {string.Join(" ", parameterValues)}";
-                string? stdOut = null, stdErr = null;
                 int? exitCode = null;
-                AnsiConsole.Status().WithSpinner()
-                    .Start($"Executing '{componentExecutionString}'", statusContext =>
+                AnsiConsole.Status()
+                    .Start($"Executing '{componentName}'", statusContext =>
                     {
                         var cliRunner = DotnetCliRunner.Create(componentName, parameterValues);
-                        exitCode = cliRunner.ExecuteAndCaptureOutput(out stdOut, out stdErr);
+                        exitCode = cliRunner.ExecuteWithCallbacks(
+                            (s) => AnsiConsole.Console.MarkupLine($"[lightgreen]{s}[/]"),
+                            (s) => AnsiConsole.Console.MarkupLine($"[lightred]{s}[/]"));
                     });
 
                 if (exitCode != null)
@@ -59,16 +60,6 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                     // demo noisy
                     //AnsiConsole.Console.WriteLine($"\nCommand: '{componentExecutionString}'");
 
-                    // TODO: Long-term we probably want to pipe these out as we get them rather than
-                    // just collect them, otherwise they're out of order
-                    if (!string.IsNullOrWhiteSpace(stdOut))
-                    {
-                        AnsiConsole.Console.MarkupLine($"\n[lightgreen]{stdOut}[/]");
-                    }
-                    if (!string.IsNullOrWhiteSpace(stdErr))
-                    {
-                        AnsiConsole.Console.MarkupLine($"\n[lightred]{stdErr}[/]");
-                    }
                     if (exitCode != 0)
                     {
                         AnsiConsole.Console.WriteLine($"\nCommand exit code: {exitCode}");


### PR DESCRIPTION
- Changes the output from the dependent tools to be displayed as it happens rather than all at once when it exits.
- Tweaks the output of the aspire tool slightly just to clean things up a bit

This is what it looks like at the end now (it has the status spinner thing while it's working, and these come in one at a time now):

![image](https://github.com/dotnet/Scaffolding/assets/9613109/37d0ca67-3755-4d40-a54d-8934773033d5)
