### PR TITLE
T4 template fixes

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.cs
@@ -30,8 +30,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     var entityProperties = Model.ModelMetadata.Properties.Where(x => !x.IsPrimaryKey).ToList();
 

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     var entityProperties = Model.ModelMetadata.Properties.Where(x => !x.IsPrimaryKey).ToList();
 #>

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Delete.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Delete.cs
@@ -30,8 +30,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Delete.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Delete.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Details.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Details.cs
@@ -30,8 +30,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Details.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Details.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.cs
@@ -30,8 +30,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}.{Model.ContextTypeName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
@@ -178,7 +178,7 @@ if ((ModelValueAcquired == false))
 }
 if ((ModelValueAcquired == false))
 {
-    object data = global::Microsoft.DotNet.Scaffolding.Shared.T4Templating.CallContext.LogicalGetData("Model");
+    object data = global::System.Runtime.Remoting.Messaging.CallContext.LogicalGetData("Model");
     if ((data != null))
     {
         this._ModelField = ((global::Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor.BlazorModel)(data));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.cs
@@ -30,8 +30,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}.{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;
@@ -178,7 +179,7 @@ if ((ModelValueAcquired == false))
 }
 if ((ModelValueAcquired == false))
 {
-    object data = global::System.Runtime.Remoting.Messaging.CallContext.LogicalGetData("Model");
+    object data = global::Microsoft.DotNet.Scaffolding.Shared.T4Templating.CallContext.LogicalGetData("Model");
     if ((data != null))
     {
         this._ModelField = ((global::Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor.BlazorModel)(data));

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelType.PluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}.{Model.ContextTypeName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.tt
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Index.tt
@@ -9,7 +9,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : $"{Model.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.ContextTypeName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}.{Model.ContextTypeName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Create.cs
@@ -30,8 +30,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Create.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Delete.cs
@@ -30,8 +30,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Delete.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Details.cs
@@ -30,8 +30,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Details.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Edit.cs
@@ -30,8 +30,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Edit.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}.";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Index.cs
@@ -30,8 +30,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorCrud
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorCrud/Index.tt
@@ -8,8 +8,9 @@
     string pluralModel = Model.ModelInfo.ModelTypePluralName;
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
-    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : $"{Model.DbContextInfo.DbContextNamespace}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextNamespace}{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(builderExtensions));
             this.Write(";\r\n\r\n        ");
 
-        if (dbProvider == "CosmosDb")
+        if (dbProvider == "cosmos-efcore")
         {
 
             this.Write("group.MapDelete(\"/{id}\", async ");
@@ -273,7 +273,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
 
         }
 
-        if (dbProvider != "CosmosDb")
+        if (dbProvider != "cosmos-efcore")
         {
 
             this.Write("group.MapDelete(\"/{id}\", async ");

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(builderExtensions));
             this.Write(";\r\n\r\n    ");
 
-        if (dbProvider == "cosmos-efcore")
+        if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 
             this.Write("        group.MapPut(\"/{id}\", async ");
@@ -163,8 +163,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(";\r\n        })\r\n    ");
 
         }
-
-        if (dbProvider != "cosmos-efcore")
+        else
         {
 
             this.Write("    group.MapPut(\"/{id}\", async ");
@@ -246,7 +245,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(builderExtensions));
             this.Write(";\r\n\r\n        ");
 
-        if (dbProvider == "cosmos-efcore")
+        if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 
             this.Write("group.MapDelete(\"/{id}\", async ");
@@ -272,8 +271,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(";\r\n        })\r\n        ");
 
         }
-
-        if (dbProvider != "cosmos-efcore")
+        else
         {
 
             this.Write("group.MapDelete(\"/{id}\", async ");

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
@@ -178,7 +178,7 @@ public static class <#= Model.EndpointsClassName #>
 <#= builderExtensions #>;
 
         <#
-        if (dbProvider == "CosmosDb")
+        if (dbProvider == "cosmos-efcore")
         {
 #>
 group.MapDelete("/{id}", async <#= typedTaskWithNotFound #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= dbContextName #> db) =>
@@ -195,7 +195,7 @@ group.MapDelete("/{id}", async <#= typedTaskWithNotFound #> (<#= primaryKeyShort
         <#
         }
 
-        if (dbProvider != "CosmosDb")
+        if (dbProvider != "cosmos-efcore")
         {
 #>
 group.MapDelete("/{id}", async <#= typedTaskOkNotFound #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= dbContextName #> db) =>

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
@@ -99,7 +99,7 @@ public static class <#= Model.EndpointsClassName #>
         <#= builderExtensions #>;
 
     <#
-        if (dbProvider == "cosmos-efcore")
+        if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 #>
         group.MapPut("/{id}", async <#= typedTaskWithNoContent #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= modelName #> <#= Model.ModelInfo.ModelVariable #>, <#= dbContextName #> db) =>
@@ -118,8 +118,7 @@ public static class <#= Model.EndpointsClassName #>
         })
     <#
         }
-
-        if (dbProvider != "cosmos-efcore")
+        else
         {
 #>
     group.MapPut("/{id}", async <#= typedTaskOkNotFound #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= modelName #> <#= Model.ModelInfo.ModelVariable #>, <#= dbContextName #> db) =>
@@ -178,7 +177,7 @@ public static class <#= Model.EndpointsClassName #>
 <#= builderExtensions #>;
 
         <#
-        if (dbProvider == "cosmos-efcore")
+        if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 #>
 group.MapDelete("/{id}", async <#= typedTaskWithNotFound #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= dbContextName #> db) =>
@@ -194,8 +193,7 @@ group.MapDelete("/{id}", async <#= typedTaskWithNotFound #> (<#= primaryKeyShort
         })
         <#
         }
-
-        if (dbProvider != "cosmos-efcore")
+        else
         {
 #>
 group.MapDelete("/{id}", async <#= typedTaskOkNotFound #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= dbContextName #> db) =>


### PR DESCRIPTION
`blazor-crud` templates : 
- added `dbContextFullName` and using it correctly (was missing a '.' after last change but the '.' would cause errors elsewhere in the templates).

`minimalapi` templates : 
- fix the check for `cosmos-efcore` db provider type.