### PR TITLE
adding new DbContext in aspire database scenarios

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -47,10 +47,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             _logger.LogMessage("Updating App host project...");
             var appHostResult = await UpdateAppHostAsync(settings);
 
+            _logger.LogMessage("Adding new DbContext...");
+            var dbContextCreationResult = CreateNewDbContext(settings);
+
             _logger.LogMessage("Updating web/worker project...");
             var workerResult = await UpdateWebAppAsync(settings);
 
-            if (appHostResult && workerResult)
+            if (appHostResult && dbContextCreationResult && workerResult)
             {
                 _logger.LogMessage("Finished");
                 return 0;
@@ -66,15 +69,12 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
         /// generate a path for DbContext, then use DbContextHelper.CreateDbContext to invoke 'NewDbContext.tt'
         /// DbContextHelper.CreateDbContext will also write the resulting templated string (class text) to disk
         /// </summary>
-        private void CreateNewDbContext(DatabaseCommandSettings settings)
+        private bool CreateNewDbContext(DatabaseCommandSettings settings)
         {
             var newDbContextPath = CreateNewDbContextPath(settings);
             var relativeContextPath = Path.GetRelativePath(settings.Project, newDbContextPath);
             var dbContextCreated = DbContextHelper.CreateDbContext(GetCmdsHelper.SqlServerDefaults, newDbContextPath, _fileSystem);
-            if (dbContextCreated)
-            {
-                _logger.LogMessage($"Created '{relativeContextPath}'");
-            }
+            return dbContextCreated;
         }
 
         private string CreateNewDbContextPath(DatabaseCommandSettings commandSettings)

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
@@ -32,6 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Pack="true" Include="$(RepoRoot)src\Shared\Microsoft.DotNet.Scaffolding.Helpers\Templates\DbContext\*.tt" PackagePath="Templates\DbContext\" />
+    <None Pack="true" Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.Helpers\Templates\DbContext\*.tt" PackagePath="Templates\DbContext\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
we missed adding the 'NewDbContext' for the `dotnet scaffold aspire database` scenarios in the database scenario [PR](https://github.com/dotnet/Scaffolding/pull/2767)