### PR TITLE
validating `ModelInfo` for required CRUD properties

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/AnsiConsoleLogger.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/AnsiConsoleLogger.cs
@@ -34,11 +34,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                     case LogMessageType.Error:
                         if (removeNewLine)
                         {
-                            AnsiConsole.Console.Markup($"[red]{message}");
+                            AnsiConsole.Console.MarkupInterpolated($"[red]{message}[/]");
                         }
                         else
                         {
-                            AnsiConsole.Console.MarkupLine($"[red]{message}");
+                            AnsiConsole.Console.MarkupLineInterpolated($"[red]{message}[/]");
                         }
                         break;
                     case LogMessageType.Information:

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/MinimalApi/MinimalApiCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/API/MinimalApi/MinimalApiCommand.cs
@@ -261,9 +261,10 @@ internal class MinimalApiCommand : AsyncCommand<MinimalApiSettings>
             modelInfo = ClassAnalyzers.GetModelClassInfo(modelClassSymbol);
         }
 
-        if (modelInfo is null)
+        var validateModelInfoResult = ClassAnalyzers.ValidateModelForCrudScaffolders(modelInfo, _logger);
+        if (!validateModelInfoResult)
         {
-            _logger.LogMessage($"Invalid --model '{settings.Model}' provided", LogMessageType.Error);
+            _logger.LogMessage($"Invalid --model '{settings.Model}'", LogMessageType.Error);
             return null;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
@@ -237,7 +237,7 @@ internal class BlazorCrudCommand : AsyncCommand<BlazorCrudSettings>
         var modelClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(settings.Model, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(settings.Model) || modelClassSymbol is null)
         {
-            _logger.LogMessage($"Invalid --model '{settings.Model}' provided", LogMessageType.Error);
+            _logger.LogMessage($"Invalid --model '{settings.Model}'", LogMessageType.Error);
             return null;
         }
         else
@@ -245,12 +245,13 @@ internal class BlazorCrudCommand : AsyncCommand<BlazorCrudSettings>
             modelInfo = ClassAnalyzers.GetModelClassInfo(modelClassSymbol);
         }
 
-        if (modelInfo is null)
+        var validateModelInfoResult = ClassAnalyzers.ValidateModelForCrudScaffolders(modelInfo, _logger);
+        if (!validateModelInfoResult)
         {
-            _logger.LogMessage($"Invalid --model '{settings.Model}' provided", LogMessageType.Error);
+            _logger.LogMessage($"Invalid --model '{settings.Model}'", LogMessageType.Error);
             return null;
         }
-
+        
         //find DbContext info or create properties for a new one.
         var dbContextClassName = settings.DataContext;
         DbContextInfo dbContextInfo = new();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ClassAnalyzers.cs
@@ -70,6 +70,32 @@ internal static class ClassAnalyzers
         return modelInfo;
     }
 
+    /// <summary>
+    /// Check if atleast one property and a primary key property were found for given --model class.
+    /// </summary>
+    /// <param name="modelInfo"></param>
+    /// <param name="logger"></param>
+    /// <returns></returns>
+    internal static bool ValidateModelForCrudScaffolders(ModelInfo modelInfo, ILogger logger)
+    {
+        if (modelInfo is null || string.IsNullOrEmpty(modelInfo.ModelTypeName))
+        {
+            return false;
+        }
+        else if (modelInfo.ModelProperties is null || modelInfo.ModelProperties.Count == 0)
+        {
+            logger.LogMessage($"No properties found for --model '{modelInfo.ModelTypeName}'", LogMessageType.Error);
+            return false;
+        }
+        else if (string.IsNullOrEmpty(modelInfo.PrimaryKeyName))
+        {
+            logger.LogMessage($"No primary key found for --model '{modelInfo.ModelTypeName}'", LogMessageType.Error);
+            return false;
+        }
+
+        return true;
+    }
+
     internal static ProjectInfo GetProjectInfo(string projectPath, ILogger logger)
     {
         var projectInfo = new ProjectInfo();


### PR DESCRIPTION
added `ClassAnalyzers.ValidateModelForCrudScaffolders`
- check if any `ModelProperties` were populated
- check if a primary key was initialized

- fixed writing to AnsiConsole in `dotnet-scaffold-aspnet\AnsiConsoleLogger`
- tested with MinimalApiCommand and BlazorCrudCommand