### PR TITLE
Bootstrap5: Refactor unnecessary else block

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DeletePageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DeletePageModel.cshtml
@@ -62,15 +62,14 @@ namespace @Model.NamespaceName
 
             var @viewDataTypeShortNameLowerCase = await _context.@(entitySetName).FirstOrDefaultAsync(m => m.@primaryKeyName == id);
 
-            if (@viewDataTypeShortNameLowerCase == null)
-            {
-                return NotFound();
-            }
-            else
+            if (@viewDataTypeShortNameLowerCase is not null)
             {
                 @Model.ViewDataTypeShortName = @viewDataTypeShortNameLowerCase;
+
+                return Page();
             }
-            return Page();
+
+            return NotFound();
         }
 
         public async Task<IActionResult> OnPostAsync(@primaryKeyNullableTypeName id)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DetailsPageModel.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap5/DetailsPageModel.cshtml
@@ -55,15 +55,15 @@ namespace @Model.NamespaceName
             }
 
             var @viewDataTypeShortNameLowerCase = await _context.@(entitySetName).FirstOrDefaultAsync(m => m.@primaryKeyName == id);
-            if (@viewDataTypeShortNameLowerCase == null)
-            {
-                return NotFound();
-            }
-            else
+
+            if (@viewDataTypeShortNameLowerCase is not null)
             {
                 @Model.ViewDataTypeShortName = @viewDataTypeShortNameLowerCase;
+
+                return Page();
             }
-            return Page();
+
+            return NotFound();
         }
     }
 }


### PR DESCRIPTION
Refactored the `OnGetAsync` method to simplify control flow by removing the unnecessary else statement and moving the `return Page();` inside the conditional check where record is not null. This enhances readability and reduces nesting.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


