### PR TITLE
switch AnsiConsole.Status to calling StartAsync instead of Start

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/CodeService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/CodeService.cs
@@ -60,7 +60,7 @@ internal class CodeService : ICodeService, IDisposable
         var workspace = MSBuildWorkspace.Create(_settings.GlobalProperties);
         workspace.WorkspaceFailed += OnWorkspaceFailed;
         workspace.LoadMetadataForReferencedProjects = true;
-        await workspace.OpenProjectAsync(path).ConfigureAwait(false);
+        await workspace.OpenProjectAsync(path);
         _workspace = workspace;
         return _workspace;
     }
@@ -126,7 +126,7 @@ internal class CodeService : ICodeService, IDisposable
         UnloadWorkspace();
     }
 
-    public async Task<IList<ISymbol>> GetAllClassSymbolsAsync()
+    public async Task<List<ISymbol>> GetAllClassSymbolsAsync()
     {
         List<ISymbol> classSymbols = [];
         if (_compilation is null)
@@ -161,7 +161,7 @@ internal class CodeService : ICodeService, IDisposable
         return classSymbols;
     }
 
-    public async Task<IList<Document>> GetAllDocumentsAsync()
+    public async Task<List<Document>> GetAllDocumentsAsync()
     {
         var workspace = await GetWorkspaceAsync();
         var project = workspace?.CurrentSolution?.GetProject(_settings.Workspace().InputPath);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/ICodeService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/ICodeService.cs
@@ -29,7 +29,7 @@ internal interface ICodeService
     /// <returns></returns>
     Task ReloadWorkspaceAsync(string? projectPath);
 
-    Task <IList<ISymbol>> GetAllClassSymbolsAsync();
-    Task<IList<Document>> GetAllDocumentsAsync();
+    Task <List<ISymbol>> GetAllClassSymbolsAsync();
+    Task<List<Document>> GetAllDocumentsAsync();
     Task<Document?> GetDocumentAsync(string? documentName);
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                     }
                     else
                     {
-                        var allDocuments = (await codeService.GetAllDocumentsAsync()).ToList();
+                        var allDocuments = await codeService.GetAllDocumentsAsync();
                         stepOptions = GetDocumentNames(allDocuments);
                     }
 
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var allClassSymbols = await AnsiConsole
                 .Status()
                 .WithSpinner()
-                .Start("Gathering project classes!", async statusContext =>
+                .StartAsync("Gathering project classes!", async statusContext =>
                 {
                     //ICodeService might be null if no InteractivePickerType.ProjectPicker was passed.
                     //will add better documentation so users will know what to expect.
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                         return [];
                     }
 
-                    return (await codeService.GetAllClassSymbolsAsync()).ToList();
+                    return await codeService.GetAllClassSymbolsAsync();
                 });
 
             List<StepOption> classNames = [];


### PR DESCRIPTION
was causing an issue where the call `MSBuildWorkspace.OpenProjectAsync` was blocking the main thread and the AnsiConsole.Status progress UI was dropped. Switching to `AnsiConsole.Status.StartAsync` to allow async Tasks. Fixed the issue!