### PR TITLE
Remove redundant msbuild props

### DIFF
--- a/eng/Versions.MSIdentity.props
+++ b/eng/Versions.MSIdentity.props
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Opt out of certain Arcade features -->
-  <PropertyGroup>
-    <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-  </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>2.0.7</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>


### PR DESCRIPTION
Thes are already set in Versions.props: 

https://github.com/dotnet/Scaffolding/blob/aa14b4c5fa67c21cd1093d242cd7a537a5317981/eng/Versions.props#L3-L7

which is imported first into the same projects as part of the default arcade imports.. Essentially the things in this file (Versions.MSIdentity.props) just override a few things in Versions.props.

Just something small I noticed while preparing for Centralized Package Management