### PR TITLE
Small builder cleanup/docs changes

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldBuilder.cs
@@ -8,11 +8,34 @@ namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 
 public interface IScaffoldBuilder
 {
+    /// <summary>
+    /// Configures the name of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI
+    /// </summary>
     IScaffoldBuilder WithDisplayName(string displayName);
+
+    /// <summary>
+    /// Configures the category in which the scaffolder will be organized in the dotnet-scaffold interactive UI
+    /// </summary>
     IScaffoldBuilder WithCategory(string category);
+
+    /// <summary>
+    /// Configures the description of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI
+    /// </summary>
     IScaffoldBuilder WithDescription(string description);
+
+    /// <summary>
+    /// Adds an option to be used with this scaffolder. This adds the configured option to both the command line and
+    /// to the dotnet-scaffold interactive UI.
+    /// </summary>
     IScaffoldBuilder WithOption(ScaffolderOption option);
+
+    /// <summary>
+    /// Adds a <see cref="ScaffoldStep"/> to the scaffolder to be run in the order it was added. Additionally allows for pre- and post-execution actions to be performed to configure the step and subsequent steps
+    /// </summary>
     IScaffoldBuilder WithStep<TStep>(Action<ScaffoldStepConfigurator<TStep>>? preExecute = null, Action<ScaffoldStepConfigurator<TStep>>? postExecute = null) where TStep : ScaffoldStep;
 
+    /// <summary>
+    /// Builds the <see cref="IScaffolder"/> from the configured options and steps. This is generally called by the <see cref="IScaffoldRunner"/> when it is building the scaffolders and does not need to be called directly.
+    /// </summary>
     IScaffolder Build(IServiceProvider serviceProvider);
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldRunner.cs
@@ -1,13 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 
 namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 
 public interface IScaffoldRunner
 {
+    /// <summary>
+    /// The collection of configured <see cref="IScaffolder"/>s that can be executed by the runner
+    /// </summary>
     IEnumerable<IScaffolder>? Scaffolders { get; set; }
+
+    /// <summary>
+    /// Executes the scaffolders based on the provided arguments
+    /// </summary>
     Task RunAsync(string[] args);
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldRunnerBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/IScaffoldRunnerBuilder.cs
@@ -8,9 +8,29 @@ namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 
 public interface IScaffoldRunnerBuilder
 {
+    /// <summary>
+    /// Gets a collection of logging providers for the application to compose. This is useful for adding new logging providers.
+    /// </summary>
     ILoggingBuilder Logging { get; }
+
+    /// <summary>
+    /// Gets a collection of services for the application to compose. This is useful for adding user provided or framework provided services.
+    /// </summary>
     IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Gets the collection of <see cref="IScaffoldBuilder"/>s being configured by this <see cref="IScaffoldRunnerBuilder"/>
+    /// </summary>
     IEnumerable<IScaffoldBuilder> Scaffolders { get; }
+
+    /// <summary>
+    /// Builds the <see cref="IScaffoldRunner"/> from the scaffolders and services configured in the builder.
+    /// </summary>
     IScaffoldRunner Build();
+
+    /// <summary>
+    /// Adds a new <see cref="IScaffoldBuilder"/> to the builder with the specified name.
+    /// </summary>
+    /// <param name="name">The name of the scaffolder. This will be used as the command line command to execute that scaffolder.</param>
     IScaffoldBuilder AddScaffolder(string name);
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
@@ -12,7 +12,7 @@ internal class ScaffoldBuilder(string name) : IScaffoldBuilder
 
     private readonly List<ScaffolderOption> _options = [];
     private readonly List<ScaffoldStepPreparer> _stepPreparers = [];
-    private readonly string _name = name.ToLowerInvariant();
+    private readonly string _name = FixName(name);
     private string? _displayName;
     private string? _category;
     private string? _description;
@@ -74,4 +74,7 @@ internal class ScaffoldBuilder(string name) : IScaffoldBuilder
 
         return new Scaffolder(Name, DisplayName, Category, Description, _options, steps, _stepPreparers);
     }
+
+    private static string FixName(string name)
+        => name.Replace(" ", "-").ToLowerInvariant();
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldRunnerBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldRunnerBuilder.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
 using Microsoft.DotNet.Scaffolding.Core.CommandLine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
 
 namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Hosting/Host.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Hosting/Host.cs
@@ -7,5 +7,8 @@ namespace Microsoft.DotNet.Scaffolding.Core.Hosting;
 
 public static class Host
 {
+    /// <summary>
+    /// The starting point for creating a scaffolder. Returns a builder for a scaffold runner that allows configuration of any number of scaffolders, their options and steps.
+    /// </summary>
     public static IScaffoldRunnerBuilder CreateScaffoldBuilder() => new ScaffoldRunnerBuilder();
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Properties/AssemblyInfo.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-//test
-[assembly: InternalsVisibleTo("Microsoft.DotNet.Scaffolding.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
@@ -7,10 +7,33 @@ namespace Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 
 public interface IScaffolder
 {
+    /// <summary>
+    /// The name of the scaffolder. This will be used as the command line command to execute that scaffolder.
+    /// </summary>
     string Name { get; }
+
+    /// <summary>
+    /// The display name of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI
+    /// </summary>
     string DisplayName { get; }
+
+    /// <summary>
+    /// The category in which the scaffolder will be organized in the dotnet-scaffold interactive UI
+    /// </summary>
     string Category { get; }
+
+    /// <summary>
+    /// The description of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI
+    /// </summary>
     string? Description { get; }
+
+    /// <summary>
+    /// The collection of options that can be used with this scaffolder
+    /// </summary>
     IEnumerable<ScaffolderOption> Options { get; }
+
+    /// <summary>
+    /// Executes the scaffolder based on the current context. Generally this will be called by the <see cref="IScaffoldRunner"/> and does not need to be called directly.
+    /// </summary>
     Task ExecuteAsync(ScaffolderContext context);
 }


### PR DESCRIPTION
Small follow up to #2875 

- Adds some doc comments
- Deletes some unused code and unused usings
- Tweaks the way scaffolder name is stored so it can more reliably be used as a command line command (e.g. can't contain spaces). 