### PR TITLE
adding support for multi template execution in a single step.

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModificationStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModificationStep.cs
@@ -76,7 +76,7 @@ public class CodeModificationStep : ScaffoldStep
         }
         else
         {
-            _logger.LogInformation("Failed");
+            _logger.LogError("Failed");
         }
 
         return projectModificationResult;

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModificationStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModificationStep.cs
@@ -69,7 +69,17 @@ public class CodeModificationStep : ScaffoldStep
 
         string projectName = Path.GetFileNameWithoutExtension(ProjectPath);
         _logger.LogInformation($"Updating project '{projectName}'");
-        return await projectModifier.RunAsync();
+        var projectModificationResult = await projectModifier.RunAsync();
+        if (projectModificationResult)
+        {
+            _logger.LogInformation("Done");
+        }
+        else
+        {
+            _logger.LogInformation("Failed");
+        }
+
+        return projectModificationResult;
     }
 
     private void EditCodeModifierConfig(CodeModifierConfig codeModifierConfig)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/Constants.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/Constants.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.DotNet.Scaffolding.TextTemplating;
+
+internal static class Constants
+{
+    public const string NewDbContext = nameof(NewDbContext);
+    public const string CSharpExtension = ".cs";
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/DbContext/DbContextProperties.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/DbContext/DbContextProperties.cs
@@ -4,7 +4,7 @@ namespace Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
 
 internal class DbContextProperties
 {
-    public string DbContextName { get; set; } = "NewDbContext";
+    public string DbContextName { get; set; } = Constants.NewDbContext;
     public string DbContextPath { get; set; } = default!;
     public string? DbSetStatement { get; set; }
     public string? NewDbConnectionString { get; set; }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/DbContext/DbContextProperties.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/DbContext/DbContextProperties.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
 internal class DbContextProperties
 {
     public string DbContextName { get; set; } = "NewDbContext";
-    public string? DbContextPath { get; set; }
+    public string DbContextPath { get; set; } = default!;
     public string? DbSetStatement { get; set; }
     public string? NewDbConnectionString { get; set; }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/ScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/ScaffolderBuilderExtensions.cs
@@ -35,7 +35,7 @@ internal static class ScaffolderBuilderExtensions
             }
 
             step.TextTemplatingProperties = [dbContextTextTemplatingProperty];
-            step.DisplayName = $"{dbContextProperties?.DbContextName ?? "NewDbContext"}.cs";
+            step.DisplayName = $"{dbContextProperties?.DbContextName ?? Constants.NewDbContext}{Constants.CSharpExtension}";
         });
 
         return builder;

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingProperty.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingProperty.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.DotNet.Scaffolding.TextTemplating;
+
+public class TextTemplatingProperty
+{
+    public string? MyProperty { get; set; }
+    //Path to .tt (T4) template on disk (likely to be packed in a dotnet tool)
+    public required string TemplatePath { get; set; }
+    //the System.Type auto-generated object of the template (using TextTemplatingFilePreprocessor)
+    public required Type TemplateType { get; set; }
+    //output file path where the templated content will be written (should include the extension if one is wanted)
+    public required string OutputPath { get; set; }
+    //the 'name' property of <#@ parameter #> in provided .tt template
+    public required string TemplateModelName { get; set; }
+    //the 'type' property of <#@ parameter #> in provided .tt template
+    public required object TemplateModel { get; set; }
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingProperty.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingProperty.cs
@@ -4,7 +4,6 @@ namespace Microsoft.DotNet.Scaffolding.TextTemplating;
 
 public class TextTemplatingProperty
 {
-    public string? MyProperty { get; set; }
     //Path to .tt (T4) template on disk (likely to be packed in a dotnet tool)
     public required string TemplatePath { get; set; }
     //the System.Type auto-generated object of the template (using TextTemplatingFilePreprocessor)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingStep.cs
@@ -10,16 +10,8 @@ namespace Microsoft.DotNet.Scaffolding.TextTemplating;
 /// </summary>
 public class TextTemplatingStep : ScaffoldStep
 {
-    //Path to .tt (T4) template on disk (likely to be packed in a dotnet tool)
-    public required string TemplatePath { get; set; }
-    //the System.Type auto-generated object of the template (using TextTemplatingFilePreprocessor)
-    public required Type TemplateType { get; set; }
-    //output file path where the templated content will be written (should include the extension if one is wanted)
-    public required string OutputPath { get; set; }
-    //the 'name' property of <#@ parameter #> in provided .tt template
-    public required string TemplateModelName { get; set; }
-    //the 'type' property of <#@ parameter #> in provided .tt template
-    public required object TemplateModel { get; set; }
+    public string? DisplayName { get; set; } = "files";
+    public required IEnumerable<TextTemplatingProperty> TextTemplatingProperties { get; set; }
     private readonly ILogger _logger;
 
     public TextTemplatingStep(ILogger<TextTemplatingStep> logger)
@@ -30,46 +22,49 @@ public class TextTemplatingStep : ScaffoldStep
     public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
     {
         var templateInvoker = new TemplateInvoker();
-        var dictParams = new Dictionary<string, object>()
+        _logger.LogInformation($"Adding {DisplayName}...");
+        foreach(var templatingProperty in TextTemplatingProperties)
         {
-            { TemplateModelName, TemplateModel }
-        };
-
-        var host = new TextTemplatingEngineHost { TemplateFile = TemplatePath };
-        ITextTransformation? textTransformation;
-        try
-        {
-            //need to re-instantiate the ITextTransformation type provided (using the TextTemplatingFilePreprocessor in the scaffolder)
-            textTransformation = Activator.CreateInstance(TemplateType) as ITextTransformation;
-            if (textTransformation != null)
+            var dictParams = new Dictionary<string, object>()
             {
-                textTransformation.Session = host.CreateSession();
-            }
-        }
-        catch (Exception ex)
-        {
-            var newException = new Exception($"Unable to create an instance of template type '{TemplateType.Name}'", ex);
-            throw newException;
-        }
+                { templatingProperty.TemplateModelName, templatingProperty.TemplateModel }
+            };
 
-        if (textTransformation is not null)
-        {
-            var templatedString = templateInvoker.InvokeTemplate(textTransformation, dictParams);
-            var outputFolderPath = Path.GetDirectoryName(OutputPath);
-            //create the directory for the output file incase not already there.
-            if (!string.IsNullOrEmpty(templatedString) && !string.IsNullOrEmpty(outputFolderPath))
+            var host = new TextTemplatingEngineHost { TemplateFile = templatingProperty.TemplatePath };
+            ITextTransformation? textTransformation = null;
+            try
             {
-                if (!Directory.Exists(outputFolderPath))
+                //need to re-instantiate the ITextTransformation type provided (using the TextTemplatingFilePreprocessor in the scaffolder)
+                textTransformation = Activator.CreateInstance(templatingProperty.TemplateType) as ITextTransformation;
+                if (textTransformation != null)
                 {
-                    Directory.CreateDirectory(outputFolderPath);
+                    textTransformation.Session = host.CreateSession();
                 }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Unable to create an instance of template type '{templatingProperty.TemplateType.Name}'");
+                _logger.LogError(ex.Message);
+            }
 
-                File.WriteAllText(OutputPath, templatedString);
-                _logger.LogInformation($"Added '{Path.GetFileName(OutputPath)}'");
-                return Task.FromResult(true);
+            if (textTransformation is not null)
+            {
+                var templatedString = templateInvoker.InvokeTemplate(textTransformation, dictParams);
+                var outputFolderPath = Path.GetDirectoryName(templatingProperty.OutputPath);
+                //create the directory for the output file incase not already there.
+                if (!string.IsNullOrEmpty(templatedString) && !string.IsNullOrEmpty(outputFolderPath))
+                {
+                    if (!Directory.Exists(outputFolderPath))
+                    {
+                        Directory.CreateDirectory(outputFolderPath);
+                    }
+
+                    File.WriteAllText(templatingProperty.OutputPath, templatedString);
+                }
             }
         }
 
-        return Task.FromResult(false);
+        _logger.LogInformation("Done\n");
+        return Task.FromResult(true);
     }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/TextTemplatingStep.cs
@@ -21,6 +21,12 @@ public class TextTemplatingStep : ScaffoldStep
 
     public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
     {
+        if (TextTemplatingProperties is null || !TextTemplatingProperties.Any())
+        {
+            _logger.LogError("Invalid/empty value provided for the 'TextTemplatingStep.TextTemplatingProperties' variable");
+            return Task.FromResult(false);
+        }
+
         var templateInvoker = new TemplateInvoker();
         _logger.LogInformation($"Adding {DisplayName}...");
         foreach(var templatingProperty in TextTemplatingProperties)

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -103,31 +103,8 @@ internal static class MinimalApiScaffolderBuilderExtensions
             }
 
             ArgumentNullException.ThrowIfNull(minimalApiModel);
-            var allT4Templates = new TemplateFoldersUtilities().GetAllT4Templates(["MinimalApi"]);
-            string? t4TemplatePath = null;
-            if (minimalApiModel.DbContextInfo.EfScenario)
-            {
-                t4TemplatePath = allT4Templates.FirstOrDefault(x => x.EndsWith("MinimalApiEf.tt", StringComparison.OrdinalIgnoreCase));
-            }
-            else
-            {
-                t4TemplatePath = allT4Templates.FirstOrDefault(x => x.EndsWith("MinimalApi.tt", StringComparison.OrdinalIgnoreCase));
-            }
-
-            var templateType = MinimalApiHelper.GetMinimalApiTemplateType(t4TemplatePath);
-
-            if (string.IsNullOrEmpty(t4TemplatePath) ||
-                string.IsNullOrEmpty(minimalApiModel.EndpointsPath) ||
-                templateType is null)
-            {
-                throw new InvalidOperationException("could not get minimal api template");
-            }
-
-            step.TemplatePath = t4TemplatePath;
-            step.TemplateType = templateType;
-            step.TemplateModel = minimalApiModel;
-            step.TemplateModelName = "Model";
-            step.OutputPath = minimalApiModel.EndpointsPath;
+            step.TextTemplatingProperties = [MinimalApiHelper.GetMinimalApiTemplatingProperty(minimalApiModel)];
+            step.DisplayName = "Minimal API controller";
         });
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/ScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/ScaffolderBuilderExtensions.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
-using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
+using Constants = Microsoft.DotNet.Scaffolding.Internal.Constants;
 
 namespace Microsoft.DotNet.Scaffolding.Core.Hosting;
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/BlazorCrudHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/BlazorCrudHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Scaffolding.Roslyn;
+using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud;
 
@@ -241,5 +242,38 @@ internal static class BlazorCrudHelper
         }
 
         return codeChanges;
+    }
+
+    internal static IEnumerable<TextTemplatingProperty> GetTextTemplatingProperties(IEnumerable<string> allT4TemplatePaths, BlazorCrudModel blazorCrudModel)
+    {
+        var textTemplatingProperties = new List<TextTemplatingProperty>();
+        foreach (var templatePath in allT4TemplatePaths)
+        {
+            var templateName = Path.GetFileNameWithoutExtension(templatePath);
+            var templateType = GetTemplateType(templatePath);
+            if (!string.IsNullOrEmpty(templatePath) && templateType is not null)
+            {
+                if (!IsValidTemplate(blazorCrudModel.PageType, templateName))
+                {
+                    break;
+                }
+
+                string baseOutputPath = GetBaseOutputPath(
+                    blazorCrudModel.ModelInfo.ModelTypeName,
+                    blazorCrudModel.ProjectInfo.ProjectPath);
+                string outputFileName = Path.Combine(baseOutputPath, $"{templateName}{Common.Constants.BlazorExtension}");
+
+                textTemplatingProperties.Add(new()
+                {
+                    TemplateModel = blazorCrudModel,
+                    TemplateModelName = "Model",
+                    TemplatePath = templatePath,
+                    TemplateType = templateType,
+                    OutputPath = outputFileName
+                });
+            }
+        }
+
+        return textTemplatingProperties;
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/MinimalApiHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/MinimalApiHelper.cs
@@ -1,10 +1,45 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.DotNet.Scaffolding.TextTemplating;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
 
 internal static class MinimalApiHelper
 {
-    internal static Type? GetMinimalApiTemplateType(string? templatePath)
+    internal static TextTemplatingProperty GetMinimalApiTemplatingProperty(MinimalApiModel minimalApiModel)
+    {
+        var allT4Templates = new TemplateFoldersUtilities().GetAllT4Templates(["MinimalApi"]);
+        string? t4TemplatePath = null;
+        if (minimalApiModel.DbContextInfo.EfScenario)
+        {
+            t4TemplatePath = allT4Templates.FirstOrDefault(x => x.EndsWith("MinimalApiEf.tt", StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            t4TemplatePath = allT4Templates.FirstOrDefault(x => x.EndsWith("MinimalApi.tt", StringComparison.OrdinalIgnoreCase));
+        }
+
+        var templateType = GetMinimalApiTemplateType(t4TemplatePath);
+
+        if (string.IsNullOrEmpty(t4TemplatePath) ||
+            string.IsNullOrEmpty(minimalApiModel.EndpointsPath) ||
+            templateType is null)
+        {
+            throw new InvalidOperationException("could not get minimal api template");
+        }
+
+        return new TextTemplatingProperty
+        {
+            TemplatePath = t4TemplatePath,
+            TemplateType = templateType,
+            TemplateModel = minimalApiModel,
+            TemplateModelName = "Model",
+            OutputPath = minimalApiModel.EndpointsPath
+        };
+    }
+
+    private static Type? GetMinimalApiTemplateType(string? templatePath)
     {
         if (string.IsNullOrEmpty(templatePath))
         {


### PR DESCRIPTION
- added `TextTemplatingProperty` and using an `IEnumerable<TextTemplatingProperty>` in `TextTemplatingStep` instead of having a single instance of these properties in the `TextTemplatingStep`.
- moved logic for finding the `.tt` templates out of the `*BuilderExtensions.cs` to Helper classes.