### PR TITLE
adding a connection string in new DbContext scenarios

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
@@ -3,6 +3,7 @@
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.T4Templating;
 using Microsoft.DotNet.Scaffolding.Helpers.Templates.DbContext;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Scaffolding.Helpers.General;
 
@@ -26,7 +27,7 @@ internal static class DbContextHelper
         return transformation;
     }
 
-    public static bool CreateDbContext(DbContextProperties dbContextProperties, string dbContextPath, IFileSystem fileSystem)
+    public static bool CreateDbContext(DbContextProperties dbContextProperties, string dbContextPath, string? projectBasePath, IFileSystem fileSystem)
     {
         var templateUtilities = new TemplateFoldersUtilities();
         var allT4Templates = templateUtilities.GetAllT4Templates(["DbContext"]);
@@ -40,12 +41,60 @@ internal static class DbContextHelper
 
         var t4TemplateName = Path.GetFileNameWithoutExtension(t4TemplatePath);
         var templatedString = templateInvoker.InvokeTemplate(textTransformation, dictParams);
-        if (!string.IsNullOrEmpty(templatedString) && !string.IsNullOrEmpty(dbContextPath))
+        if (!string.IsNullOrEmpty(templatedString) &&
+            !string.IsNullOrEmpty(dbContextPath) &&
+            !string.IsNullOrEmpty(projectBasePath))
         {
             fileSystem.WriteAllText(dbContextPath, templatedString);
+            AddConnectionString(dbContextProperties, projectBasePath, fileSystem);
             return true;
         }
 
         return false;
+    }
+
+    public static void AddConnectionString(DbContextProperties dbContextProperties, string projectBasePath, IFileSystem fileSystem)
+    {
+        string databaseName = dbContextProperties.DbContextName;
+        var appSettingsFileSearch = fileSystem.EnumerateFiles(projectBasePath, "appsettings.Json", SearchOption.AllDirectories);
+        var appSettingsFile = appSettingsFileSearch.FirstOrDefault();
+        JObject content;
+        bool writeContent = false;
+
+        if (string.IsNullOrEmpty(appSettingsFile) || !fileSystem.FileExists(appSettingsFile))
+        {
+            content = [];
+            writeContent = true;
+        }
+        else
+        {
+            content = JObject.Parse(fileSystem.ReadAllText(appSettingsFile));
+        }
+
+        string connectionStringNodeName = "ConnectionStrings";
+
+        if (content[connectionStringNodeName] is null)
+        {
+            writeContent = true;
+            content[connectionStringNodeName] = new JObject();
+        }
+
+        if (content[connectionStringNodeName] is JObject connectionStringObject &&
+            connectionStringObject[databaseName] is null &&
+            !string.IsNullOrEmpty(dbContextProperties.NewDbConnectionString))
+        {
+            string connectionString = string.Format(dbContextProperties.NewDbConnectionString, databaseName);
+            writeContent = true;
+            connectionStringObject[databaseName] = connectionString;
+            content[connectionStringNodeName] = connectionStringObject;
+        }
+
+        // Json.Net loses comments so the above code if requires any changes loses
+        // comments in the file. The writeContent bool is for saving
+        // a specific case without losing comments - when no changes are needed.
+        if (writeContent && !string.IsNullOrEmpty(appSettingsFile))
+        {
+            fileSystem.WriteAllText(appSettingsFile, content.ToString());
+        }
     }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
@@ -41,16 +41,16 @@ internal static class DbContextHelper
 
         var t4TemplateName = Path.GetFileNameWithoutExtension(t4TemplatePath);
         var templatedString = templateInvoker.InvokeTemplate(textTransformation, dictParams);
-        if (!string.IsNullOrEmpty(templatedString) &&
-            !string.IsNullOrEmpty(dbContextPath) &&
-            !string.IsNullOrEmpty(projectBasePath))
+        if (string.IsNullOrEmpty(templatedString) ||
+            string.IsNullOrEmpty(dbContextPath) ||
+            string.IsNullOrEmpty(projectBasePath))
         {
-            fileSystem.WriteAllText(dbContextPath, templatedString);
-            AddConnectionString(dbContextProperties, projectBasePath, fileSystem);
-            return true;
+            return false;
         }
 
-        return false;
+        fileSystem.WriteAllText(dbContextPath, templatedString);
+        AddConnectionString(dbContextProperties, projectBasePath, fileSystem);
+        return true;
     }
 
     public static void AddConnectionString(DbContextProperties dbContextProperties, string projectBasePath, IFileSystem fileSystem)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextHelper.cs
@@ -73,12 +73,14 @@ internal static class DbContextHelper
 
         string connectionStringNodeName = "ConnectionStrings";
 
+        //find the "ConnectionStrings" node.
         if (content[connectionStringNodeName] is null)
         {
             writeContent = true;
             content[connectionStringNodeName] = new JObject();
         }
 
+        //if a key with the 'databaseName' already exists, skipping adding a connection string.
         if (content[connectionStringNodeName] is JObject connectionStringObject &&
             connectionStringObject[databaseName] is null &&
             !string.IsNullOrEmpty(dbContextProperties.NewDbConnectionString))

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextProperties.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/General/DbContextProperties.cs
@@ -9,4 +9,5 @@ internal class DbContextProperties
     public string? DbName { get; set; }
     public string? DbType { get; set; }
     public string? DbSetStatement { get; set; }
+    public string? NewDbConnectionString { get; set; }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -72,9 +72,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
         private bool CreateNewDbContext(DatabaseCommandSettings settings)
         {
             var newDbContextPath = CreateNewDbContextPath(settings);
+            var projectBasePath = Path.GetDirectoryName(settings.Project);
             var relativeContextPath = Path.GetRelativePath(settings.Project, newDbContextPath);
-            var dbContextCreated = DbContextHelper.CreateDbContext(GetCmdsHelper.SqlServerDefaults, newDbContextPath, _fileSystem);
-            return dbContextCreated;
+            if (GetCmdsHelper.DatabaseTypeDefaults.TryGetValue(settings.Type, out var dbContextProperties) && dbContextProperties is not null)
+            {
+                return DbContextHelper.CreateDbContext(dbContextProperties, newDbContextPath, projectBasePath, _fileSystem);
+            }
+
+            return false;
         }
 
         private string CreateNewDbContextPath(DatabaseCommandSettings commandSettings)

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/GetCommands.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/GetCommands.cs
@@ -57,7 +57,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             DbType = "sqlserver",
             DbName = "sqldb",
             AddDbMethod = "AddSqlServer",
-            AddDbContextMethod = "AddSqlServerDbContext"
+            AddDbContextMethod = "AddSqlServerDbContext",
+            NewDbConnectionString = "Server=(localdb)\\mssqllocaldb;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true"
         };
 
         internal static DbContextProperties NpgsqlDefaults = new()
@@ -65,7 +66,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Commands
             DbType = "postgresql",
             DbName = "postgresqldb",
             AddDbMethod = "AddPostgres",
-            AddDbContextMethod = "AddNpgsqlDbContext"
+            AddDbContextMethod = "AddNpgsqlDbContext",
+            NewDbConnectionString = "server=localhost;username=postgres;database={0}"
         };
 
         internal static List<string> CachingTypeCustomValues = ["redis", "redis-with-output-caching"];

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/MinimalApi/MinimalApiCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/MinimalApi/MinimalApiCommand.cs
@@ -67,7 +67,7 @@ internal class MinimalApiCommand : AsyncCommand<MinimalApiSettings>
         {
             _logger.LogMessage("Installing packages...");
             InstallEfPackages(settings);
-            CommandHelpers.AddDbContext(minimalApiModel.DbContextInfo, _logger, _fileSystem);
+            minimalApiModel.DbContextInfo.AddDbContext(minimalApiModel.ProjectInfo, _logger, _fileSystem);
         }
 
         _logger.LogMessage("Adding API controller...");

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
@@ -68,7 +68,7 @@ internal class BlazorCrudCommand : AsyncCommand<BlazorCrudSettings>
         {
             _logger.LogMessage("Installing packages...");
             InstallPackages(settings);
-            AddDbContext(blazorCrudModel);
+            blazorCrudModel.DbContextInfo.AddDbContext(blazorCrudModel.ProjectInfo, _logger, _fileSystem);
         }
 
         _logger.LogMessage("Adding razor components...");
@@ -93,14 +93,6 @@ internal class BlazorCrudCommand : AsyncCommand<BlazorCrudSettings>
         {
             _logger.LogMessage("An error occurred.");
             return -1;
-        }
-    }
-
-    private void AddDbContext(BlazorCrudModel blazorCrudModel)
-    {
-        if (blazorCrudModel.DbContextInfo is not null)
-        {
-            blazorCrudModel.DbContextInfo.AddDbContext(_logger, _fileSystem);
         }
     }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/CommandHelpers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/CommandHelpers.cs
@@ -4,30 +4,11 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
-using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Common;
 
 internal static class CommandHelpers
 {
-    internal static void AddDbContext(DbContextInfo dbContextInfo, ILogger logger, IFileSystem fileSystem)
-    {
-        //need to create a DbContext
-        if (dbContextInfo.CreateDbContext && !string.IsNullOrEmpty(dbContextInfo.DatabaseProvider))
-        {
-            AspNetDbContextHelper.DatabaseTypeDefaults.TryGetValue(dbContextInfo.DatabaseProvider, out var dbContextProperties);
-            if (dbContextProperties != null &&
-                !string.IsNullOrEmpty(dbContextInfo.DbContextClassName) &&
-                !string.IsNullOrEmpty(dbContextInfo.DbContextClassPath))
-            {
-                dbContextProperties.DbContextName = dbContextInfo.DbContextClassName;
-                dbContextProperties.DbSetStatement = dbContextInfo.NewDbSetStatement;
-                logger.LogMessage($"Adding new DbContext '{dbContextProperties.DbContextName}'...");
-                DbContextHelper.CreateDbContext(dbContextProperties, dbContextInfo.DbContextClassPath, fileSystem);
-            }
-        }
-    }
-
     /// <summary>
     /// Given a class name (only meant for C# classes), get a file path at the base of the project (where the .csproj is on disk)
     /// </summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/DbContextInfo.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/DbContextInfo.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.IO;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
@@ -17,7 +18,7 @@ internal class DbContextInfo
     public string? EntitySetVariableName { get; set; }
     public string? NewDbSetStatement { get; set; }
 
-    internal void AddDbContext(ILogger logger, IFileSystem fileSystem)
+    internal void AddDbContext(ProjectInfo projectInfo, ILogger logger, IFileSystem fileSystem)
     {
         if (CreateDbContext && !string.IsNullOrEmpty(DatabaseProvider))
         {
@@ -26,10 +27,11 @@ internal class DbContextInfo
                 !string.IsNullOrEmpty(DbContextClassName) &&
                 !string.IsNullOrEmpty(DbContextClassPath))
             {
+                var projectBasePath = Path.GetDirectoryName(projectInfo.AppSettings?.Workspace()?.InputPath);
                 dbContextProperties.DbContextName = DbContextClassName;
                 dbContextProperties.DbSetStatement = NewDbSetStatement;
                 logger.LogMessage($"Adding new DbContext '{dbContextProperties.DbContextName}'...");
-                DbContextHelper.CreateDbContext(dbContextProperties, DbContextClassPath, fileSystem);
+                DbContextHelper.CreateDbContext(dbContextProperties, DbContextClassPath, projectBasePath, fileSystem);
             }
         }
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
@@ -14,21 +14,25 @@ internal class AspNetDbContextHelper
     internal static DbContextProperties SqlServerDefaults = new()
     {
         AddDbMethod = "AddSqlServer",
+        NewDbConnectionString = "Server=(localdb)\\mssqllocaldb;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true"
     };
 
     internal static DbContextProperties SqliteDefaults = new()
     {
         AddDbMethod = "AddSqlite",
+        NewDbConnectionString = "Data Source={0}.db"
     };
 
     internal static DbContextProperties CosmosDefaults = new()
     {
         AddDbMethod = "AddCosmos",
+        NewDbConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
     };
 
     internal static DbContextProperties NpgsqlDefaults = new()
     {
         AddDbMethod = "AddPostgres",
+        NewDbConnectionString = "server=localhost;username=postgres;database={0}"
     };
 
     internal static Dictionary<string, DbContextProperties?> DatabaseTypeDefaults = new()
@@ -51,12 +55,19 @@ internal class AspNetDbContextHelper
 
             var globalMethod = programCsFile?.Methods?["Global"];
             var addDbContextChange = globalMethod?.CodeChanges?.FirstOrDefault(x => x.Block.Contains("builder.Services.AddDbContext", StringComparison.OrdinalIgnoreCase));
+            var getConnectionStringChange = globalMethod?.CodeChanges?.FirstOrDefault(x => x.Block.Contains("builder.Configuration.GetConnectionString", StringComparison.OrdinalIgnoreCase));
             if (dbContextInfo.CreateDbContext &&
                 addDbContextChange is not null &&
                 !string.IsNullOrEmpty(dbContextInfo.DatabaseProvider) &&
                 PackageConstants.EfConstants.UseDatabaseMethods.TryGetValue(dbContextInfo.DatabaseProvider, out var useDbMethod))
             {
                 addDbContextChange.Block = string.Format(addDbContextChange.Block, dbContextInfo.DbContextClassName, useDbMethod);
+            }
+
+            if (dbContextInfo.CreateDbContext &&
+                getConnectionStringChange is not null)
+            {
+                getConnectionStringChange.Block = string.Format(getConnectionStringChange.Block, dbContextInfo.DbContextClassName);
             }
 
             if (string.IsNullOrEmpty(dbContextInfo.EntitySetVariableName) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/PackageConstants.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Collections.Generic;
-using Microsoft.DotNet.Scaffolding.Helpers.General;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
 
@@ -21,19 +20,6 @@ internal class PackageConstants
         public const string QuickGridEfAdapterPackageName = "Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter";
         public const string AspNetCoreDiagnosticsEfCorePackageName = "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore";
         public const string PostgresPackageName = "Npgsql.EntityFrameworkCore.PostgreSQL";
-        public const string SQLConnectionStringFormat = "Server=(localdb)\\mssqllocaldb;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true";
-        public const string SQLiteConnectionStringFormat = "Data Source={0}.db";
-        public const string CosmosDbConnectionStringFormat = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
-        public const string PostgresConnectionStringFormat = "server=localhost;username=postgres;database={0}";
-
-        public static readonly IDictionary<string, string> ConnectionStringsDict = new Dictionary<string, string>
-        {
-            { SqlServer, SQLConnectionStringFormat },
-            { SQLite, SQLiteConnectionStringFormat },
-            { CosmosDb, CosmosDbConnectionStringFormat },
-            { Postgres, PostgresConnectionStringFormat }
-        };
-
         public static readonly IDictionary<string, string> EfPackagesDict = new Dictionary<string, string>
         {
             { SqlServer, SqlServerPackageName },


### PR DESCRIPTION
added `AddConnectionString` to `DbContextHelper` and calling it in `CreateDbContext`
- find `appsettings.json` file
- parse it to a `JObject`
- find/create a `ConnectionStrings` node
- add the new connection string for the newly created DbContext

other minor changes :
- `DatabaseCommand` now actually configuring for the correct `--type` parameter.
- initialize `DbContextProperties` to include new property `NewDbConnectionString`
- remove unnecessary `CommandHelpers.AddDbContext` method and switch `MinimalApiCommand` use of it to `DbContextInfo.AddDbContext`
- removed unnecessary properties from `PackageConstants.cs`
- 