### PR TITLE
Add tool commands

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Microsoft.DotNet.Scaffolding.Core.Services;
 using Microsoft.DotNet.Tools.Scaffold.AppBuilder;
+using Microsoft.DotNet.Tools.Scaffold.Command;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console.Cli;
 
@@ -21,7 +22,13 @@ internal class ScaffoldCommandAppBuilder(string[] args)
         {
             config
                 .SetApplicationName("dotnet-scaffold")
-                .SetApplicationVersion(GetToolVersion());
+                .SetApplicationVersion(GetToolVersion())
+                .AddBranch<ToolSettings>("tool", tool =>
+                {
+                    tool.AddCommand<ToolInstallCommand>("install");
+                    tool.AddCommand<ToolListCommand>("list");
+                    tool.AddCommand<ToolUninstallCommand>("uninstall");
+                });
         });
 
         return new ScaffoldCommandApp(commandApp, _args);
@@ -34,6 +41,8 @@ internal class ScaffoldCommandAppBuilder(string[] args)
         registrar.Register(typeof(IEnvironmentService), typeof(EnvironmentService));
         registrar.Register(typeof(IFlowProvider), typeof(FlowProvider));
         registrar.Register(typeof(IDotNetToolService), typeof(DotNetToolService));
+        registrar.Register(typeof(IToolManager), typeof(ToolManager));
+        registrar.Register(typeof(IToolManifestService), typeof(ToolManifestService));
         return registrar;
     }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallCommand.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.Tools.Scaffold.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolInstallCommand(IToolManager toolManager) : Command<ToolInstallSettings>
+{
+    private readonly IToolManager _toolManager = toolManager;
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] ToolInstallSettings settings)
+    {
+        _toolManager.AddTool(settings.PackageName, settings.AddSources, settings.ConfigFile, settings.Prerelease, settings.Version);
+
+        return 0;
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallSettings.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolInstallSettings : ToolSettings
+{
+    [CommandArgument(0, "<PACKAGE_NAME>")]
+    public required string PackageName { get; set; }
+
+    [CommandOption("--add-source <SOURCE>")]
+    public string[] AddSources { get; set; } = [];
+
+    [CommandOption("--configfile <FILE>")]
+    public string? ConfigFile { get; set; }
+
+    [CommandOption("--prerelease")]
+    public bool Prerelease { get; set; }
+
+    [CommandOption("--version <VERSION_NUMBER>")]
+    public string? Version { get; set; }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolListCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolListCommand.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.Tools.Scaffold.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolListCommand(IToolManager toolManager) : Command<ToolListSettings>
+{
+    private readonly IToolManager _toolManager = toolManager;
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] ToolListSettings settings)
+    {
+        _toolManager.ListTools();
+
+        return 0;
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolListSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolListSettings.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolListSettings : ToolSettings
+{
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolSettings.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command
+{
+    internal class ToolSettings : CommandSettings
+    {
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallCommand.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.Tools.Scaffold.Services;
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolUninstallCommand(IToolManager toolManager) : Command<ToolUninstallSettings>
+{
+    private readonly IToolManager _toolManager = toolManager;
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] ToolUninstallSettings settings)
+    {
+        _toolManager.RemoveTool(settings.PackageName);
+
+        return 0;
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallSettings.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console.Cli;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Command;
+
+internal class ToolUninstallSettings : ToolSettings
+{
+    [CommandArgument(0, "<PACKAGE_NAME>")]
+    public required string PackageName { get; set; }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Models/ScaffoldManifest.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Models/ScaffoldManifest.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Scaffold.Models;
+
+internal class ScaffoldManifest
+{
+    public required string Version { get; init; }
+    public required IList<ScaffoldTool> Tools { get; init; }
+
+    public bool HasTool(string name)
+        => Tools.Any(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Models/ScaffoldTool.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Models/ScaffoldTool.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Scaffold.Models;
+
+internal class ScaffoldTool
+{
+    public required string Name { get; set; }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -30,11 +30,11 @@ internal class FirstPartyComponentInitializer
 
         foreach (var tool in toolsToInstall)
         {
-            _logger.LogInformation($"Installing {tool}!");
+            _logger.LogInformation("Installing {tool}!", tool);
             var successfullyInstalled = _dotnetToolService.InstallDotNetTool(tool, prerelease: true);
             if (!successfullyInstalled)
             {
-                _logger.LogInformation($"Failed to install {tool}!");
+                _logger.LogInformation("Failed to install {tool}!", tool);
             }
         }
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
@@ -9,6 +9,7 @@ internal interface IDotNetToolService
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
     IList<DotNetToolInfo> GetDotNetTools(bool refresh = false);
-    bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false);
+    bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false, string[]? addSources = null, string? configFile = null);
+    bool UninstallDotNetTool(string toolName);
     List<CommandInfo> GetCommands(string dotnetToolName);
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManager.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services;
+
+internal interface IToolManager
+{
+    bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version);
+    bool RemoveTool(string packageName);
+    void ListTools();
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManifestService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManifestService.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Tools.Scaffold.Models;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services;
+
+internal interface IToolManifestService
+{
+    bool AddTool(string toolName);
+    ScaffoldManifest GetManifest();
+    bool RemoveTool(string toolName);
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Scaffolding.Helpers.Services;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services;
+
+internal class ToolManager(ILogger<ToolManager> logger, IToolManifestService toolManifestService, IDotNetToolService dotnetToolService) : IToolManager
+{
+    private readonly ILogger _logger = logger;
+    private readonly IToolManifestService _toolManifestService = toolManifestService;
+    private readonly IDotNetToolService _dotnetToolService = dotnetToolService;
+
+    public bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version)
+    {
+        _logger.LogInformation("Installing {packageName}...", packageName);
+
+        if (_dotnetToolService.GetDotNetTool(packageName) is not null || _dotnetToolService.InstallDotNetTool(packageName, version, prerelease, addSources, configFile))
+        {
+            if (_toolManifestService.AddTool(packageName))
+            {
+                _logger.LogInformation("Tool {packageName} installed successfully", packageName);
+                return true;
+            }
+            else
+            {
+                _logger.LogError("Failed to add tool {packageName} to manifest", packageName);
+            }
+        }
+        else
+        {
+            _logger.LogError("Failed to install tool {packageName}", packageName);
+        }
+
+
+        return false;
+    }
+
+    public bool RemoveTool(string packageName)
+    {
+        _logger.LogInformation("Uninstalling {packageName}...", packageName);
+
+        if (_toolManifestService.RemoveTool(packageName))
+        {
+            if (_dotnetToolService.UninstallDotNetTool(packageName))
+            {
+                _logger.LogInformation("Tool {packageName} removed successfully", packageName);
+                return true;
+            }
+            else
+            {
+                _logger.LogError("Failed to uninstall tool {packageName}", packageName);
+            }
+        }
+        else
+        {
+            _logger.LogError("Failed to remove tool {packageName} from manifest", packageName);
+        }
+
+        return false;
+    }
+
+    public void ListTools()
+    {
+        var manifest = _toolManifestService.GetManifest();
+
+        var table = new Table();
+        table.AddColumn("Name");
+
+        foreach (var tool in manifest.Tools)
+        {
+            table.AddRow(tool.Name);
+        }
+
+        AnsiConsole.Write(table);
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManifestService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManifestService.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.DotNet.Scaffolding.Core.Services;
+using Microsoft.DotNet.Tools.Scaffold.Models;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services;
+
+internal class ToolManifestService(IFileSystem fileSystem) : IToolManifestService
+{
+    private static readonly string CURRENT_MANIFEST_VERSION = "0.1";
+
+    private readonly IFileSystem _fileSystem = fileSystem;
+
+    public bool AddTool(string toolName)
+    {
+        var currentManifest = GetManifest();
+        if (!currentManifest.HasTool(toolName))
+        {
+            currentManifest.Tools.Add(new ScaffoldTool { Name = toolName });
+            WriteManifest(currentManifest);
+        }
+        
+        return true;
+    }
+
+    private void EnsureManifestDirectory()
+    {
+        if (!_fileSystem.DirectoryExists(GetToolManifestDirectory()))
+        {
+            _fileSystem.CreateDirectory(GetToolManifestDirectory());
+        }
+    }
+
+    public ScaffoldManifest GetManifest()
+    {
+        EnsureManifestDirectory();
+        if (_fileSystem.FileExists(GetToolManifestPath()))
+        {
+            var manifestContent = _fileSystem.ReadAllText(GetToolManifestPath());
+            var manifest = JsonSerializer.Deserialize<ScaffoldManifest>(manifestContent);
+
+            if (manifest is not null)
+            {
+                return manifest;
+            }
+        }
+
+        return CreateDefaultManifest();
+    }
+
+    public bool RemoveTool(string toolName)
+    {
+        var currentManifest = GetManifest();
+        var toolToRemove = currentManifest.Tools.FirstOrDefault(t => string.Equals(toolName, t.Name, StringComparison.OrdinalIgnoreCase));
+        if (toolToRemove is not null)
+        {
+            currentManifest.Tools.Remove(toolToRemove);
+            WriteManifest(currentManifest);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private void WriteManifest(ScaffoldManifest manifest)
+    {
+        EnsureManifestDirectory();
+        var json = JsonSerializer.Serialize(manifest);
+        _fileSystem.WriteAllText(GetToolManifestPath(), json);
+    }
+
+    private static string GetToolManifestDirectory()
+    => Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE") ?? "", ".dotnet-scaffold");
+    private static string GetToolManifestPath()
+        => Path.Combine(GetToolManifestDirectory(), "tools.json");
+
+    private static ScaffoldManifest CreateDefaultManifest() => new() { Version = CURRENT_MANIFEST_VERSION, Tools = [] };
+}


### PR DESCRIPTION
These commands are standalone right now since they aren't plugged into anything, but it lays the foundation for being able to use them elsewhere.

These commands are implemented:
`dotnet-scaffold tool install [name]`
`dotnet-scaffold tool list`
`dotnet-scaffold tool uninstall [name]`

Install will (if required) install the tool globally and add it to the manifest. uninstall will remove it from the manifest and uninstall it globally. List prints a table that just shows the name for now, But I assume we'll add more information.

Under the hood, `IToolManager` and `IManifestService` can be used in the FirstPartyToolInitializer to do the work it needs to do there when we're ready to plug that in. Then `IManifestService` can be used to get the list of registered tools to call get-commands on (rather than just getting all dotnet tools like we do now).

The manifest file right now is _super_ simple, and intentionally so. I didn't want to lock us into much yet.