### PR TITLE
not invoking 'GlobalDotNetTools' before installing 1st party tools

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -123,7 +123,7 @@ internal class DotNetToolService : IDotNetToolService
         return exitCode == 0;
     }
 
-    private static IList<DotNetToolInfo> GetDotNetTools()
+    public IList<DotNetToolInfo> GetDotNetTools()
     {
         var dotnetToolList = new List<DotNetToolInfo>();
         var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -17,22 +17,15 @@ internal class DotNetToolService : IDotNetToolService
     {
         _environmentService = environmentService;
         _fileSystem = fileSystem;
+        _dotNetTools = [];
     }
 
-    private IList<DotNetToolInfo>? _dotNetTools;
-    public IList<DotNetToolInfo> GlobalDotNetTools
-    {
-        get
-        {
-            _dotNetTools ??= GetDotNetTools();
-            return _dotNetTools;
-        }
-    }
-
+    private IList<DotNetToolInfo> _dotNetTools;
     public List<CommandInfo> GetCommands(string dotnetToolName)
     {
         List<CommandInfo>? commands = null;
-        if (GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(dotnetToolName, StringComparison.OrdinalIgnoreCase)) != null)
+        var dotnetTools = GetDotNetTools();
+        if (dotnetTools.FirstOrDefault(x => x.Command.Equals(dotnetToolName, StringComparison.OrdinalIgnoreCase)) != null)
         {
             var runner = DotnetCliRunner.Create(dotnetToolName, ["get-commands"]);
             var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
@@ -59,8 +52,8 @@ internal class DotNetToolService : IDotNetToolService
         {
             return null;
         }
-
-        var matchingTools = GlobalDotNetTools.Where(x => x.PackageName.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+        var dotnetTools = GetDotNetTools();
+        var matchingTools = dotnetTools.Where(x => x.PackageName.Equals(componentName, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(version))
         {
             return matchingTools.FirstOrDefault();
@@ -75,7 +68,7 @@ internal class DotNetToolService : IDotNetToolService
     {
         if (components is null || components.Count == 0)
         {
-            components = GlobalDotNetTools;
+            components = GetDotNetTools();
         }
 
         var options = new ParallelOptions
@@ -123,27 +116,32 @@ internal class DotNetToolService : IDotNetToolService
         return exitCode == 0;
     }
 
-    public IList<DotNetToolInfo> GetDotNetTools()
+    public IList<DotNetToolInfo> GetDotNetTools(bool refresh = false)
     {
-        var dotnetToolList = new List<DotNetToolInfo>();
-        var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);
-        var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
-        if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
+        if (refresh || _dotNetTools.Count == 0)
         {
-            var stdOutByLine = stdOut.Split(System.Environment.NewLine);
-            foreach (var line in stdOutByLine)
+            var dotnetToolList = new List<DotNetToolInfo>();
+            var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);
+            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
+            if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
             {
-                var parsedDotNetTool = ParseToolInfo(line);
-                if (parsedDotNetTool != null &&
-                    !parsedDotNetTool.Command.Equals("dotnet-scaffold", StringComparison.OrdinalIgnoreCase) &&
-                    !parsedDotNetTool.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase))
+                var stdOutByLine = stdOut.Split(System.Environment.NewLine);
+                foreach (var line in stdOutByLine)
                 {
-                    dotnetToolList.Add(parsedDotNetTool);
+                    var parsedDotNetTool = ParseToolInfo(line);
+                    if (parsedDotNetTool != null &&
+                        !parsedDotNetTool.Command.Equals("dotnet-scaffold", StringComparison.OrdinalIgnoreCase) &&
+                        !parsedDotNetTool.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase))
+                    {
+                        dotnetToolList.Add(parsedDotNetTool);
+                    }
                 }
+
+                _dotNetTools = dotnetToolList;
             }
         }
 
-        return dotnetToolList;
+        return _dotNetTools;
     }
 
     private static DotNetToolInfo? ParseToolInfo(string line)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
@@ -6,10 +6,9 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services;
 
 internal interface IDotNetToolService
 {
-    IList<DotNetToolInfo> GlobalDotNetTools { get; }
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
-    IList<DotNetToolInfo> GetDotNetTools();
+    IList<DotNetToolInfo> GetDotNetTools(bool refresh = false);
     bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false);
     List<CommandInfo> GetCommands(string dotnetToolName);
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IDotNetToolService.cs
@@ -9,6 +9,7 @@ internal interface IDotNetToolService
     IList<DotNetToolInfo> GlobalDotNetTools { get; }
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
+    IList<DotNetToolInfo> GetDotNetTools();
     bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false);
     List<CommandInfo> GetCommands(string dotnetToolName);
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var componentName = settings?.ComponentName;
             var commandName = settings?.CommandName;
             string? displayCategory = null;
-            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+            var dotnetTools = _dotnetToolService.GetDotNetTools();
+            var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
 
             CategoryDiscovery categoryDiscovery = new(_dotnetToolService, dotnetToolComponent);
             displayCategory = categoryDiscovery.Discover(context);
@@ -76,7 +77,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             //check if user input included a component name.
             //if included, check for a command name, and get the CommandInfo object.
-            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+            var dotnetTools = _dotnetToolService.GetDotNetTools();
+            var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             if (dotnetToolComponent != null)
             {
                 var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent.Command);

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
@@ -59,7 +59,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             //KeyValuePair with key being name of the DotnetToolInfo (component) and value being the CommandInfo supported by that component.
             KeyValuePair<string, CommandInfo>? commandInfoKvp = null;
             CommandInfo? commandInfo = null;
-            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+            var dotnetTools = _dotnetToolService.GetDotNetTools();
+            var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             CommandDiscovery commandDiscovery = new(_dotnetToolService, dotnetToolComponent);
             commandInfoKvp = commandDiscovery.Discover(context);
             if (commandDiscovery.State.IsNavigation())
@@ -102,7 +103,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             //check if user input included a component name.
             //if included, check for a command name, and get the CommandInfo object.
-            var dotnetToolComponent = _dotnetToolService.GlobalDotNetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+            var dotnetTools = _dotnetToolService.GetDotNetTools();
+            var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             if (dotnetToolComponent != null)
             {
                 var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent.Command);

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ComponentDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ComponentDiscovery.cs
@@ -21,7 +21,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
         public DotNetToolInfo? Discover(IFlowContext context)
         {
-            return Prompt(context, "Pick a scaffolding component ('dotnet tool')", _dotnetToolService.GlobalDotNetTools);
+            var dotnetTools = _dotnetToolService.GetDotNetTools();
+            return Prompt(context, "Pick a scaffolding component ('dotnet tool')", dotnetTools);
         }
 
         private DotNetToolInfo? Prompt(IFlowContext context, string title, IList<DotNetToolInfo> components)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 
 namespace Microsoft.DotNet.Tools.Scaffold.Services;
@@ -19,9 +20,10 @@ internal class FirstPartyComponentInitializer
     public void Initialize()
     {
         List<string> toolsToInstall = [];
+        var installedTools = _dotnetToolService.GetDotNetTools();
         foreach (var tool in _firstPartyTools)
         {
-            if (_dotnetToolService.GetDotNetTool(tool) is null)
+            if (installedTools.FirstOrDefault(x => x.PackageName.Equals(tool)) is null)
             {
                 toolsToInstall.Add(tool);
             }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -20,7 +20,7 @@ internal class FirstPartyComponentInitializer
     public void Initialize()
     {
         List<string> toolsToInstall = [];
-        var installedTools = _dotnetToolService.GetDotNetTools();
+        var installedTools = _dotnetToolService.GetDotNetTools(refresh: true);
         foreach (var tool in _firstPartyTools)
         {
             if (installedTools.FirstOrDefault(x => x.PackageName.Equals(tool)) is null)


### PR DESCRIPTION
surfacing `IDotNetToolService.GetDotNetTools` instead of being a private helper and removing `GlobalDotNetTools`
- using this when checking for installed 1st party tools instead of invoking `GlobalDotNetTools`
- added a `bool refresh` parameter and using it in `FirstPartyComponentInitializer`
- fixes the scenario where commands are not found on the first run. `GlobalDotNetTools` was getting initialized with all the dotnet tools before our installation and this property was not refreshed after the new 1st party tools get installed.