### PR TITLE
fix `DotnetCliRunner`

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
@@ -49,6 +49,8 @@ internal class DotnetCliRunner
         }
         catch (Exception e)
         {
+            stdOutCallback(e.Message);
+            stdErrCallback(e.Message);
             return -1;
         }
 
@@ -80,7 +82,7 @@ internal class DotnetCliRunner
         }
         catch (Exception e)
         {
-            stdOut = null;
+            stdOut = e.Message;
             stdErr = e.Message;
             return -1;
         }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
@@ -43,7 +43,15 @@ internal class DotnetCliRunner
             }
         };
 
-        process.Start();
+        try
+        {
+            process.Start();
+        }
+        catch (Exception e)
+        {
+            return -1;
+        }
+
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
         process.WaitForExit();
@@ -66,7 +74,16 @@ internal class DotnetCliRunner
 
         process.EnableRaisingEvents = true;
 
-        process.Start();
+        try
+        {
+            process.Start();
+        }
+        catch (Exception e)
+        {
+            stdOut = null;
+            stdErr = e.Message;
+            return -1;
+        }
 
         var taskOut = outStream.BeginRead(process.StandardOutput);
         var taskErr = errStream.BeginRead(process.StandardError);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
@@ -49,7 +49,6 @@ internal class DotnetCliRunner
         }
         catch (Exception e)
         {
-            stdOutCallback(e.Message);
             stdErrCallback(e.Message);
             return -1;
         }
@@ -82,7 +81,7 @@ internal class DotnetCliRunner
         }
         catch (Exception e)
         {
-            stdOut = e.Message;
+            stdOut = string.Empty;
             stdErr = e.Message;
             return -1;
         }


### PR DESCRIPTION
When using `DotNetCliRunner.ExecuteWithCallbacks` or `DotNetCliRunner.ExecuteAndCaptureOutput` either in dotnet-scaffold or elsewhere, `Process.Start()` can throw on a myriad of reasons. 
- Found this when had another dotnet global tool installed `Sarif.PatternMatcher.Cli` and this method would throw and exit when trying to start the tool's process. 
- We should catch the exception and continue execution
- `dotnet-scaffold` would fail on getting all the commands due to this failure instead of returning all found commands.