### PR TITLE
fixing `FirstPartyComponentInitializer`

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -60,7 +60,7 @@ internal class DotNetToolService : IDotNetToolService
             return null;
         }
 
-        var matchingTools = GlobalDotNetTools.Where(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+        var matchingTools = GlobalDotNetTools.Where(x => x.PackageName.Equals(componentName, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(version))
         {
             return matchingTools.FirstOrDefault();

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -9,7 +9,7 @@ internal class FirstPartyComponentInitializer
 {
     private readonly ILogger _logger;
     private readonly IDotNetToolService _dotnetToolService;
-    private readonly List<string> _firstPartyTools = ["dotnet-scaffold-aspnet", "dotnet-scaffold-aspire"];
+    private readonly List<string> _firstPartyTools = ["Microsoft.dotnet-scaffold-aspnet", "Microsoft.dotnet-scaffold-aspire"];
     public FirstPartyComponentInitializer(ILogger logger, IDotNetToolService dotnetToolService)
     {
         _logger = logger;


### PR DESCRIPTION
- edited `List<string> _firstPartyTools` to have the correct tool names
- checking for the correct property in `DotnetToolService.GetCommands`
