### PR TITLE
Fix incorrect usage of TryCreateContextUsingAppCode

### DIFF
--- a/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
+++ b/src/Scaffolding/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
@@ -528,7 +528,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(modelType));
             }
 
-            DbContext dbContextInstance = TryCreateContextUsingAppCode(dbContextType, dbContextType);
+            DbContext dbContextInstance = TryCreateContextUsingAppCode(dbContextType, startupType);
             Console.WriteLine($"\nUsing database provider '{dbContextInstance.Database.ProviderName}'!\n");
             if (dbContextInstance == null)
             {


### PR DESCRIPTION
Might fix #1765

The method `TryCreateContextUsingAppCode` accepts a `dbContextType` and a `startupType`, but the calling code doesn't pass any startup type, instead it passes the `dbContextType` twice.

I believe this might be the reason why scaffolding with `dotnet aspnet-codegenerator` fails when your `DbContext` resides in a class library (see long list of victims in #1765).