### PR TITLE
fix project discovery (for macOS and linux)

### DIFF
--- a/scripts/install-scaffold-aspire.sh
+++ b/scripts/install-scaffold-aspire.sh
@@ -9,8 +9,8 @@ NUPKG=artifacts/packages/Debug/Shipping/
 #kill all dotnet procs
 pkill -f dotnet
 rm -rf artifacts
-dotnet pack src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj -c Debug
-dotnet tool uninstall -g Microsoft.dotnet-scaffold
+dotnet pack src/dotnet-scaffolding/dotnet-scaffold-aspire/dotnet-scaffold-aspire.csproj
+dotnet tool uninstall -g Microsoft.dotnet-scaffold-aspire
 cd "$OLDPWD"/$NUPKG 
 dotnet tool install -g Microsoft.dotnet-scaffold --add-source $SRC_DIR/$NUPKG  --version $VERSION
 cd "$OLDPWD"

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/StringUtil.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/StringUtil.cs
@@ -29,6 +29,22 @@ internal static class StringUtil
         return path;
     }
 
+    //normalize the path separators between mac/linux and windows. 
+    //replacing the other platform's path separator with the one we're on.
+    public static string NormalizePathSeparators(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+        
+        // get current platform's path separator
+        string currentSeparator = Path.DirectorySeparatorChar.ToString();
+        string otherSeparator = Path.DirectorySeparatorChar == '/' ? "\\" : "/";
+        //replace the other platform's separator with the current one.
+        return path.Replace(otherSeparator, currentSeparator);
+    }
+
     //remove prefix from namespace, used to remove the project name from namespace when creating the path
     public static string RemovePrefix(string projectNamespace, string basePath, string prefix)
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -266,8 +266,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             {
                 var normalizedPath = StringUtil.NormalizePathSeparators(projectPath);
                 var projectName = Path.GetFileName(normalizedPath);
-                //not using case comparison, seems like macOS/Linux project names in the .sln file are not case sensitive. 
-                if (!baseProjectNames.Contains(projectName))
+                //not making a case-sensitive comparison, seems like macOS/Linux project names in the .sln file are not case sensitive. 
+                if (!baseProjectNames.Contains(projectName, StringComparer.OrdinalIgnoreCase))
                 {
                     baseList.Add(normalizedPath);
                 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -233,10 +233,10 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                 return [];
             }
 
-            var projects = _fileSystem.EnumerateFiles(workingDirectory, "*.csproj", SearchOption.AllDirectories).ToList();
+            List<string> projects = _fileSystem.EnumerateFiles(workingDirectory, "*.csproj", SearchOption.AllDirectories).ToList();
             var slnFiles = _fileSystem.EnumerateFiles(workingDirectory, "*.sln", SearchOption.TopDirectoryOnly).ToList();
-            var projectsFromSlnFiles = GetProjectsFromSolutionFiles(slnFiles, workingDirectory);
-            projects = projects.Union(projectsFromSlnFiles).ToList();
+            List<string> projectsFromSlnFiles = GetProjectsFromSolutionFiles(slnFiles, workingDirectory);
+            projects = AddUniqueProjects(projects, projectsFromSlnFiles);
 
             //should we search in all directories if nothing in top level? (yes, for now)
             if (projects.Count == 0)
@@ -247,7 +247,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             return projects.Select(x => new StepOption() { Name = GetProjectDisplayName(x), Value = x }).ToList();
         }
 
-        internal IList<string> GetProjectsFromSolutionFiles(List<string> solutionFiles, string workingDir)
+        internal List<string> GetProjectsFromSolutionFiles(List<string> solutionFiles, string workingDir)
         {
             List<string> projectPaths = [];
             foreach (var solutionFile in solutionFiles)
@@ -256,6 +256,21 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             }
 
             return projectPaths;
+        }
+
+        internal List<string> AddUniqueProjects(List<string> baseList, List<string> projectPathsToAdd)
+        {
+            var baseProjectNames = baseList.Select(x => Path.GetFileName(x));
+            foreach(var projectPath in projectPathsToAdd)
+            {
+                var projectName = Path.GetFileName(projectPath);
+                if (!baseProjectNames.Contains(projectName))
+                {
+                    baseList.Add(projectPath);
+                }
+            }
+
+            return baseList;
         }
 
         internal IList<string> GetProjectsFromSolutionFile(string solutionFilePath, string workingDir)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -266,6 +266,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             {
                 var normalizedPath = StringUtil.NormalizePathSeparators(projectPath);
                 var projectName = Path.GetFileName(normalizedPath);
+                //not using case comparison, seems like macOS/Linux project names in the .sln file are not case sensitive. 
                 if (!baseProjectNames.Contains(projectName))
                 {
                     baseList.Add(normalizedPath);

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Scaffolding.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Helpers.Extensions;
+using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
 using Spectre.Console;
@@ -263,10 +264,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var baseProjectNames = baseList.Select(x => Path.GetFileName(x));
             foreach(var projectPath in projectPathsToAdd)
             {
-                var projectName = Path.GetFileName(projectPath);
+                var normalizedPath = StringUtil.NormalizePathSeparators(projectPath);
+                var projectName = Path.GetFileName(normalizedPath);
                 if (!baseProjectNames.Contains(projectName))
                 {
-                    baseList.Add(projectPath);
+                    baseList.Add(normalizedPath);
                 }
             }
 


### PR DESCRIPTION
Duplicate project files were being displayed when using `InteractivePickerType.ProjectPicker`
- project files discovered rom `.sln` were not being normalized (based on platform) and duplicates were being added.
- fixed scripts for installing tools on macOS and linux.