### PR TITLE
Enable ImplicitUsings for all of dotnet-scaffolding

### DIFF
--- a/src/dotnet-scaffolding/Directory.Build.props
+++ b/src/dotnet-scaffolding/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.ComponentModel/Microsoft.DotNet.Scaffolding.ComponentModel.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Microsoft.DotNet.Scaffolding.Core.csproj
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Microsoft.DotNet.Scaffolding.Core.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Helpers/Microsoft.DotNet.Scaffolding.Helpers.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/Microsoft.DotNet.Scaffolding.TextTemplating.csproj
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/Microsoft.DotNet.Scaffolding.TextTemplating.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/CachingCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/CachingCommand.cs
@@ -1,9 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/DatabaseCommand.cs
@@ -1,10 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/GetCmdsHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/GetCmdsHelper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/StorageCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Commands/StorageCommand.cs
@@ -1,9 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/AspireHelpers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/AspireHelpers.cs
@@ -1,9 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/PackageConstants.cs
@@ -1,7 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
-
 namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers
 {
     internal class PackageConstants

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/StorageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Helpers/StorageConstants.cs
@@ -1,7 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
-
 namespace Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
 
 internal static class StorageConstants

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/ScaffoldSteps/PlaceholderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/ScaffoldSteps/PlaceholderStepBase.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Commands;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/AreaCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/AreaCommand.cs
@@ -1,7 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.Services.Environment;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudCommand.cs
@@ -1,11 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudHelper.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Blazor/BlazorCrud/BlazorCrudModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Common;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Blazor.BlazorCrud;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ClassAnalyzers.cs
@@ -1,7 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/CommandHelpers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/CommandHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ModelInfo.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Common/ModelInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Common;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/DotnetNewCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/DotnetNewCommand.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/EmptyControllerCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/EmptyControllerCommand.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiCommand.cs
@@ -1,16 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.Helpers.Steps;
-using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Blazor.BlazorCrud;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Common;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/MinimalApi/MinimalApiHelper.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.IO;
-using System;
-
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.MinimalApi;
 
 internal static class MinimalApiHelper

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Settings/ICommandWithSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Commands/Settings/ICommandWithSettings.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
@@ -1,9 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.DotNet.Scaffolding.Helpers.General;
 using Microsoft.DotNet.Scaffolding.Helpers.Roslyn;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/PackageConstants.cs
@@ -1,7 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Collections.Generic;
-
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
 
 internal class PackageConstants

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.DotNet.Scaffolding.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Core.Builder;
 using Microsoft.DotNet.Scaffolding.Core.Hosting;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/AreaScaffolderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/AreaScaffolderStepBase.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/BlazorCrudScaffolderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/BlazorCrudScaffolderStepBase.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStepBase.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStepBase.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/MinimalApiScaffolderStepBase.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/MinimalApiScaffolderStepBase.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Settings;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffolderBuilderExtensions.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System;
-using System.IO;
-using System.Linq;
 using Microsoft.DotNet.Scaffolding.Helpers.Services;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Commands.Blazor.BlazorCrud;

--- a/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
@@ -8,7 +8,6 @@
     <PackageTags>dotnet;scaffold</PackageTags>
     <PackageId>Microsoft.dotnet-scaffold</PackageId>
     <RootNamespace>Microsoft.DotNet.Tools.Scaffold</RootNamespace>
-    <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
`ImplicitUsings` was enabled for some, but not all, of the `dotnet-scaffolding` projects. This is just a quick PR to enable it for all of them in a clean way (using a shared `Directory.Build.props` file) and clean up the usings that were no longer necessary.