### PR TITLE
calling 'dotnet tool restore' before invoking local tools

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -76,6 +76,15 @@ internal class DotNetToolService : IDotNetToolService
             components = GetDotNetTools(refresh: true);
         }
 
+        //if any local tools are present, we need to restore them first
+        //when sdks/runtimes are switched/rolled forward, local tools need to be restored before they are called
+        var anyLocalTools = components.FirstOrDefault(x => !x.IsGlobalTool) is not null;
+        if (anyLocalTools)
+        {
+            var runner = DotnetCliRunner.CreateDotNet("tool", ["restore"]);
+            runner.ExecuteAndCaptureOutput(out _, out _);
+        }
+
         var options = new ParallelOptions
         {
             MaxDegreeOfParallelism = System.Environment.ProcessorCount


### PR DESCRIPTION
when bumping .NET SDK versions on a machine (.NET 8 --> 9 lets  say), local tools are not available to call until a 'dotnet tool restore' is called. Also a fairly mindful operation incase local tool files are messed with, this will help them be repaired before invocation.