### PR TITLE
adding a readme for blazor identity for scenario specific information.

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -141,7 +141,16 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
 
             var blazorTemplateModel = await ValidateAndBuild(model);
             ExecuteTemplates(blazorTemplateModel);
+            AddReadmeFile(blazorTemplateModel.BaseOutputPath);
             await ModifyFilesAsync(blazorTemplateModel);
+        }
+
+        internal void AddReadmeFile(string outputPath)
+        {
+            string fileName = BlazorIdentityHelper.BlazorIdentityReadmeFileName;
+            string readmeFilePath = Path.Combine(outputPath, fileName);
+            FileSystem.WriteAllText(readmeFilePath, BlazorIdentityHelper.BlazorIdentityReadmeString);
+            Logger.LogMessage($"Added Blazor identity file : {fileName}");
         }
 
         internal async Task<BlazorIdentityModel> ValidateAndBuild(BlazorIdentityCommandLineModel commandlineModel)

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
@@ -104,11 +104,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.BlazorIdentity
 
         internal static string BlazorIdentityReadmeFileName = "Scaffolding-README.md";
         internal static string BlazorIdentityReadmeString =
-@"Support for Blazor Identity was added to your project.
+@"Blazor Identity scaffolding has completed successfully.
 
 For setup and configuration information, see https://learn.microsoft.com/en-us/aspnet/core/blazor/security.
 
-If adding Blazor Identity to a project with existing Identity, ensure the following changes in your Program.cs file:
+If the project had identity support prior to scaffolding, ensure that the following changes are present in Program.cs:
 1. Correct DbContextClass is used in the following statements :
     - var connectionString = builder.Configuration.GetConnectionString(DBCONTEXT_CONNECTIONSTRING) ...
     - builder.Services.AddDbContext<DBCONTEXT>(options => ...

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.BlazorIdentity
         internal static string BlazorIdentityReadmeString =
 @"Blazor Identity scaffolding has completed successfully.
 
-For setup and configuration information, see https://learn.microsoft.com/en-us/aspnet/core/blazor/security.
+For setup and configuration information, see https://go.microsoft.com/fwlink/?linkid=2290075.
 
 If the project had identity support prior to scaffolding, ensure that the following changes are present in Program.cs:
 1. Correct DbContextClass is used in the following statements :

--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityHelper.cs
@@ -101,5 +101,23 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.BlazorIdentity
 
             return filteredChanges;
         }
+
+        internal static string BlazorIdentityReadmeFileName = "Scaffolding-README.md";
+        internal static string BlazorIdentityReadmeString =
+@"Support for Blazor Identity was added to your project.
+
+For setup and configuration information, see https://learn.microsoft.com/en-us/aspnet/core/blazor/security.
+
+If adding Blazor Identity to a project with existing Identity, ensure the following changes in your Program.cs file:
+1. Correct DbContextClass is used in the following statements :
+    - var connectionString = builder.Configuration.GetConnectionString(DBCONTEXT_CONNECTIONSTRING) ...
+    - builder.Services.AddDbContext<DBCONTEXT>(options => ...
+    - builder.Services.AddIdentityCore<IDENTITY_USER_CLASS>...
+        .AddEntityFrameworkStores<DBCONTEXT>() ...
+2. Correct Identity User class is being used, (if using the default 'IdentityUser' or a custom IdentityUser class).
+    - builder.Services.AddIdentityCore<IDENTITY_USER_CLASS>...
+    - builder.Services.AddSingleton<IEmailSender<IDENTITY_USER_CLASS>...
+";
+
     }
 }


### PR DESCRIPTION
Context : Currently, scaffolding does not support updating/removing existing statements in a C# class and chosing not to add additional duplicate references with the newly created names. This causes more build errors and confusion. Updating using roslyn required more complicated logic and chosing to not add it for the older scaffolders. Therefore, just adding a readme to clear up the confusion with very simple, obvious workarounds.

For Blazor Identity scenarios, there was some confusion regarding the identity specific statements/calls in the Program.cs file. If blazor-identity was scaffolded on top an app with preexisting identity:
- the `IdentityUser` class could be incorrect (old one) if a new one was created.
- the `DbContextClass` class could be incorrect (old one) if a new one was created.
- the `ConnectionString` could be incorrect (old one) if a new DbContext was created.

@sayedihashimi can you review the `BlazorIdentityReadmeString` variable please.
