### PR TITLE
fix FirstPartyComponentInitializer and DotNetToolService

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/DotNetToolService.cs
@@ -53,7 +53,10 @@ internal class DotNetToolService : IDotNetToolService
             return null;
         }
         var dotnetTools = GetDotNetTools();
-        var matchingTools = dotnetTools.Where(x => x.PackageName.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+        var matchingTools = dotnetTools.Where(x =>
+            x.PackageName.Equals(componentName, StringComparison.OrdinalIgnoreCase) ||
+            x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
+
         if (string.IsNullOrEmpty(version))
         {
             return matchingTools.FirstOrDefault();

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IAppSettings.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Services/IAppSettings.cs
@@ -4,6 +4,7 @@ namespace Microsoft.DotNet.Scaffolding.Helpers.Services;
 
 internal interface IAppSettings
 {
+    //used for MSBuildWorkspace.Create()
     IDictionary<string, string> GlobalProperties { get; }
     object? GetSettings(string sectionName);
     void AddSettings(string sectionName, object settings);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Steps/AddPackagesStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Steps/AddPackagesStep.cs
@@ -14,6 +14,7 @@ internal class AddPackagesStep : ScaffoldStep
 
     public override Task<bool> ExecuteAsync()
     {
+        new MsBuildInitializer(Logger).Initialize();
         foreach (var packageName in PackageNames)
         {
             if (!string.IsNullOrEmpty(packageName))

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -23,7 +23,7 @@ internal class FirstPartyComponentInitializer
         var installedTools = _dotnetToolService.GetDotNetTools(refresh: true);
         foreach (var tool in _firstPartyTools)
         {
-            if (installedTools.FirstOrDefault(x => x.PackageName.Equals(tool)) is null)
+            if (installedTools.FirstOrDefault(x => x.PackageName.Equals(tool, System.StringComparison.OrdinalIgnoreCase)) is null)
             {
                 toolsToInstall.Add(tool);
             }


### PR DESCRIPTION
minor fixes
- `FirstPartyComponentInitializer` was checking for installed dotnet tools with case sensitivity. We were reinstalling the 1st party tools every time, fixes that issue.
- adding a `DotNetToolInfo.CommandName` check in `DotNetToolService.GetCommands` alongside the `DotNetToolInfo.PackageName` check
- added `MsBuildInitializer.Initialize()` to `AddPackagesStep` (each step that needs MSBuild initialization should do it)
- added `EnsureInitialized()` to `CodeService` implementation. Making sure the initialization is thread safe.