### PR TITLE
correctly adding --namespace for a bunch of scaffolders

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -66,6 +66,7 @@ public static class Program
                 var step = config.Step;
                 var context = config.Context;
                 step.ProjectPath = context.GetOptionResult(projectOption);
+                step.NamespaceName = Path.GetFileNameWithoutExtension(step.ProjectPath);
                 step.FileName = context.GetOptionResult(fileNameOption);
                 step.CommandName = "page";
             });

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
@@ -14,6 +14,7 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
 {
     public string? ProjectPath { get; set; }
     public required string CommandName { get; set; }
+    public string? NamespaceName { get; set; }
     public string? FileName { get; set; }
     private readonly ILogger _logger;
     private readonly IFileSystem _fileSystem;
@@ -56,8 +57,7 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
         //TODO maybe change this?
         var projectName = Path.GetFileNameWithoutExtension(stepSettings.Project);
         if (Directory.Exists(projectBasePath) &&
-            !string.IsNullOrEmpty(projectBasePath) &&
-            !string.IsNullOrEmpty(projectName))
+            !string.IsNullOrEmpty(projectBasePath))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()
@@ -65,11 +65,15 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
                 stepSettings.CommandName,
                 "--name",
                 stepSettings.Name,
-                "--namespace",
-                projectName,
                 "--output",
                 projectBasePath
             };
+
+            if (!string.IsNullOrEmpty(stepSettings.NamespaceName))
+            {
+                args.Add("--namespace");
+                args.Add(stepSettings.NamespaceName);
+            }
 
             var runner = DotnetCliRunner.CreateDotNet("new", args);
             var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);
@@ -102,6 +106,7 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
         {
             Project = ProjectPath,
             Name = FileName,
+            NamespaceName = NamespaceName,
             CommandName = CommandName
         };
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
@@ -46,11 +46,13 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
 
         return Task.FromResult(result);
     }
+
     private bool InvokeDotnetNew(EmptyControllerStepSettings settings)
     {
         var projectBasePath = Path.GetDirectoryName(settings.Project);
+        var projectName = Path.GetFileNameWithoutExtension(settings.Project);
         var actionsParameter = settings.Actions ? "--actions" : string.Empty;
-        if (Directory.Exists(projectBasePath))
+        if (Directory.Exists(projectBasePath) && !string.IsNullOrEmpty(projectName))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()
@@ -58,11 +60,16 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
                 settings.CommandName,
                 "--name",
                 settings.Name,
-                "--actions",
                 "--output",
                 projectBasePath,
-                actionsParameter
+                "--namespace",
+                projectName,
             };
+
+            if (!string.IsNullOrEmpty(actionsParameter))
+            {
+                args.Add(actionsParameter);
+            }
 
             var runner = DotnetCliRunner.CreateDotNet("new", args);
             var exitCode = runner.ExecuteAndCaptureOutput(out _, out _);

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/Settings/DotnetNewStepSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/Settings/DotnetNewStepSettings.cs
@@ -6,4 +6,5 @@ internal class DotnetNewStepSettings : BaseSettings
 {
     public required string CommandName { get; set; }
     public required string Name { get; set; }
+    public string? NamespaceName { get; set; }
 }


### PR DESCRIPTION
fix empty scaffolders
- `razorpage-empty` : adding missing `--namespace` parameter
- `controller` scaffolders : 
   - adding missing `--namespace` parameter
   - correctly adding `--actions` parameter (was being added to every scenario)
- `razorview-empty` and `blazor-empty` : not adding unnecessary `--namespace` parameter, was causing the scenario to fail.
