### PR TITLE
add/edit paths where we look for dotnet sdk.

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.Scaffolding.Roslyn.Services;
 internal class MsBuildInitializer
 {
     private readonly ILogger _logger;
-    private readonly string[] LinuxDotnetSdkPaths = [@"/usr/share/dotnet/sdk/", @"/usr/share/dotnet/", @"/usr/share/dotnet/dotnet"];
     public MsBuildInitializer(ILogger logger)
     {
         _logger = logger;
@@ -79,19 +78,12 @@ internal class MsBuildInitializer
             sdkBasePath = @"/usr/local/share/dotnet/sdk";
             if (!Directory.Exists(sdkBasePath))
             {
-                sdkBasePath = @"/usr/local/share/dotnet/x64/sdk";
+                sdkBasePath = @"/usr/local/share/dotnet/x64";
             }
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            foreach(var sdkPath in LinuxDotnetSdkPaths)
-            {
-                if (Directory.Exists(sdkBasePath))
-                {
-                    sdkBasePath = sdkPath;
-                    break;
-                }
-            }
+            sdkBasePath = @"/usr/share/dotnet/sdk";
         }
 
         return sdkBasePath;

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Scaffolding.Roslyn.Services;
 internal class MsBuildInitializer
 {
     private readonly ILogger _logger;
+    private readonly string[] LinuxDotnetSdkPaths = [@"/usr/share/dotnet/sdk/", @"/usr/share/dotnet/", @"/usr/share/dotnet/dotnet"];
     public MsBuildInitializer(ILogger logger)
     {
         _logger = logger;
@@ -74,14 +75,22 @@ internal class MsBuildInitializer
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            sdkBasePath = @"/usr/local/share/dotnet/x64/sdk";
+            //check for the ARM sdk first
+            sdkBasePath = @"/usr/local/share/dotnet/sdk";
+            if (!Directory.Exists(sdkBasePath))
+            {
+                sdkBasePath = @"/usr/local/share/dotnet/x64/sdk";
+            }
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            sdkBasePath = @"/usr/share/dotnet/sdk";
-            if (!Directory.Exists(sdkBasePath))
+            foreach(var sdkPath in LinuxDotnetSdkPaths)
             {
-                sdkBasePath = @"/usr/local/share/dotnet/sdk";
+                if (Directory.Exists(sdkBasePath))
+                {
+                    sdkBasePath = sdkPath;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
incorrect paths were being checked for both mac and linux. For mac, the ARM path was not being checked. For linux, the path being checked was wrong.
- added the correct linux default path.
- added the correct path to look in macOS for the ARM .NET SDK. Check for this before an x64 version of the sdk because macOS is ARM based now (and x64 will eventually be deprecated)