### PR TITLE
bunch of little fixes for `dotnet-scaffold`

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.Logging;
@@ -38,9 +39,10 @@ internal class MsBuildInitializer
 
             //register newest MSBuild from the newest dotnet sdk installed.
             var sdkPath = Directory.GetDirectories(sdkBasePath)
-                .Select(d => new DirectoryInfo(d).Name)
-                .Where(name => Version.TryParse(name.Split('-')[0], out _))
-                .OrderByDescending(name => name)
+                .Select(d => new { Path = d, new DirectoryInfo(d).Name })
+                .Where(d => Version.TryParse(d.Name.Split('-')[0], out _))
+                .OrderByDescending(d => Version.Parse(d.Name.Split('-')[0]))
+                .Select(d => d.Path)
                 .FirstOrDefault();
 
             if (string.IsNullOrEmpty(sdkPath))

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MsBuildInitializer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.Logging;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ModelInfo.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ModelInfo.cs
@@ -9,6 +9,7 @@ internal class ModelInfo
     //Model class info
     public List<IPropertySymbol>? ModelProperties { get; set; }
     public string? ModelNamespace { get; set; }
+    public string? ModelFullName { get; set; }
     public string ModelTypeName { get; set; } = default!;
     public string ModelTypeNameCapitalized => !string.IsNullOrEmpty(ModelTypeName) ? char.ToUpper(ModelTypeName[0]) + ModelTypeName.Substring(1) : ModelTypeName;
     //TODO pluralize correctly

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
@@ -49,7 +49,13 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
     private bool InvokeDotnetNew(DotnetNewStepSettings stepSettings)
     {
         var projectBasePath = Path.GetDirectoryName(stepSettings.Project);
-        if (Directory.Exists(projectBasePath))
+        //using the project name from the csproj path as namespace currently.
+        //to evaluate the correct namespace is a lot of overhead for a simple 'dotnet new' operation
+        //TODO maybe change this?
+        var projectName = Path.GetFileNameWithoutExtension(stepSettings.Project);
+        if (Directory.Exists(projectBasePath) &&
+            !string.IsNullOrEmpty(projectBasePath) &&
+            !string.IsNullOrEmpty(projectName))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()
@@ -57,6 +63,8 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
                 stepSettings.CommandName,
                 "--name",
                 stepSettings.Name,
+                "--namespace",
+                projectName,
                 "--output",
                 projectBasePath
             };

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateBlazorCrudStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateBlazorCrudStep.cs
@@ -171,7 +171,7 @@ internal class ValidateBlazorCrudStep : ScaffoldStep
         if (!string.IsNullOrEmpty(dbContextClassName) && !string.IsNullOrEmpty(settings.DatabaseProvider))
         {
             var dbContextClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(dbContextClassName, StringComparison.OrdinalIgnoreCase));
-            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, settings.Model);
+            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, modelInfo);
             dbContextInfo.EfScenario = true;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
@@ -178,7 +178,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
         if (!string.IsNullOrEmpty(dbContextClassName) && !string.IsNullOrEmpty(settings.DatabaseProvider))
         {
             var dbContextClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(dbContextClassName, StringComparison.OrdinalIgnoreCase));
-            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, settings.Model);
+            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, modelInfo);
             dbContextInfo.EfScenario = true;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateMinimalApiStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateMinimalApiStep.cs
@@ -161,7 +161,7 @@ internal class ValidateMinimalApiStep : ScaffoldStep
         if (!string.IsNullOrEmpty(dbContextClassName) && !string.IsNullOrEmpty(settings.DatabaseProvider))
         {
             var dbContextClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(dbContextClassName, StringComparison.OrdinalIgnoreCase));
-            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, settings.Model);
+            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, modelInfo);
         }
 
         MinimalApiModel scaffoldingModel = new()

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateRazorPagesStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateRazorPagesStep.cs
@@ -163,7 +163,7 @@ internal class ValidateRazorPagesStep : ScaffoldStep
         if (!string.IsNullOrEmpty(dbContextClassName) && !string.IsNullOrEmpty(settings.DatabaseProvider))
         {
             var dbContextClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(dbContextClassName, StringComparison.OrdinalIgnoreCase));
-            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, settings.Model);
+            dbContextInfo = ClassAnalyzers.GetDbContextInfo(settings.Project, dbContextClassSymbol, dbContextClassName, settings.DatabaseProvider, modelInfo);
             dbContextInfo.EfScenario = true;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.cs
@@ -76,6 +76,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
             this.Write(";\r\n");
 
 }
+ if (!string.IsNullOrEmpty(Model.ModelInfo.ModelNamespace))
+{
+            this.Write("using ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.ModelInfo.ModelNamespace));
+            this.Write(";\r\n");
+
+}
             this.Write("\r\npublic static class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.EndpointsClassName));
             this.Write("\r\n{\r\n    public static void ");

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/MinimalApi/MinimalApiEf.tt
@@ -52,6 +52,11 @@ using Microsoft.EntityFrameworkCore;
 using <#= Model.DbContextInfo.DbContextNamespace #>;
 <#
 }#>
+<# if (!string.IsNullOrEmpty(Model.ModelInfo.ModelNamespace))
+{#>
+using <#= Model.ModelInfo.ModelNamespace #>;
+<#
+}#>
 
 public static class <#= Model.EndpointsClassName #>
 {


### PR DESCRIPTION
- fixed `MsBuildInitializer.RegisterMsbuild()` change from last PR. The LINQ op was returning the highest version of the .NET SDK but not the path. Didn't catch it due no verbose logging rn, coming soon.
- adding the model namespace (if non-empty) to the Minimal API scaffolded class (EF scenario).
  - was not missing from other EF scenario templates
- adding the full model name to the DbContext class when defining the DbSet property.
  - was not accounting for namespaces at all.