### PR TITLE
only adding blazor identity when they are not on disk

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -447,8 +447,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
                     }
 
                     templatedString = StringUtil.NormalizeLineEndings(templatedString);
-                    FileSystem.WriteAllText(templatedFilePath, templatedString);
-                    Logger.LogMessage($"Added Blazor identity file : {templatedFilePath}");
+                    if (!FileSystem.FileExists(templatedFilePath))
+                    {
+                        FileSystem.WriteAllText(templatedFilePath, templatedString);
+                        Logger.LogMessage($"Added Blazor identity file : {templatedFilePath}");
+                    }
                 }
             }
         }

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/blazorIdentityChanges.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/blazorIdentityChanges.json
@@ -69,6 +69,7 @@
             },
             {
               "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();" ],
+              "CheckBlock" : "builder.Services.AddIdentityCore",
               "MultiLineBlock": [
                 "builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)",
                 "    .AddEntityFrameworkStores<ApplicationDbContext>()",
@@ -81,6 +82,7 @@
             },
             {
               "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();" ],
+              "CheckBlock" : "builder.Services.AddSingleton<IEmailSender",
               "Block": "builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>()",
               "LeadingTrivia": {
                 "Newline": true


### PR DESCRIPTION
- not adding blazor identity blazor files when they are already on disk
- adding `CheckBlocks` (property for checking statements and if found, skip the code change) for some blazor identity code changes.