### PR TITLE
installing and prioritizing local tools for dotnet-scaffold

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/DotnetToolInfo.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/DotnetToolInfo.cs
@@ -3,14 +3,14 @@
 namespace Microsoft.DotNet.Scaffolding.Core.ComponentModel;
 
 /// <summary>
-/// Info from 'dotnet tool list -g'
+/// Info from 'dotnet tool list' and 'dotnet tool list -g'
 /// </summary>
 internal class DotNetToolInfo
 {
     public string PackageName { get; set; } = default!;
     public string Version { get; set; } = default!;
     public string Command { get; set; } = default!;
-
+    public bool IsGlobalTool { get; set; } = false;
     public string ToDisplayString()
     {
         return $"{Command} ({PackageName} v{Version})";

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
@@ -32,7 +32,7 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
         var result = false;
         if (stepSettings is not null)
         {
-            return Task.FromResult(InvokeDotnetNew(stepSettings));
+            result = InvokeDotnetNew(stepSettings);
         }
 
         if (result)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallCommand.cs
@@ -13,8 +13,7 @@ internal class ToolInstallCommand(IToolManager toolManager) : Command<ToolInstal
 
     public override int Execute([NotNull] CommandContext context, [NotNull] ToolInstallSettings settings)
     {
-        _toolManager.AddTool(settings.PackageName, settings.AddSources, settings.ConfigFile, settings.Prerelease, settings.Version);
-
+        _toolManager.AddTool(settings.PackageName, settings.AddSources, settings.ConfigFile, settings.Prerelease, settings.Version, settings.Global);
         return 0;
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolInstallSettings.cs
@@ -19,6 +19,9 @@ internal class ToolInstallSettings : ToolSettings
     [CommandOption("--prerelease")]
     public bool Prerelease { get; set; }
 
+    [CommandOption("--global")]
+    public bool Global { get; set; }
+
     [CommandOption("--version <VERSION_NUMBER>")]
     public string? Version { get; set; }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallCommand.cs
@@ -13,8 +13,7 @@ internal class ToolUninstallCommand(IToolManager toolManager) : Command<ToolUnin
 
     public override int Execute([NotNull] CommandContext context, [NotNull] ToolUninstallSettings settings)
     {
-        _toolManager.RemoveTool(settings.PackageName);
-
+        _toolManager.RemoveTool(settings.PackageName, settings.Global);
         return 0;
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ToolUninstallSettings.cs
@@ -9,4 +9,7 @@ internal class ToolUninstallSettings : ToolSettings
 {
     [CommandArgument(0, "<PACKAGE_NAME>")]
     public required string PackageName { get; set; }
+
+    [CommandOption("--global")]
+    public bool Global { get; set; }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             if (dotnetToolComponent != null)
             {
-                var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent.Command);
+                var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent);
                 commandInfo = allCommands.FirstOrDefault(x => x.Name.Equals(commandName, StringComparison.OrdinalIgnoreCase));
             }
             else

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             if (dotnetToolComponent != null)
             {
-                var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent.Command);
+                var allCommands = _dotnetToolService.GetCommands(dotnetToolComponent);
                 commandInfo = allCommands.FirstOrDefault(x => x.Name.Equals(commandName, StringComparison.OrdinalIgnoreCase));
             }
             else

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -27,20 +27,9 @@ internal class DotNetToolService : IDotNetToolService
     public List<CommandInfo> GetCommands(DotNetToolInfo dotnetTool)
     {
         List<CommandInfo>? commands = null;
-        DotnetCliRunner? runner = null;
-        if (dotnetTool.IsGlobalTool)
-        {
-            runner = DotnetCliRunner.Create(dotnetTool.Command, ["get-commands"]);
-        }
-        else
-        {
-            runner = DotnetCliRunner.CreateDotNet(dotnetTool.Command, ["get-commands"]);
-        }
-
-        if (runner is null)
-        {
-            return [];
-        }
+        var runner = dotnetTool.IsGlobalTool ?
+            DotnetCliRunner.Create(dotnetTool.Command, ["get-commands"]) :
+            DotnetCliRunner.CreateDotNet(dotnetTool.Command, ["get-commands"]);
 
         var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
         if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -24,25 +24,35 @@ internal class DotNetToolService : IDotNetToolService
     }
 
     private IList<DotNetToolInfo> _dotNetTools;
-    public List<CommandInfo> GetCommands(string dotnetToolName)
+    public List<CommandInfo> GetCommands(DotNetToolInfo dotnetTool)
     {
         List<CommandInfo>? commands = null;
-        var dotnetTools = GetDotNetTools();
-        if (dotnetTools.FirstOrDefault(x => x.Command.Equals(dotnetToolName, StringComparison.OrdinalIgnoreCase)) != null)
+        DotnetCliRunner? runner = null;
+        if (dotnetTool.IsGlobalTool)
         {
-            var runner = DotnetCliRunner.Create(dotnetToolName, ["get-commands"]);
-            var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
-            if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
-            {
-                try
-                {
-                    string escapedJsonString = stdOut.Replace("\r", "").Replace("\n", "");
-                    commands = JsonSerializer.Deserialize<List<CommandInfo>>(escapedJsonString);
-                }
-                catch (Exception)
-                {
+            runner = DotnetCliRunner.Create(dotnetTool.Command, ["get-commands"]);
+        }
+        else
+        {
+            runner = DotnetCliRunner.CreateDotNet(dotnetTool.Command, ["get-commands"]);
+        }
 
-                }
+        if (runner is null)
+        {
+            return [];
+        }
+
+        var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
+        if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
+        {
+            try
+            {
+                string escapedJsonString = stdOut.Replace("\r", "").Replace("\n", "");
+                commands = JsonSerializer.Deserialize<List<CommandInfo>>(escapedJsonString);
+            }
+            catch (Exception)
+            {
+
             }
         }
 
@@ -74,7 +84,7 @@ internal class DotNetToolService : IDotNetToolService
     {
         if (components is null || components.Count == 0)
         {
-            components = GetDotNetTools();
+            components = GetDotNetTools(refresh: true);
         }
 
         var options = new ParallelOptions
@@ -85,7 +95,7 @@ internal class DotNetToolService : IDotNetToolService
         var commands = new ConcurrentBag<KeyValuePair<string, CommandInfo>>();
         Parallel.ForEach(components, options, dotnetTool =>
         {
-            var commandInfo = GetCommands(dotnetTool.Command);
+            var commandInfo = GetCommands(dotnetTool);
             if (commandInfo != null)
             {
                 foreach (var cmd in commandInfo)
@@ -98,14 +108,23 @@ internal class DotNetToolService : IDotNetToolService
         return commands.ToList();
     }
 
-    public bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false, string[]? addSources = null, string? configFile = null)
+    public bool InstallDotNetTool(string toolName, string? version = null, bool global = false, bool prerelease = false, string[]? addSources = null, string? configFile = null)
     {
         if (string.IsNullOrEmpty(toolName))
         {
             return false;
         }
 
-        var installParams = new List<string> { "install", "-g", toolName };
+        var installParams = new List<string> { "install", toolName };
+        if (global)
+        {
+            installParams.Add("-g");
+        }
+        else
+        {
+            installParams.Add("--create-manifest-if-needed");
+        }
+
         if (!string.IsNullOrEmpty(version))
         {
             installParams.Add("--version");
@@ -137,13 +156,20 @@ internal class DotNetToolService : IDotNetToolService
         return exitCode == 0;
     }
 
-    public bool UninstallDotNetTool(string toolName)
+    public bool UninstallDotNetTool(string toolName, bool global = false)
     {
         if (string.IsNullOrEmpty(toolName))
         {
             return false;
         }
-        var runner = DotnetCliRunner.CreateDotNet("tool", ["uninstall", "-g", toolName]);
+
+        List<string> uninstallParams = ["uninstall", toolName];
+        if (global)
+        {
+            uninstallParams.Add("-g");
+        }
+
+        var runner = DotnetCliRunner.CreateDotNet("tool", uninstallParams);
         var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
         return exitCode == 0;
     }
@@ -152,24 +178,44 @@ internal class DotNetToolService : IDotNetToolService
     {
         if (refresh || _dotNetTools.Count == 0)
         {
+            //only want unique tools, we will try to invoke local tools over global tools
             var dotnetToolList = new List<DotNetToolInfo>();
             var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);
+            var localRunner = DotnetCliRunner.CreateDotNet("tool", ["list"]);
             var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
-            if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
+            var localExitCode = localRunner.ExecuteAndCaptureOutput(out var localStdOut, out var localStdErr);
+            //parse through local dotnet tools first. 
+            if (localExitCode == 0 && !string.IsNullOrEmpty(localStdOut))
             {
-                var stdOutByLine = stdOut.Split(System.Environment.NewLine);
-                foreach (var line in stdOutByLine)
+                var localDtdOutByLine = localStdOut.Split(Environment.NewLine);
+                foreach (var line in localDtdOutByLine)
                 {
                     var parsedDotNetTool = ParseToolInfo(line);
-                    if (parsedDotNetTool != null &&
-                        !parsedDotNetTool.Command.Equals("dotnet-scaffold", StringComparison.OrdinalIgnoreCase) &&
-                        !parsedDotNetTool.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase))
+                    if (parsedDotNetTool is not null &&
+                        IsValidDotNetTool(parsedDotNetTool))
                     {
                         dotnetToolList.Add(parsedDotNetTool);
                     }
                 }
 
-                _dotNetTools = dotnetToolList;
+                _dotNetTools = [.. dotnetToolList];
+            }
+
+            //parse through global tools
+            if (exitCode == 0 && !string.IsNullOrEmpty(stdOut))
+            {
+                var stdOutByLine = stdOut.Split(Environment.NewLine);
+                foreach (var line in stdOutByLine)
+                {
+                    var parsedDotNetTool = ParseToolInfo(line);
+                    if (parsedDotNetTool is not null &&
+                        IsValidDotNetTool(parsedDotNetTool) &&
+                        !_dotNetTools.Any(x => x.Command.Equals(parsedDotNetTool.Command, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        parsedDotNetTool.IsGlobalTool = true;
+                        _dotNetTools.Add(parsedDotNetTool);
+                    }
+                }
             }
         }
 
@@ -190,5 +236,12 @@ internal class DotNetToolService : IDotNetToolService
         }
 
         return null;
+    }
+
+    private static bool IsValidDotNetTool(DotNetToolInfo dotnetToolInfo)
+    {
+        return
+            !dotnetToolInfo.Command.Equals("dotnet-scaffold", StringComparison.OrdinalIgnoreCase) &&
+            !dotnetToolInfo.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
@@ -9,7 +9,7 @@ internal interface IDotNetToolService
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
     IList<DotNetToolInfo> GetDotNetTools(bool refresh = false);
-    bool InstallDotNetTool(string toolName, string? version = null, bool prerelease = false, string[]? addSources = null, string? configFile = null);
-    bool UninstallDotNetTool(string toolName);
-    List<CommandInfo> GetCommands(string dotnetToolName);
+    bool InstallDotNetTool(string toolName, string? version = null, bool global = false, bool prerelease = false, string[]? addSources = null, string? configFile = null);
+    bool UninstallDotNetTool(string toolName, bool global = false);
+    List<CommandInfo> GetCommands(DotNetToolInfo dotnetTool);
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IToolManager.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Services;
 
 internal interface IToolManager
 {
-    bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version);
-    bool RemoveTool(string packageName);
+    bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version, bool global);
+    bool RemoveTool(string packageName, bool global);
     void ListTools();
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
@@ -12,11 +12,11 @@ internal class ToolManager(ILogger<ToolManager> logger, IToolManifestService too
     private readonly IToolManifestService _toolManifestService = toolManifestService;
     private readonly IDotNetToolService _dotnetToolService = dotnetToolService;
 
-    public bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version)
+    public bool AddTool(string packageName, string[] addSources, string? configFile, bool prerelease, string? version, bool global)
     {
         _logger.LogInformation("Installing {packageName}...", packageName);
 
-        if (_dotnetToolService.GetDotNetTool(packageName) is not null || _dotnetToolService.InstallDotNetTool(packageName, version, global: false, prerelease, addSources, configFile))
+        if (_dotnetToolService.GetDotNetTool(packageName) is not null || _dotnetToolService.InstallDotNetTool(packageName, version, global: global, prerelease, addSources, configFile))
         {
             if (_toolManifestService.AddTool(packageName))
             {
@@ -37,13 +37,13 @@ internal class ToolManager(ILogger<ToolManager> logger, IToolManifestService too
         return false;
     }
 
-    public bool RemoveTool(string packageName)
+    public bool RemoveTool(string packageName, bool global)
     {
         _logger.LogInformation("Uninstalling {packageName}...", packageName);
 
         if (_toolManifestService.RemoveTool(packageName))
         {
-            if (_dotnetToolService.UninstallDotNetTool(packageName))
+            if (_dotnetToolService.UninstallDotNetTool(packageName, global))
             {
                 _logger.LogInformation("Tool {packageName} removed successfully", packageName);
                 return true;

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/ToolManager.cs
@@ -16,7 +16,7 @@ internal class ToolManager(ILogger<ToolManager> logger, IToolManifestService too
     {
         _logger.LogInformation("Installing {packageName}...", packageName);
 
-        if (_dotnetToolService.GetDotNetTool(packageName) is not null || _dotnetToolService.InstallDotNetTool(packageName, version, prerelease, addSources, configFile))
+        if (_dotnetToolService.GetDotNetTool(packageName) is not null || _dotnetToolService.InstallDotNetTool(packageName, version, global: false, prerelease, addSources, configFile))
         {
             if (_toolManifestService.AddTool(packageName))
             {


### PR DESCRIPTION
Currently dotnet-scaffold only deals with global tools"
- It will install the 1st party tools (`dotnet-scaffold-aspire` and `dotnet-scaffold-aspnet`) globally
- Also populates the list of commands and category by iterating over all global tools. 

Changing this to installing 1st party tools as 'local' tools:
- Allow repos to control the version of these 1st party tools 
- These 1st party tools are only relevant in the context of the repo/project so global tool list will stay clean
- When populating the list of commands, search local tools first, and then global tools. For duplicates, only track and invoke the local one.

changes description:
- most changes are in `DotNetToolService.GetCommands`
- for invoking local tools, we have to invoke the `dotnet` command, for eg. `dotnet dotnet-scaffold-aspnet` instead of just `dotnet-scaffold-aspnet`.
- minor changes to `IDotNetToolService.InstallDotNetTool` amd `IDotNetToolService.UninstallDotNetTool` to account for local scenarios.

adding some information on `global` vs. `local` tools. We should be clear on the following info understand installing and using these tools in both contexts.

| Category| global | local |
| --- | --- |--- |
| Invocation (eg. 'sample-tool'| use the command name, `sample-tool`. If the command name has `dotnet-` prefix, it can invoked with `dotnet ` instead as well. | prefix command name with 'dotnet' or 'dotnet tool run', `dotnet sample-tool` or `dotnet tool run sample-tool` from the installation directory |
| Location on disk | On Linux and macOS it's `$HOME/.dotnet/tools`, and on Windows it's `%USERPROFILE%\.dotnet\tools` | Installed in the NuGet global directory, and shim files are created in `$HOME/.dotnet/toolResolverCache` to point to the tools' location |
- upon a local tools installation, a manifest is either created or an existing one is used, the default one being at `CURRENT_PATH\.config\dotnet-tools.json`. This config consists of all the local tool versions and command names.