### PR TITLE
Remove encoding override

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/AnsiConsoleLogger.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/AnsiConsoleLogger.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DotNet.Tools.Scaffold.Services
             CommandName = commandName ?? string.Empty;
             _jsonOutput = jsonOutput;
             _silent = silent;
-            AnsiConsole.Console.Profile.Encoding = Encoding.UTF8;
         }
 
         public void LogMessage(string? message, LogMessageType level, bool removeNewLine = false)


### PR DESCRIPTION
Spectre.Console has [logic in it](https://github.com/spectreconsole/spectre.console/blob/5c87d7fa04424faadf54686f92709af277ec28b3/src/Spectre.Console/AnsiConsoleFactory.cs#L31) to detect the output encoding of the shell being used, but we had a line in AnsiConsoleLogger that always overrode that to make it be Utf8. That worked ok in a lot of shells that were Utf8 natively (like powershell core) but some (e.g. Windows Powershell) did not have Utf8 enabled by default and this led to rendering bugs like this:

![image](https://github.com/dotnet/Scaffolding/assets/9613109/d6a5087d-fcbe-4dd4-a705-7c2e1b84976c)

Removing this one line appears to allow the default detection through