### PR TITLE
using IFileSystem instead of System.IO.File

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/ProjectModifier.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.DotNet.MSIdentity.Properties;
 using Microsoft.DotNet.MSIdentity.Shared;
 using Microsoft.DotNet.MSIdentity.Tool;
+using Microsoft.DotNet.Scaffolding.Shared;
 using Microsoft.DotNet.Scaffolding.Shared.CodeModifier;
 using Microsoft.DotNet.Scaffolding.Shared.CodeModifier.CodeChange;
 using Microsoft.DotNet.Scaffolding.Shared.Project;
@@ -160,7 +161,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(fileDoc, filteredCodeChanges);
             if (editedDocument != null)
             {
-                await ProjectModifierHelper.UpdateDocument(editedDocument);
+                await ProjectModifierHelper.UpdateDocument(editedDocument, new DefaultFileSystem());
             }
         }
 
@@ -188,7 +189,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, replacements);
             if (editedDocument != null)
             {
-                await ProjectModifierHelper.UpdateDocument(editedDocument);
+                await ProjectModifierHelper.UpdateDocument(editedDocument, new DefaultFileSystem());
             }
         }
 

--- a/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -127,11 +127,12 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         /// <param name="dbContextTypeName"></param>
         /// <param name="dataBaseName"></param>
         /// <param name="dataContextTypeString"></param>
-        internal StatementSyntax GetAddDbContextStatement(SyntaxNode rootNode, string dbContextTypeName, string dataBaseName, DbProvider dataContextTypeString)
+        /// <param name="useDbFactory">bool to indicate whether to add 'AddDbContextFactory' instead of 'AddDbContext' when creating a new database </param>
+        internal StatementSyntax GetAddDbContextStatement(SyntaxNode rootNode, string dbContextTypeName, string dataBaseName, DbProvider dataContextTypeString, bool useDbFactory = false)
         {
             //get leading trivia. there should be atleast one member var statementLeadingTrivia = classSyntax.ChildNodes()
             var statementLeadingTrivia = rootNode.ChildNodes().First()?.GetLeadingTrivia().ToString();
-            string textToAddAtEnd = AddDbContextString(minimalHostingTemplate: true, statementLeadingTrivia, dataContextTypeString);
+            string textToAddAtEnd = AddDbContextString(minimalHostingTemplate: true, statementLeadingTrivia, dataContextTypeString, useDbFactory);
             _connectionStringsWriter.AddConnectionString(dbContextTypeName, dataBaseName, dataContextTypeString);
             textToAddAtEnd = Environment.NewLine + textToAddAtEnd;
 
@@ -452,11 +453,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                     if (!useTopLevelStatements)
                     {
                         MethodDeclarationSyntax methodSyntax = DocumentBuilder.GetMethodFromSyntaxRoot(compilationSyntax, Main);
-                        dbContextExpression = GetAddDbContextStatement(methodSyntax.Body, dbContextTypeName, databaseName, dataContextType);
+                        dbContextExpression = GetAddDbContextStatement(methodSyntax.Body, dbContextTypeName, databaseName, dataContextType, useDbFactory);
                     }
                     else if (useTopLevelStatements)
                     {
-                        dbContextExpression = GetAddDbContextStatement(compilationSyntax, dbContextTypeName, databaseName, dataContextType);
+                        dbContextExpression = GetAddDbContextStatement(compilationSyntax, dbContextTypeName, databaseName, dataContextType, useDbFactory);
                     }
 
                     if (statementLeadingTrivia != null && dbContextExpression != null)

--- a/src/Scaffolding/VS.Web.CG.Mvc/Blazor/BlazorWebCRUDGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Blazor/BlazorWebCRUDGenerator.cs
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
             //write to Program.cs file
             var changedDocument = docEditor.GetChangedDocument();
             //ApplyTextReplacements will write the updated document to disk (takes changes from above as well).
-            await DocumentBuilder.ApplyTextReplacements(programCsFile, changedDocument, new CodeChangeOptions());
+            await DocumentBuilder.ApplyTextReplacements(programCsFile, changedDocument, new CodeChangeOptions(), FileSystem);
             ConsoleLogger.LogMessage($"Modified {programDocument.Name}.\n");
         }
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -353,7 +353,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
             foreach (var file in otherFiles)
             {
                 var fileDoc = project.GetDocumentFromName(file.FileName, FileSystem);
-                await DocumentBuilder.ApplyTextReplacements(file, fileDoc, new CodeChangeOptions());
+                await DocumentBuilder.ApplyTextReplacements(file, fileDoc, new CodeChangeOptions(), FileSystem);
                 if (file.FileName.Equals("Routes.razor", StringComparison.OrdinalIgnoreCase) &&
                     FileSystem.FileExists(fileDoc.Name))
                 {

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
@@ -315,7 +315,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
             return updatedMethod ?? originalMethod;
         }
 
-        internal static async Task ApplyTextReplacements(CodeFile file, Document document, CodeChangeOptions toolOptions)
+        internal static async Task ApplyTextReplacements(CodeFile file, Document document, CodeChangeOptions toolOptions, IFileSystem fileSystem)
         {
             if (document is null)
             {
@@ -331,7 +331,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
             var editedDocument = await ProjectModifierHelper.ModifyDocumentText(document, replacements);
             if (editedDocument != null)
             {
-                await ProjectModifierHelper.UpdateDocument(editedDocument);
+                await ProjectModifierHelper.UpdateDocument(editedDocument, fileSystem);
             }
         }
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -574,10 +572,10 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
             return fileDoc.WithText(updatedSourceText);
         }
 
-        internal static async Task UpdateDocument(Document document)
+        internal static async Task UpdateDocument(Document document, IFileSystem fileSystem)
         {
             var classFileTxt = await document.GetTextAsync();
-            File.WriteAllText(document.Name, classFileTxt.ToString(), new UTF8Encoding(false));
+            fileSystem.WriteAllText(document.Name, classFileTxt.ToString());
         }
 
         // Filter out CodeBlocks that are invalid using FilterOptions


### PR DESCRIPTION
fixing an issue where file changes were not being persisted without using IFileSystem (for VS scenarios)
- due to file changes being tracked by `MessageOrchestrator.cs` and sent to VS using `SendFileSystemChangeInformation`

also fixed an issue where `useDbFactory` was not being passed to the methods creating the `AddDb` strings in `DbContextEditorServices.cs`

- will be porting this to release/9.0-preview6 and release/8.0