### PR TITLE
fix ModifyDocumentTextAsync

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModification/ProjectModifier.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModification/ProjectModifier.cs
@@ -83,7 +83,7 @@ internal class ProjectModifier
         }
         catch (Exception e)
         {
-            _consoleLogger.LogError($"Failed to modify code file {file.FileName}, {e.Message}");
+            _consoleLogger.LogError($"Failed to modify file '{file.FileName}', {e.Message}");
         }
 
         return project;

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/ProjectModifierHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/ProjectModifierHelper.cs
@@ -499,13 +499,22 @@ internal static class ProjectModifierHelper
             }
         }
 
-        //get the CodeAnalysis.Solution, add the AdditionalDocument with the updated text
-        //and return the updated TextDocument.
         var updatedSourceText = SourceText.From(sourceFileString);
-        var solution = fileDoc.Project.Solution;
-        var updatedSolution = solution.WithAdditionalDocumentText(fileDoc.Id, updatedSourceText);
-        var updatedTextDocument = updatedSolution.GetAdditionalDocument(fileDoc.Id);
-        return updatedTextDocument as T;
+        //check for Document class first as its a subclass of TextDocument
+        //use Document.WithText extension to return an updated Document
+        if (fileDoc is Document document)
+        {
+            return document.WithText(updatedSourceText) as T;
+        }
+        //get the CodeAnalysis.Solution, add the AdditionalDocument with the updated text
+        //and return the updated TextDocument using Solution.GetAdditionalDocument.
+        else if (fileDoc is TextDocument)
+        {
+            var updatedSolution = fileDoc.Project.Solution.WithAdditionalDocumentText(fileDoc.Id, updatedSourceText);
+            return updatedSolution.GetAdditionalDocument(fileDoc.Id) as T;
+        }
+
+        return null;
     }
 
     internal static async Task UpdateDocument(Document document)


### PR DESCRIPTION
- `ProjectModifierHelper.ModifyDocumentTextAsync` has incorrect logic
  - `fileDoc` could have been of type `Document` or its base class `TextDocument`, however the logic was only handling `TextDocument`
  - added logic for handling `Document` types
- minor change in log message when an exception is caught it `ProjectModifier.HandleCodeFileAsync`