### PR TITLE
adding empty scaffolders for dotnet-scaffold-aspnet

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/ApiControllerEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/ApiControllerEmptyCommand.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Helpers.General;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.API;
+
+internal class ApiControllerEmptyCommand : Command<ApiControllerEmptyCommand.ApiControllerEmptySettings>
+{
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    public ApiControllerEmptyCommand(IFileSystem fileSystem, ILogger logger)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] ApiControllerEmptySettings settings)
+    {
+        if (!ValidateApiControllerEmptyCommandSettings(settings))
+        {
+            return -1;
+        }
+
+        _logger.LogMessage("Adding API Controller...");
+        var addingComponentResult = AddEmptyApiController(settings);
+
+        if (addingComponentResult)
+        {
+            _logger.LogMessage("Finished");
+            return 0;
+        }
+        else
+        {
+            _logger.LogMessage("An error occurred.");
+            return -1;
+        }
+    }
+
+    private bool AddEmptyApiController(ApiControllerEmptySettings settings)
+    {
+        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        if (Directory.Exists(projectBasePath))
+        {
+            var apiControllerName = settings.Name;
+            var actionsParameter = settings.Actions ? "--actions" : string.Empty;
+            //arguments for 'dotnet new apicontroller'
+            var args = new List<string>()
+            {
+                "apicontroller",
+                "--name",
+                apiControllerName,
+                "--output",
+                projectBasePath,
+                actionsParameter
+            };
+
+            var runner = DotnetCliRunner.CreateDotNet("new", args);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
+            return exitCode == 0;
+        }
+
+        return false;
+    }
+
+    private bool ValidateApiControllerEmptyCommandSettings(ApiControllerEmptySettings commandSettings)
+    {
+        if (string.IsNullOrEmpty(commandSettings.Project) || !_fileSystem.FileExists(commandSettings.Project))
+        {
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(commandSettings.Name))
+        {
+            _logger.LogMessage("Missing/Invalid --name option.", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
+    public class ApiControllerEmptySettings : CommandSettings
+    {
+        [CommandOption("--project <PROJECT>")]
+        public string? Project { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        public required string Name { get; init; }
+
+        [CommandOption("--actions <ACTIONS>")]
+        public required bool Actions { get; init; }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/ApiControllerEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/ApiControllerEmptyCommand.cs
@@ -44,7 +44,8 @@ internal class ApiControllerEmptyCommand : Command<ApiControllerEmptyCommand.Api
     private bool AddEmptyApiController(ApiControllerEmptySettings settings)
     {
         var projectBasePath = Path.GetDirectoryName(settings.Project);
-        if (Directory.Exists(projectBasePath))
+        var projectName = Path.GetFileNameWithoutExtension(settings.Project);
+        if (!string.IsNullOrEmpty(projectName) && Directory.Exists(projectBasePath))
         {
             var apiControllerName = settings.Name;
             var actionsParameter = settings.Actions ? "--actions" : string.Empty;
@@ -56,6 +57,8 @@ internal class ApiControllerEmptyCommand : Command<ApiControllerEmptyCommand.Api
                 apiControllerName,
                 "--output",
                 projectBasePath,
+                "--namespace",
+                projectName,
                 actionsParameter
             };
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorEmptyCommand.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Cli;
+
+using Microsoft.DotNet.Scaffolding.Helpers.General;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Blazor;
+
+internal class BlazorEmptyCommand : Command<BlazorEmptyCommand.BlazorEmptySettings>
+{
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    public BlazorEmptyCommand(IFileSystem fileSystem, ILogger logger)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] BlazorEmptySettings settings)
+    {
+        if (!ValidateBlazorEmptyCommandSettings(settings))
+        {
+            return -1;
+        }
+
+        _logger.LogMessage("Adding Razor Component...");
+        var addingComponentResult = AddEmptyRazorComponent(settings);
+
+        if (addingComponentResult)
+        {
+            _logger.LogMessage("Finished");
+            return 0;
+        }
+        else
+        {
+            _logger.LogMessage("An error occurred.");
+            return -1;
+        }
+    }
+
+    private bool AddEmptyRazorComponent(BlazorEmptySettings settings)
+    {
+        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        if (Directory.Exists(projectBasePath))
+        {
+            var razorComponentName = settings.Name;
+            //arguments for 'dotnet new razorcomponent'
+            var args = new List<string>()
+            {
+                "razorcomponent",
+                "--name",
+                razorComponentName,
+                "--output",
+                projectBasePath
+            };
+
+            var runner = DotnetCliRunner.CreateDotNet("new", args);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
+            return exitCode == 0;
+        }
+
+        return false;
+    }
+
+    private bool ValidateBlazorEmptyCommandSettings(BlazorEmptySettings commandSettings)
+    {
+        if (string.IsNullOrEmpty(commandSettings.Project) || !_fileSystem.FileExists(commandSettings.Project))
+        {
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(commandSettings.Name))
+        {
+            _logger.LogMessage("Missing/Invalid --name option.", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
+    public class BlazorEmptySettings : CommandSettings
+    {
+        [CommandOption("--project <PROJECT>")]
+        public string? Project { get; set; }
+
+        [CommandOption("--name <NAME>")]
+        public required string Name { get; set; }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/GetCommands.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/GetCommands.cs
@@ -29,6 +29,46 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
                     DisplayCategory = "MVC",
                     Description = "Generates an Area folder structure.",
                     Parameters = GetCmdsHelper.AreaParameters // Add parameters if any
+                },
+                new()
+                {
+                    Name = "blazor-empty",
+                    DisplayName = "Razor Component - Empty",
+                    DisplayCategory = "Blazor",
+                    Description = "Generates an empty Razor Component (.razor) file.",
+                    Parameters = GetCmdsHelper.BlazorEmptyParameters
+                },
+                new()
+                {
+                    Name = "razorpage-empty",
+                    DisplayName = "Razor Page - Empty",
+                    DisplayCategory = "Web",
+                    Description = "Generates an empty Razor Page (.cshtml) file.",
+                    Parameters = GetCmdsHelper.RazorPageEmptyParameters
+                },
+                new()
+                {
+                    Name = "mvccontroller-empty",
+                    DisplayName = "MVC Controller - Empty",
+                    DisplayCategory = "MVC",
+                    Description = "Generates an empty MVC Controller (.cs) file.",
+                    Parameters = GetCmdsHelper.MvcControllerEmptyParameters
+                },
+                new()
+                {
+                    Name = "apicontroller-empty",
+                    DisplayName = "API Controller - Empty",
+                    DisplayCategory = "API",
+                    Description = "Generates an empty API Controller (.cs) file.",
+                    Parameters = GetCmdsHelper.ApiControllerEmptyParameters
+                },
+                new()
+                {
+                    Name = "razorview-empty",
+                    DisplayName = "Razor View - Empty",
+                    DisplayCategory = "MVC",
+                    Description = "Generates an empty Razor View",
+                    Parameters = GetCmdsHelper.RazorViewEmptyParameters
                 }
                 // Add other commands here
             };
@@ -49,7 +89,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
         internal static Parameter DatabaseProvider = new() { Name = "--dbProvider", DisplayName = "Database Provider", Description = "", Required = false, Type = BaseTypes.String, PickerType = InteractivePickerType.CustomPicker, CustomPickerValues = [.. AspNetDbContextHelper.DatabaseTypeDefaults.Keys] };
         internal static Parameter PrereleaseParameter = new() { Name = "--prerelease", DisplayName = "Include prerelease packages?", Description = "Include prerelease package versions when installing latest Aspire components", Required = true, Type = BaseTypes.Bool, PickerType = InteractivePickerType.YesNo };
         internal static Parameter AreaName = new() { Name = "--name", DisplayName = "Area Name", Description = "Name for the area being created", Required = true, Type = BaseTypes.String };
+        internal static Parameter FileName = new() { Name = "--name", DisplayName = "File Name", Description = "Name for the item being created", Required = true, Type = BaseTypes.String };
+        internal static Parameter Actions = new() { Name = "--actions", DisplayName = "Read/Write Actions", Description = "Create controller with read/write actions?", Required = true, Type = BaseTypes.Bool, PickerType = InteractivePickerType.YesNo };
         internal static Parameter[] AreaParameters = [Project, AreaName];
         internal static Parameter[] MinimalApiParameters = [Project, ModelName, EndpointsClass, DataContextClass, DatabaseProvider, OpenApi, PrereleaseParameter];
+        internal static Parameter[] BlazorEmptyParameters = [Project, FileName];
+        internal static Parameter[] MvcControllerEmptyParameters = [Project, FileName, Actions];
+        internal static Parameter[] ApiControllerEmptyParameters = [Project, FileName, Actions];
+        internal static Parameter[] RazorPageEmptyParameters = [Project, FileName];
+        internal static Parameter[] RazorViewEmptyParameters = [Project, FileName];
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/MvcControllerEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/MvcControllerEmptyCommand.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Helpers.General;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MVC;
+
+internal class MvcControllerEmptyCommand : Command<MvcControllerEmptyCommand.MvcControllerEmptySettings>
+{
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    public MvcControllerEmptyCommand(IFileSystem fileSystem, ILogger logger)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] MvcControllerEmptySettings settings)
+    {
+        if (!ValidateMvcControllerEmptyCommandSettings(settings))
+        {
+            return -1;
+        }
+
+        _logger.LogMessage("Adding MVC Controller...");
+        var addingComponentResult = AddEmptyMvcController(settings);
+
+        if (addingComponentResult)
+        {
+            _logger.LogMessage("Finished");
+            return 0;
+        }
+        else
+        {
+            _logger.LogMessage("An error occurred.");
+            return -1;
+        }
+    }
+
+    private bool AddEmptyMvcController(MvcControllerEmptySettings settings)
+    {
+        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        if (Directory.Exists(projectBasePath))
+        {
+            var mvcControllerName = settings.Name;
+            var actionsParameter = settings.Actions ? "--actions" : string.Empty;
+            //arguments for 'dotnet new mvccontroller'
+            var args = new List<string>()
+            {
+                "mvccontroller",
+                "--name",
+                mvcControllerName,
+                "--output",
+                projectBasePath,
+                actionsParameter
+            };
+
+            var runner = DotnetCliRunner.CreateDotNet("new", args);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
+            return exitCode == 0;
+        }
+
+        return false;
+    }
+
+    private bool ValidateMvcControllerEmptyCommandSettings(MvcControllerEmptySettings commandSettings)
+    {
+        if (string.IsNullOrEmpty(commandSettings.Project) || !_fileSystem.FileExists(commandSettings.Project))
+        {
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(commandSettings.Name))
+        {
+            _logger.LogMessage("Missing/Invalid --name option.", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
+    public class MvcControllerEmptySettings : CommandSettings
+    {
+        [CommandOption("--project <PROJECT>")]
+        public string? Project { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        public required string Name { get; init; }
+
+        [CommandOption("--actions <ACTIONS>")]
+        public required bool Actions { get; init; }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/MvcControllerEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/MvcControllerEmptyCommand.cs
@@ -44,7 +44,8 @@ internal class MvcControllerEmptyCommand : Command<MvcControllerEmptyCommand.Mvc
     private bool AddEmptyMvcController(MvcControllerEmptySettings settings)
     {
         var projectBasePath = Path.GetDirectoryName(settings.Project);
-        if (Directory.Exists(projectBasePath))
+        var projectName = Path.GetFileNameWithoutExtension(settings.Project);
+        if (!string.IsNullOrEmpty(projectName) && Directory.Exists(projectBasePath))
         {
             var mvcControllerName = settings.Name;
             var actionsParameter = settings.Actions ? "--actions" : string.Empty;
@@ -56,6 +57,8 @@ internal class MvcControllerEmptyCommand : Command<MvcControllerEmptyCommand.Mvc
                 mvcControllerName,
                 "--output",
                 projectBasePath,
+                "--namespace",
+                projectName,
                 actionsParameter
             };
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/RazorViewEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MVC/RazorViewEmptyCommand.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Helpers.General;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MVC;
+
+internal class RazorViewEmptyCommand : Command<RazorViewEmptyCommand.RazorViewEmptySettings>
+{
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    public RazorViewEmptyCommand(IFileSystem fileSystem, ILogger logger)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] RazorViewEmptySettings settings)
+    {
+        if (!ValidateRazorViewEmptyCommandSettings(settings))
+        {
+            return -1;
+        }
+
+        _logger.LogMessage("Adding Razor View...");
+        var addingComponentResult = AddEmptyRazorView(settings);
+
+        if (addingComponentResult)
+        {
+            _logger.LogMessage("Finished");
+            return 0;
+        }
+        else
+        {
+            _logger.LogMessage("An error occurred.");
+            return -1;
+        }
+    }
+
+    private bool AddEmptyRazorView(RazorViewEmptySettings settings)
+    {
+        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        if (Directory.Exists(projectBasePath))
+        {
+            var razorViewName = settings.Name;
+            //arguments for 'dotnet new view'
+            var args = new List<string>()
+            {
+                "view",
+                "--name",
+                razorViewName,
+                "--output",
+                projectBasePath
+            };
+
+            var runner = DotnetCliRunner.CreateDotNet("new", args);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
+            return exitCode == 0;
+        }
+
+        return false;
+    }
+
+    private bool ValidateRazorViewEmptyCommandSettings(RazorViewEmptySettings commandSettings)
+    {
+        if (string.IsNullOrEmpty(commandSettings.Project) || !_fileSystem.FileExists(commandSettings.Project))
+        {
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(commandSettings.Name))
+        {
+            _logger.LogMessage("Missing/Invalid --name option.", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
+    public class RazorViewEmptySettings : CommandSettings
+    {
+        [CommandOption("--project <PROJECT>")]
+        public string? Project { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        public required string Name { get; init; }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Razor Pages/RazorPageEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Razor Pages/RazorPageEmptyCommand.cs
@@ -44,17 +44,20 @@ internal class RazorPageEmptyCommand : Command<RazorPageEmptyCommand.RazorPageEm
     private bool AddEmptyRazorPage(RazorPageEmptySettings settings)
     {
         var projectBasePath = Path.GetDirectoryName(settings.Project);
-        if (Directory.Exists(projectBasePath))
+        var projectName = Path.GetFileNameWithoutExtension(settings.Project);
+        if (!string.IsNullOrEmpty(projectName) && Directory.Exists(projectBasePath))
         {
             var razorPageName = settings.Name;
             //arguments for 'dotnet new razorpage'
             var args = new List<string>()
             {
-                "razorpage",
+                "page",
                 "--name",
                 razorPageName,
                 "--output",
-                projectBasePath
+                projectBasePath,
+                "--namespace",
+                projectName
             };
 
             var runner = DotnetCliRunner.CreateDotNet("new", args);

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Razor Pages/RazorPageEmptyCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Razor Pages/RazorPageEmptyCommand.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Helpers.General;
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.RazorPage;
+
+internal class RazorPageEmptyCommand : Command<RazorPageEmptyCommand.RazorPageEmptySettings>
+{
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    public RazorPageEmptyCommand(IFileSystem fileSystem, ILogger logger)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] RazorPageEmptySettings settings)
+    {
+        if (!ValidateRazorPageEmptyCommandSettings(settings))
+        {
+            return -1;
+        }
+
+        _logger.LogMessage("Adding Razor Page...");
+        var addingPageResult = AddEmptyRazorPage(settings);
+
+        if (addingPageResult)
+        {
+            _logger.LogMessage("Finished");
+            return 0;
+        }
+        else
+        {
+            _logger.LogMessage("An error occurred.");
+            return -1;
+        }
+    }
+
+    private bool AddEmptyRazorPage(RazorPageEmptySettings settings)
+    {
+        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        if (Directory.Exists(projectBasePath))
+        {
+            var razorPageName = settings.Name;
+            //arguments for 'dotnet new razorpage'
+            var args = new List<string>()
+            {
+                "razorpage",
+                "--name",
+                razorPageName,
+                "--output",
+                projectBasePath
+            };
+
+            var runner = DotnetCliRunner.CreateDotNet("new", args);
+            var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
+            return exitCode == 0;
+        }
+
+        return false;
+    }
+
+    private bool ValidateRazorPageEmptyCommandSettings(RazorPageEmptySettings commandSettings)
+    {
+        if (string.IsNullOrEmpty(commandSettings.Project) || !_fileSystem.FileExists(commandSettings.Project))
+        {
+            _logger.LogMessage("Missing/Invalid --project option.", LogMessageType.Error);
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(commandSettings.Name))
+        {
+            _logger.LogMessage("Missing/Invalid --name option.", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
+    public class RazorPageEmptySettings : CommandSettings
+    {
+        [CommandOption("--project <PROJECT>")]
+        public string? Project { get; set; }
+
+        [CommandOption("--name <NAME>")]
+        public required string Name { get; set; }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -1,11 +1,13 @@
-using Microsoft.DotNet.Scaffolding.Helpers.Environment;
-using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands;
-using Spectre.Console.Cli;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.API;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Blazor;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi;
-using System.Diagnostics;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MVC;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.RazorPage;
+using Spectre.Console.Cli;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet;
 public static class Program
@@ -16,8 +18,13 @@ public static class Program
         var app = new CommandApp(serviceRegistrations);
         app.Configure(config =>
         {
+            config.AddCommand<BlazorEmptyCommand>("blazor-empty");
             config.AddCommand<MinimalApiCommand>("minimalapi");
+            config.AddCommand<ApiControllerEmptyCommand>("apicontroller-empty");
             config.AddCommand<AreaCommand>("area");
+            config.AddCommand<MvcControllerEmptyCommand>("mvccontroller-empty");
+            config.AddCommand<RazorViewEmptyCommand>("razorview-empty");
+            config.AddCommand<RazorPageEmptyCommand>("razorpage-empty");
             config.AddCommand<GetCmdsCommand>("get-commands");
         });
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
@@ -50,9 +50,8 @@ internal class CategoryDiscovery
         displayCategories = (_componentPicked != null ? allCommands?.Where(x => x.Key.Equals(_componentPicked.Command)) : allCommands)
             ?.Select(y => y.Value.DisplayCategory)
             ?.Distinct()
+            ?.Order()
             ?.ToList();
-        //using Sort() to sort 'DisplayCategory's alphabetically.
-        displayCategories?.Sort();
 
         var prompt = new FlowSelectionPrompt<string>()
             .Title("[lightseagreen]Pick a scaffolding category: [/]")

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Collections.Generic;
 using Microsoft.DotNet.Scaffolding.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
@@ -52,6 +51,8 @@ internal class CategoryDiscovery
             ?.Select(y => y.Value.DisplayCategory)
             ?.Distinct()
             ?.ToList();
+        //using Sort() to sort 'DisplayCategory's alphabetically.
+        displayCategories?.Sort();
 
         var prompt = new FlowSelectionPrompt<string>()
             .Title("[lightseagreen]Pick a scaffolding category: [/]")

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
@@ -52,14 +52,15 @@ internal class CommandDiscovery
         }
 
         var scaffoldingCategory = context.GetScaffoldingCategory();
-        var allCommandsByCategory = allCommands?.Where(x => x.Value.DisplayCategory.Equals(scaffoldingCategory)).ToList();
-        //using OrderBy() to sort 'DisplayName's alphabetically.
-        var sortedCommands = allCommandsByCategory?.OrderBy(kvp => kvp.Value.DisplayName).ToList();
+        var allCommandsByCategory = allCommands?
+            .Where(x => x.Value.DisplayCategory.Equals(scaffoldingCategory))
+            .OrderBy(kvp => kvp.Value.DisplayName)
+            .ToList();
 
         var prompt = new FlowSelectionPrompt<KeyValuePair<string, CommandInfo>>()
             .Title("[lightseagreen]Pick a scaffolding command: [/]")
             .Converter(GetCommandInfoDisplayName)
-            .AddChoices(sortedCommands, navigation: context.Navigation);
+            .AddChoices(allCommandsByCategory, navigation: context.Navigation);
 
         var result = prompt.Show();
         State = result.State;

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Scaffolding.ComponentModel;
@@ -54,11 +53,13 @@ internal class CommandDiscovery
 
         var scaffoldingCategory = context.GetScaffoldingCategory();
         var allCommandsByCategory = allCommands?.Where(x => x.Value.DisplayCategory.Equals(scaffoldingCategory)).ToList();
+        //using OrderBy() to sort 'DisplayName's alphabetically.
+        var sortedCommands = allCommandsByCategory?.OrderBy(kvp => kvp.Value.DisplayName).ToList();
 
         var prompt = new FlowSelectionPrompt<KeyValuePair<string, CommandInfo>>()
             .Title("[lightseagreen]Pick a scaffolding command: [/]")
             .Converter(GetCommandInfoDisplayName)
-            .AddChoices(allCommandsByCategory, navigation: context.Navigation);
+            .AddChoices(sortedCommands, navigation: context.Navigation);
 
         var result = prompt.Show();
         State = result.State;

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -54,8 +54,12 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                     }
 
                     return Validate(context, x);
-                })
-                .AllowEmpty();
+                });
+
+                if (!_parameter.Required)
+                {
+                    prompt = prompt.AllowEmpty();
+                }
 
                 await Task.Delay(1);
                 return AnsiConsole.Prompt(prompt).Trim();


### PR DESCRIPTION
Commands added for `dotnet-scaffold-aspnet` : `apicontroller-empty`, `mvccontroller-empty`, `razorpage-empty`, `razorview-empty`, `blazor-empty`
- only `--name` and `--project` options for all the new empty scaffolders
- `--actions` option for `mvccontroller-empty` and `apicontroller-empty` to enable read/write actions controller option
- all new commands into their respective `dotnet new` templates.
- sorting display options in `CommandDiscovery` and `CategoryDiscovery`

