### PR TITLE
Add --prerelease option

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Parameter.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.ComponentModel/Parameter.cs
@@ -55,5 +55,6 @@ public enum InteractivePickerType
     FilePicker,
     DbProviderPicker,
     ProjectPicker,
-    CustomPicker
+    CustomPicker,
+    YesNo
 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Helpers/General/DotnetCommands.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.General;
 
 public static class DotnetCommands
 {
-    public static void AddPackage(string packageName, ILogger logger, string? projectFile = null, string? packageVersion = null, string? tfm = null)
+    public static void AddPackage(string packageName, ILogger logger, string? projectFile = null, string? packageVersion = null, string? tfm = null, bool includePrerelease = false)
     {
         if (!string.IsNullOrEmpty(packageName))
         {
@@ -22,7 +22,10 @@ public static class DotnetCommands
                 arguments.AddRange(["-v", packageVersion]);
             }
 
-            arguments.Add("--prerelease");
+            if (includePrerelease)
+            {
+                arguments.Add("--prerelease");
+            }
             logger.LogMessage(string.Format("\nAdding package '{0}'...", packageName));
 
             var runner = DotnetCliRunner.CreateDotNet("add", arguments);

--- a/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -72,6 +72,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
             [CommandOption("--project <PROJECT>")]
             public required string Project { get; set; }
+
+            [CommandOption("--prerelease")]
+            public required bool Prerelease { get; set; }
         }
 
         internal async Task<bool> UpdateAppHostAsync(CachingCommandSettings commandSettings)
@@ -202,7 +205,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 DotnetCommands.AddPackage(
                     packageName: PackageConstants.CachingPackages.AppHostRedisPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.AppHostProject);
+                    projectFile: commandSettings.AppHostProject,
+                    includePrerelease: commandSettings.Prerelease);
             }
             
             PackageConstants.CachingPackages.CachingPackagesDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
@@ -211,7 +215,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 DotnetCommands.AddPackage(
                     packageName: projectPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.Project);
+                    projectFile: commandSettings.Project,
+                    includePrerelease: commandSettings.Prerelease);
             }
         }
 

--- a/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -42,6 +42,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
 
             [CommandOption("--project <PROJECT>")]
             public required string Project { get; set; }
+
+            [CommandOption("--prerelease")]
+            public required bool Prerelease { get; set; }
         }
 
         internal bool ValidateDatabaseCommandSettings(DatabaseCommandSettings commandSettings)
@@ -78,7 +81,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 DotnetCommands.AddPackage(
                     packageName: appHostPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.AppHostProject);
+                    projectFile: commandSettings.AppHostProject,
+                    includePrerelease: commandSettings.Prerelease);
             }
 
             PackageConstants.DatabasePackages.DatabasePackagesApiServiceDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
@@ -87,7 +91,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
                 DotnetCommands.AddPackage(
                     packageName: projectPackageName,
                     logger: _logger,
-                    projectFile: commandSettings.Project);
+                    projectFile: commandSettings.Project,
+                    includePrerelease: commandSettings.Prerelease);
             }
         }
     }

--- a/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/GetCommands.cs
@@ -51,14 +51,19 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
     {
         internal static Parameter AppHostProjectParameter = new() { Name = "--apphost-project", DisplayName = "Aspire App host project file", Description = "Aspire App host project for the scaffolding", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
         internal static Parameter ProjectParameter = new() { Name = "--project", DisplayName = "Web or worker project file", Description = "Web or worker project associated with the Aspire App host", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.ProjectPicker };
+
         internal static List<string> CachingTypeCustomValues = ["redis", "redis-with-output-caching"];
         internal static List<string> DatabaseTypeCustomValues = ["npgsql", "npgsql-efcore", "sqlserver-efcore", "cosmos-efcore"];
         internal static List<string> StorageTypeCustomValues = ["azure-storage-queues", "azure-storage-blobs", "azure-data-tables"];
+
         internal static Parameter CachingTypeParameter = new() { Name = "--type", DisplayName = "Caching type", Description = "Types of caching", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = CachingTypeCustomValues };
         internal static Parameter DatabaseTypeParameter = new() { Name = "--type", DisplayName = "Database type", Description = "Types of database", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = DatabaseTypeCustomValues };
         internal static Parameter StorageTypeParameter = new() { Name = "--type", DisplayName = "Storage type", Description = "Types of storage", Required = true, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = StorageTypeCustomValues };
-        internal static Parameter[] CachingParameters = [CachingTypeParameter, AppHostProjectParameter, ProjectParameter];
-        internal static Parameter[] DatabaseParameters = [DatabaseTypeParameter, AppHostProjectParameter, ProjectParameter];
-        internal static Parameter[] StorageParameters = [StorageTypeParameter, AppHostProjectParameter, ProjectParameter];
+
+        internal static Parameter PrereleaseParameter = new() { Name = "--prerelease", DisplayName = "Include prerelease packages?", Description = "Include prerelease package versions when installing latest Aspire components", Required = true, Type = BaseTypes.Bool, PickerType = InteractivePickerType.YesNo };
+
+        internal static Parameter[] CachingParameters = [CachingTypeParameter, AppHostProjectParameter, ProjectParameter, PrereleaseParameter];
+        internal static Parameter[] DatabaseParameters = [DatabaseTypeParameter, AppHostProjectParameter, ProjectParameter, PrereleaseParameter];
+        internal static Parameter[] StorageParameters = [StorageTypeParameter, AppHostProjectParameter, ProjectParameter, PrereleaseParameter];
     }
 }

--- a/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
+++ b/tools/dotnet-scaffold-aspire/Commands/StorageCommand.cs
@@ -43,6 +43,9 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
 
         [CommandOption("--project <PROJECT>")]
         public required string Project { get; set; }
+
+        [CommandOption("--prerelease")]
+        public required bool Prerelease { get; set; }
     }
 
     internal bool ValidateStorageCommandSettings(StorageCommandSettings commandSettings)
@@ -78,7 +81,8 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
             DotnetCommands.AddPackage(
                 packageName: PackageConstants.StoragePackages.AppHostStoragePackageName,
                 logger: _logger,
-                projectFile: commandSettings.AppHostProject);
+                projectFile: commandSettings.AppHostProject,
+                includePrerelease: commandSettings.Prerelease);
         }
 
         PackageConstants.StoragePackages.StoragePackagesDict.TryGetValue(commandSettings.Type, out string? projectPackageName);
@@ -87,7 +91,8 @@ internal class StorageCommand : Command<StorageCommand.StorageCommandSettings>
             DotnetCommands.AddPackage(
                 packageName: projectPackageName,
                 logger: _logger,
-                projectFile: commandSettings.Project);
+                projectFile: commandSettings.Project,
+                includePrerelease: commandSettings.Prerelease);
         }
     }
 }

--- a/tools/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/tools/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -106,6 +106,10 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                     stepOptions = GetProjectFiles();
                     converter = GetDisplayNameForProjects;
                     break;
+                case InteractivePickerType.YesNo:
+                    stepOptions = [new() { Name = "Yes", Value = "true" }, new() { Name = "No", Value = "false" }];
+                    converter = GetDisplayNameForYesNo;
+                    break;
                 case InteractivePickerType.CustomPicker:
                     stepOptions = GetCustomValues(_parameter.CustomPickerValues);
                     break;
@@ -117,7 +121,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             }
 
             var prompt = new FlowSelectionPrompt<StepOption>()
-                .Title($"[lightseagreen]Pick a {_parameter.DisplayName}: [/]")
+                .Title($"[lightseagreen]{_parameter.DisplayName}: [/]")
                 .Converter(converter)
                 .AddChoices(stepOptions, navigation: context.Navigation);
 
@@ -147,6 +151,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var pathDisplay = stepOption.Value.MakeRelativePath(_environmentService.CurrentDirectory) ?? stepOption.Value;
             return $"{stepOption.Name} {pathDisplay.ToSuggestion(withBrackets: true)}";
         }
+
+        private string GetDisplayNameForYesNo(StepOption stepOption) => stepOption.Name;
 
         private ValidationResult Validate(IFlowContext context, string promptVal)
         {


### PR DESCRIPTION
- Adds a yes/no picker to keep in the "flow" of moving up/down through the options that we have for all the other selections rather than having to move to the y/n keys to answer the question with a confirmation prompt.
- Uses the yes/no picker to add a `--prerelease` option for each of the aspire commands that determines if we install the latest prerelease package (if you say Yes) or the latest release package (if you say No).