### PR TITLE
Change PR builds to use macos-13 image

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -79,7 +79,7 @@ stages:
         - job: OSX
           timeoutInMinutes: 180
           pool:
-            vmImage: macOS-11
+            vmImage: macOS-13
           strategy:
             matrix:
               release_configuration:


### PR DESCRIPTION
MacOS 11 was EOL in September 2023, s we should probably move to newer supported machines. 