### PR TITLE
Remove -pt images from 8.0 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -54,7 +54,7 @@ extends:
             timeoutInMinutes: 180
             pool:
               name: $(DncEngInternalBuildPool)
-              image: 1es-windows-2022-pt
+              image: 1es-windows-2022
             variables:
             - _Script: eng\common\cibuild.cmd
             - _ValidateSdkArgs: ''


### PR DESCRIPTION
The `-pt` images were removed once they were redundant with the base images. We should no longer reference them. This change was already made in main but needed to be made in servicing branches as well.