### PR TITLE
Bring back strong naming for dotnet-scaffolding packages

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -9,7 +9,7 @@
     <PackageTags>dotnet;scaffold;aspire;</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold-aspire</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold.Aspire</RootNamespace>
-    <SignAssembly>false</SignAssembly>
+    <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.Aspire.props" />

--- a/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
@@ -8,7 +8,7 @@
     <PackageTags>dotnet;scaffold</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold</RootNamespace>
-    <SignAssembly>false</SignAssembly>
+    <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.Scaffold.props" />


### PR DESCRIPTION
This gets around Spectre.Console not being strong named while still keeping our stuff strong named. Since strong naming doesn't provide any actual value in .NET (Core/5+) and we don't ship this for .NET Framework, there shouldn't be any harm in ignoring these warnings.