### PR TITLE
minor Blazor Identity fixes

### DIFF
--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=8.0.2
+set VERSION=8.0.6
 set DEFAULT_NUPKG_PATH=C:\Nuget
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/blazorIdentityChanges.json
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/blazorIdentityChanges.json
@@ -111,7 +111,8 @@
             "                <RedirectToLogin />",
             "            </NotAuthorized>",
             "        </AuthorizeRouteView>"
-          ]
+          ],
+          "CheckBlock": "<NotAuthorized>"
         }
       ]
     },
@@ -124,6 +125,7 @@
             "    background-image: url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-list-nested' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.5 11.5A.5.5 0 0 1 5 11h10a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 1 3h10a.5.5 0 0 1 0 1H1a.5.5 0 0 1-.5-.5z'/%3E%3C/svg%3E\");",
             "}"
           ],
+          "CheckBlock": "bi-lock-nav-menu",
           "MultiLineBlock": [
             ".bi-list-nested-nav-menu {",
             "    background-image: url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-list-nested' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.5 11.5A.5.5 0 0 1 5 11h10a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 1 3h10a.5.5 0 0 1 0 1H1a.5.5 0 0 1-.5-.5z'/%3E%3C/svg%3E\");",
@@ -242,7 +244,7 @@
             "@using Microsoft.AspNetCore.Components.Forms",
             "@using Microsoft.AspNetCore.Components.Authorization"
           ],
-          "CheckBlock": "@using Microsoft.AspNetCore.Components.Authorization"
+          "CheckBlock": "Microsoft.AspNetCore.Components.Authorization"
         }
       ]
     }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -553,7 +553,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 if (change.ReplaceSnippet != null)
                 {
                     var replaceSnippet = string.Join(Environment.NewLine, change.ReplaceSnippet);
-                    if (sourceFileString.Contains(replaceSnippet))
+                    if (!sourceFileString.Contains(change.CheckBlock, StringComparison.OrdinalIgnoreCase) && 
+                        sourceFileString.Contains(replaceSnippet, StringComparison.OrdinalIgnoreCase))
                     {
                         sourceFileString = sourceFileString.Replace(replaceSnippet, change.Block);
                     }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Project/ProjectModifierHelper.cs
@@ -553,8 +553,8 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Project
                 if (change.ReplaceSnippet != null)
                 {
                     var replaceSnippet = string.Join(Environment.NewLine, change.ReplaceSnippet);
-                    if (!sourceFileString.Contains(change.CheckBlock, StringComparison.OrdinalIgnoreCase) && 
-                        sourceFileString.Contains(replaceSnippet, StringComparison.OrdinalIgnoreCase))
+                    if (!sourceFileString.ContainsIgnoreCase(change.CheckBlock) && 
+                        sourceFileString.ContainsIgnoreCase(replaceSnippet))
                     {
                         sourceFileString = sourceFileString.Replace(replaceSnippet, change.Block);
                     }


### PR DESCRIPTION
- 'CheckBlock' property was not being checked before replacing a snippet was causing duplicated (in `ProjectModifierHelper.ModifyDocumentText`)
- added some 'CheckBlock's