### PR TITLE
Escape tool output

### DIFF
--- a/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -50,8 +50,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                     {
                         var cliRunner = DotnetCliRunner.Create(componentName, parameterValues);
                         exitCode = cliRunner.ExecuteWithCallbacks(
-                            (s) => AnsiConsole.Console.MarkupLine($"[lightgreen]{s}[/]"),
-                            (s) => AnsiConsole.Console.MarkupLine($"[lightred]{s}[/]"));
+                            (s) => AnsiConsole.Console.MarkupLineInterpolated($"[lightgreen]{s}[/]"),
+                            (s) => AnsiConsole.Console.MarkupLineInterpolated($"[lightred]{s}[/]"));
                     });
 
                 if (exitCode != null)


### PR DESCRIPTION
Per the [docs](https://spectreconsole.net/markup):

### Escaping Interpolated Strings
When working with interpolated strings, you can use the `MarkupInterpolated` and `MarkupLineInterpolated` methods to automatically escape the values in the interpolated string "holes".

The output from the tools often contains `[...]` sequences, which throws off the markup. This escapes that output.