### PR TITLE
fix postgres UseDb method name + UseDb method invocation statement

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/blazorIdentityChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/blazorIdentityChanges.json
@@ -105,7 +105,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContext",
-              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod)(connectionString))\"",
+              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod))",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/blazorWebCrudChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/blazorWebCrudChanges.json
@@ -16,7 +16,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContextFactory",
-              "Block": "builder.Services.AddDbContextFactory<$(DbContextName)>(options => options.$(UseDbMethod)(connectionString))\"",
+              "Block": "builder.Services.AddDbContextFactory<$(DbContextName)>(options => options.$(UseDbMethod))",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/efControllerChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/efControllerChanges.json
@@ -19,7 +19,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContext",
-              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod)(connectionString))\"",
+              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod))",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/minimalApiChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/minimalApiChanges.json
@@ -36,7 +36,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContext",
-              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod)(connectionString))\"",
+              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod))",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/razorPagesChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/CodeModificationConfigs/razorPagesChanges.json
@@ -19,7 +19,7 @@
             {
               "InsertAfter": "builder.Configuration.GetConnectionString",
               "CheckBlock": "builder.Services.AddDbContext",
-              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod)(connectionString))\"",
+              "Block": "builder.Services.AddDbContext<$(DbContextName)>(options => options.$(UseDbMethod))",
               "LeadingTrivia": {
                 "Newline": true
               }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
@@ -15,6 +15,7 @@ internal class PackageConstants
         public const string SqlitePackageName = "Microsoft.EntityFrameworkCore.Sqlite";
         public const string CosmosPakcageName = "Microsoft.EntityFrameworkCore.Cosmos";
         public const string PostgresPackageName = "Npgsql.EntityFrameworkCore.PostgreSQL";
+        public const string ConnectionStringVariableName = "connectionString";
         public static readonly IDictionary<string, string> EfPackagesDict = new Dictionary<string, string>
         {
             { SqlServer, SqlServerPackageName },
@@ -33,7 +34,7 @@ internal class PackageConstants
         {
             { SqlServer, "UseSqlServer" },
             { SQLite, "UseSqlite" },
-            { Postgres, "UsePostgres" },
+            { Postgres, "UseNpgsql" },
             { CosmosDb, "UseCosmos" }
         };
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Helpers/AspNetDbContextHelper.cs
@@ -31,7 +31,10 @@ internal class AspNetDbContextHelper
             if (!string.IsNullOrEmpty(dbContextInfo.DatabaseProvider) &&
                 PackageConstants.EfConstants.UseDatabaseMethods.TryGetValue(dbContextInfo.DatabaseProvider, out var useDbMethod))
             {
-                dbContextProperties.Add(Constants.CodeModifierPropertyConstants.UseDbMethod, useDbMethod);
+                string useDbMethodFull = dbContextInfo.DatabaseProvider.Equals(PackageConstants.EfConstants.CosmosDb, StringComparison.OrdinalIgnoreCase) ?
+                    $"{useDbMethod}(connectionString, \"{dbContextInfo.DbContextClassName}\")" :
+                    $"{useDbMethod}(connectionString)"; 
+                dbContextProperties.Add(Constants.CodeModifierPropertyConstants.UseDbMethod, useDbMethodFull);
             }
 
             if (!string.IsNullOrEmpty(dbContextInfo.DbContextClassName))

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
         if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 
-            this.Write("        group.MapPut(\"/{id}\", async ");
+            this.Write("    group.MapPut(\"/{id}\", async ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typedTaskWithNoContent));
             this.Write(" (");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyShortTypeName));

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
@@ -102,7 +102,7 @@ public static class <#= Model.EndpointsClassName #>
         if (dbProvider.Equals("cosmos-efcore", StringComparison.OrdinalIgnoreCase))
         {
 #>
-        group.MapPut("/{id}", async <#= typedTaskWithNoContent #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= modelName #> <#= Model.ModelInfo.ModelVariable #>, <#= dbContextName #> db) =>
+    group.MapPut("/{id}", async <#= typedTaskWithNoContent #> (<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerCase #>, <#= modelName #> <#= Model.ModelInfo.ModelVariable #>, <#= dbContextName #> db) =>
         {
             var foundModel = await db.<#= findModel #>;
 


### PR DESCRIPTION
- fix an added statement in EF scenario for `postgres-efcore` db provider type.
  - `UsePostgres()` --> `UseNpgsql()`
  - `UsePostgres` is used in Aspire scenarios but not in ASPNET.Core scenarios
- fix `UseCosmos(connectionString)` call as this is not supported anymore. For the `cosmos-efcore` db provider, adding `UseCosmos(connectionString, DB_NAME)` (formatting the DbContext name in this statement) instead. It is backwards-compat for .net8.0 scenarios as well.
- fix spacing issue for minimalapi w/ EF template, extra 4 spaces at the start of the `group.MapPut..` statement.