### PR TITLE
Remove -pt images from 6.0 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Svc-Internal
-        image: 1es-windows-2019-pt
+        image: 1es-windows-2019
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -53,7 +53,7 @@ extends:
             timeoutInMinutes: 180
             pool:
               name: NetCore1ESPool-Svc-Internal
-              image: 1es-windows-2019-pt
+              image: 1es-windows-2019
             variables:
             - _Script: eng\common\cibuild.cmd
             - _ValidateSdkArgs: ''


### PR DESCRIPTION
The `-pt` images were removed once they were redundant with the base images. We should no longer reference them. This change was already made in main but needed to be made in servicing branches as well.