### PR TITLE
minor string changes, sdk version check

### DIFF
--- a/eng/Versions.DotNetScaffold.props
+++ b/eng/Versions.DotNetScaffold.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>9.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>8</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>9</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
     <!--

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/README.md
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/README.md
@@ -7,7 +7,7 @@ For example :
 var builder = Host.CreateScaffoldBuilder();
 var newScaffolder = builder.AddScaffolder("scaffolder");
 newScaffolder.WithCategory("Custom")
-    .WithDescription("Project for scaffolding!")
+    .WithDescription("Project for scaffolding.")
     .WithOption(projectOption)
     .WithStep<CodeModificationStep>(config =>
     {

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/DotnetCommands.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/DotnetCommands.cs
@@ -45,7 +45,7 @@ internal static class DotnetCommands
                     logger.LogInformation($"\n{stdErr}");
                 }
 
-                logger.LogInformation("Failed!");
+                logger.LogInformation("Failed.");
             }
             else
             {

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/README.md
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/README.md
@@ -8,7 +8,7 @@ For example:
 var builder = Host.CreateScaffoldBuilder();
 var newScaffolder = builder.AddScaffolder("scaffolder");
 newScaffolder.WithCategory("Custom")
-    .WithDescription("Project for scaffolding!")
+    .WithDescription("Project for scaffolding.")
     .WithOption(projectOption)
     .WithStep<ScaffoldStep>(config =>
     {

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/ProcessOutputStreamReader.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/ProcessOutputStreamReader.cs
@@ -81,7 +81,7 @@ internal sealed class ProcessOutputStreamReader : IDisposable
     {
         if (_capture != null)
         {
-            throw new InvalidOperationException("Already capturing stream!"); // TODO: Localize this?
+            throw new InvalidOperationException("Already capturing stream."); // TODO: Localize this?
         }
     }
 

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
@@ -38,8 +38,10 @@ internal class MsBuildInitializer
 
             //register newest MSBuild from the newest dotnet sdk installed.
             var sdkPath = Directory.GetDirectories(sdkBasePath)
-                                  .OrderByDescending(d => new DirectoryInfo(d).Name)
-                                  .FirstOrDefault();
+                .Select(d => new DirectoryInfo(d).Name)
+                .Where(name => Version.TryParse(name.Split('-')[0], out _))
+                .OrderByDescending(name => name)
+                .FirstOrDefault();
 
             if (string.IsNullOrEmpty(sdkPath))
             {

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/README.md
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.TextTemplating/README.md
@@ -7,7 +7,7 @@ For example :
 var builder = Host.CreateScaffoldBuilder();
 var newScaffolder = builder.AddScaffolder("scaffolder");
 newScaffolder.WithCategory("Custom")
-    .WithDescription("Project for scaffolding!")
+    .WithDescription("Project for scaffolding.")
     .WithOption(projectOption)
     .WithStep<TextTemplatingStep>(config =>
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspire/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspire/Program.cs
@@ -19,7 +19,7 @@ CreateOptions(out var cachingTypeOption, out var databaseTypeOption, out var sto
 
 var caching = builder.AddScaffolder("caching");
 caching.WithCategory("Aspire")
-       .WithDescription("Modified Aspire project to make it caching ready!")
+       .WithDescription("Modified Aspire project to make it caching ready.")
        .WithOption(cachingTypeOption)
        .WithOption(appHostProjectOption)
        .WithOption(projectOption)
@@ -33,7 +33,7 @@ caching.WithCategory("Aspire")
 
 var database = builder.AddScaffolder("database");
 database.WithCategory("Aspire")
-        .WithDescription("Modifies Aspire project to make it database ready!")
+        .WithDescription("Modifies Aspire project to make it database ready.")
         .WithOption(databaseTypeOption)
         .WithOption(appHostProjectOption)
         .WithOption(projectOption)
@@ -49,7 +49,7 @@ database.WithCategory("Aspire")
 
 var storage = builder.AddScaffolder("storage");
 storage.WithCategory("Aspire")
-       .WithDescription("Modifies Aspire project to make it storage ready!")
+       .WithDescription("Modifies Aspire project to make it storage ready.")
        .WithOption(storageTypeOption)
        .WithOption(appHostProjectOption)
        .WithOption(projectOption)

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -26,7 +26,7 @@ public static class Program
             out var openApiOption, out var pageTypeOption, out var controllerNameOption, out var viewsOption, out var overwriteOption);
 
         builder.AddScaffolder("blazor-empty")
-            .WithDisplayName("Razor Component - Empty")
+            .WithDisplayName("Razor Component")
             .WithCategory("Blazor")
             .WithDescription("Add an empty razor component to a given project")
             .WithOption(projectOption)
@@ -70,8 +70,8 @@ public static class Program
                 step.CommandName = "page";
             });
 
-        builder.AddScaffolder("apicontroller-empty")
-            .WithDisplayName("API Controller - Empty")
+        builder.AddScaffolder("apicontroller")
+            .WithDisplayName("API Controller")
             .WithCategory("API")
             .WithDescription("Add an empty API Controller to a given project")
             .WithOptions([projectOption, fileNameOption, actionsOption])
@@ -85,8 +85,8 @@ public static class Program
                 step.CommandName = "apicontroller";
             });
 
-        builder.AddScaffolder("mvccontroller-empty")
-            .WithDisplayName("MVC Controller - Empty")
+        builder.AddScaffolder("mvccontroller")
+            .WithDisplayName("MVC Controller")
             .WithCategory("MVC")
             .WithDescription("Add an empty MVC Controller to a given project")
             .WithOptions([projectOption, fileNameOption, actionsOption])

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             if (string.IsNullOrEmpty(displayCategory))
             {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any component categories!"));
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any component categories."));
             }
             else
             {
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             }
             else
             {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("No component (dotnet tool) provided!"));
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("No component (dotnet tool) provided."));
             }
 
             if (commandInfo is null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandPickerFlowStep.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             if (commandInfoKvp is null || !commandInfoKvp.HasValue || commandInfoKvp.Value.Value is null || string.IsNullOrEmpty(commandInfoKvp.Value.Key))
             {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any commands!"));
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any commands."));
             }
             else
             {
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             }
             else
             {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("No component (dotnet tool) provided!"));
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("No component (dotnet tool) provided."));
             }
 
             if (commandInfo is null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/ParameterDiscovery.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             if (!string.IsNullOrEmpty(promptVal) && !ParameterHelpers.CheckType(_parameter.Type, promptVal))
             {
-                return ValidationResult.Error("Invalid input, please try again!");
+                return ValidationResult.Error("Invalid input, please try again.");
             }
 
             return ValidationResult.Success();

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
@@ -59,7 +59,7 @@ internal class StartupFlowStep : IFlowStep
                 new FirstPartyComponentInitializer(_logger, _dotnetToolService).Initialize();
                 statusContext.Status = "Done\n";
                 //parse args passed
-                statusContext.Status = "Parsing args!";
+                statusContext.Status = "Parsing args.";
                 var remainingArgs = context.GetRemainingArgs();
                 if (remainingArgs != null)
                 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -29,11 +29,11 @@ internal class FirstPartyComponentInitializer
 
         foreach (var tool in toolsToInstall)
         {
-            _logger.LogInformation("Installing {tool}!", tool);
+            _logger.LogInformation("Installing {tool}.", tool);
             var successfullyInstalled = _dotnetToolService.InstallDotNetTool(tool, prerelease: true);
             if (!successfullyInstalled)
             {
-                _logger.LogInformation("Failed to install {tool}!", tool);
+                _logger.LogInformation("Failed to install {tool}.", tool);
             }
         }
     }


### PR DESCRIPTION
- removed `!` from logged messages
- removed `- Empty` from MVC and API controllers since there might be generated content (with `--actions` flag)
- updated logic in `MsBuildInitializer.RegisterMsbuild()` to get the newest MSBuild from the newest dotnet sdk installed
  - if there were folders present in the default .NET SDK directory that did not follow the .NET version convention, the descending sort would to get the incorrect highest versioned sdk folder.
  - checking correct folders by performing a `Version.TryParse`
  - also splitting by `-` to account for preview and RC versions.