### PR TITLE
supporting scaffolders having multiple categories

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
@@ -8,18 +8,18 @@ namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 
 internal class ScaffoldBuilder(string name) : IScaffoldBuilder
 {
-    private const string DEFAULT_CATEGORY = "General";
+    private const string DEFAULT_CATEGORY = "All";
 
     private readonly List<ScaffolderOption> _options = [];
     private readonly List<ScaffoldStepPreparer> _stepPreparers = [];
     private readonly string _name = FixName(name);
     private string? _displayName;
-    private string? _category;
+    private HashSet<string> _categories = [DEFAULT_CATEGORY];
     private string? _description;
 
     internal string Name => _name;
     internal string DisplayName => _displayName ?? System.Globalization.CultureInfo.CurrentUICulture.TextInfo.ToTitleCase(name);
-    internal string Category => _category ?? DEFAULT_CATEGORY;
+    internal HashSet<string> Categories => _categories;
     internal string? Description => _description;
     internal IEnumerable<ScaffolderOption> Options => _options;
     internal IEnumerable<ScaffoldStepPreparer> StepPreparers => _stepPreparers;
@@ -32,7 +32,7 @@ internal class ScaffoldBuilder(string name) : IScaffoldBuilder
 
     public IScaffoldBuilder WithCategory(string category)
     {
-        _category = category;
+        _categories.Add(category);
         return this;
     }
 
@@ -78,7 +78,7 @@ internal class ScaffoldBuilder(string name) : IScaffoldBuilder
             steps.Add((ScaffoldStep)stepInstance);    
         }
 
-        return new Scaffolder(Name, DisplayName, Category, Description, _options, steps, _stepPreparers);
+        return new Scaffolder(Name, DisplayName, Categories.ToList(), Description, _options, steps, _stepPreparers);
     }
 
     private static string FixName(string name)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
@@ -67,7 +67,7 @@ internal static class CommandLineExtensions
         {
             Name = scaffolder.Name,
             DisplayName = scaffolder.DisplayName,
-            DisplayCategories = scaffolder.Categories,
+            DisplayCategories = scaffolder.Categories.ToList(),
             Description = scaffolder.Description,
             Parameters = scaffolder.Options.Select(o => o.ToParameter()).ToArray()
         };

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
@@ -67,7 +67,7 @@ internal static class CommandLineExtensions
         {
             Name = scaffolder.Name,
             DisplayName = scaffolder.DisplayName,
-            DisplayCategory = scaffolder.Category,
+            DisplayCategories = scaffolder.Categories,
             Description = scaffolder.Description,
             Parameters = scaffolder.Options.Select(o => o.ToParameter()).ToArray()
         };

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/CommandInfo.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/CommandInfo.cs
@@ -9,7 +9,7 @@ internal class CommandInfo
 {
     public required string Name { get; init; }
     public required string DisplayName { get; init; }
-    public required string DisplayCategory { get; init; }
+    public required List<string> DisplayCategories { get; init; }
     public string? Description { get; set; }
     public required Parameter[] Parameters { get; init; }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
@@ -18,9 +18,9 @@ public interface IScaffolder
     string DisplayName { get; }
 
     /// <summary>
-    /// The category in which the scaffolder will be organized in the dotnet-scaffold interactive UI
+    /// The categories in which the scaffolder will be organized in the dotnet-scaffold interactive UI (atleast one default 'All')
     /// </summary>
-    string Category { get; }
+    List<string> Categories { get; }
 
     /// <summary>
     /// The description of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/IScaffolder.cs
@@ -20,7 +20,7 @@ public interface IScaffolder
     /// <summary>
     /// The categories in which the scaffolder will be organized in the dotnet-scaffold interactive UI (atleast one default 'All')
     /// </summary>
-    List<string> Categories { get; }
+    IEnumerable<string> Categories { get; }
 
     /// <summary>
     /// The description of the scaffolder as it will be displayed in the dotnet-scaffold interactive UI

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/Scaffolder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/Scaffolder.cs
@@ -16,7 +16,7 @@ public class Scaffolder : IScaffolder
     private readonly List<ScaffoldStepPreparer> _preparers;
     public string Name => _name;
     public string DisplayName => _displayName;
-    public List<string> Categories => _categories;
+    public IEnumerable<string> Categories => _categories;
     public string? Description => _description;
     public IEnumerable<ScaffolderOption> Options => _options;
 

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/Scaffolder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Scaffolders/Scaffolder.cs
@@ -9,22 +9,22 @@ public class Scaffolder : IScaffolder
 {
     private readonly string _name;
     private readonly string _displayName;
-    private readonly string _category;
+    private readonly List<string> _categories;
     private readonly string? _description;
     private readonly List<ScaffolderOption> _options;
     private readonly List<ScaffoldStep> _steps;
     private readonly List<ScaffoldStepPreparer> _preparers;
     public string Name => _name;
     public string DisplayName => _displayName;
-    public string Category => _category;
+    public List<string> Categories => _categories;
     public string? Description => _description;
     public IEnumerable<ScaffolderOption> Options => _options;
 
-    internal Scaffolder(string name, string displayName, string category, string? description, List<ScaffolderOption> options, List<ScaffoldStep> steps, List<ScaffoldStepPreparer> preparers)
+    internal Scaffolder(string name, string displayName, List<string> categories, string? description, List<ScaffolderOption> options, List<ScaffoldStep> steps, List<ScaffoldStepPreparer> preparers)
     {
         _name = name;
         _displayName = displayName;
-        _category = category;
+        _categories = categories;
         _description = description;
         _options = options;
         _steps = steps;

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -249,6 +249,7 @@ public static class Program
         builder.AddScaffolder("blazor-identity")
             .WithDisplayName("Blazor Identity")
             .WithCategory("Blazor")
+            .WithCategory("Identity")
             .WithDescription("Add blazor identity to a project.")
             .WithOptions([projectOption, dataContextClassRequiredOption, identityDbProviderRequiredOption, overwriteOption, prereleaseOption])
             .WithStep<ValidateIdentityStep>(config =>

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/FlowContextProperties.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/FlowContextProperties.cs
@@ -28,6 +28,7 @@ internal static class FlowContextProperties
     public const string TargetFrameworkName = nameof(TargetFrameworkName);
     public const string RemainingArgs = nameof(RemainingArgs);
     public const string DotnetToolComponents = nameof(DotnetToolComponents);
-    public const string ScaffoldingCategory = nameof(ScaffoldingCategory);
+    public const string ScaffoldingCategories = nameof(ScaffoldingCategories);
+    public const string ChosenCategory = nameof(ChosenCategory);
     public const string TelemetryEnvironmentVariables = nameof(TelemetryEnvironmentVariables);
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/FlowExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/FlowExtensions.cs
@@ -40,9 +40,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow
             return context.GetValueOrThrow<IList<KeyValuePair<string, CommandInfo>>>(FlowContextProperties.CommandInfos, throwIfEmpty);
         }
 
-        public static string? GetScaffoldingCategory(this IFlowContext context, bool throwIfEmpty = false)
+        public static List<string>? GetScaffoldingCategories(this IFlowContext context, bool throwIfEmpty = false)
         {
-            return context.GetValueOrThrow<string>(FlowContextProperties.ScaffoldingCategory, throwIfEmpty);
+            return context.GetValueOrThrow<List<string>?>(FlowContextProperties.ScaffoldingCategories, throwIfEmpty);
+        }
+
+        public static string? GetChosenCategory(this IFlowContext context, bool throwIfEmpty = false)
+        {
+            return context.GetValueOrThrow<string>(FlowContextProperties.ChosenCategory, throwIfEmpty);
         }
 
         public static string? GetSourceProjectPath(this IFlowContext context, bool throwIfEmpty = false)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
@@ -47,7 +47,7 @@ internal class CategoryDiscovery
         var displayCategories = new List<string>();
         //only get categories from the picked DotNetToolInfo
         displayCategories = (_componentPicked != null ? allCommands?.Where(x => x.Key.Equals(_componentPicked.Command)) : allCommands)
-            ?.Select(y => y.Value.DisplayCategory)
+            ?.SelectMany(y => y.Value.DisplayCategories)
             ?.Distinct()
             ?.Order()
             ?.ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryPickerFlowStep.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
         public ValueTask ResetAsync(IFlowContext context, CancellationToken cancellationToken)
         {
-            context.Unset(FlowContextProperties.ScaffoldingCategory);
+            context.Unset(FlowContextProperties.ScaffoldingCategories);
+            context.Unset(FlowContextProperties.ChosenCategory);
             context.Unset(FlowContextProperties.ComponentName);
             context.Unset(FlowContextProperties.ComponentObj);
             context.Unset(FlowContextProperties.CommandName);
@@ -57,7 +58,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             }
             else
             {
-                SelectCategory(context, displayCategory);
+                SelectChosenCategory(context, displayCategory);
             }
 
             return new ValueTask<FlowStepResult>(FlowStepResult.Success);
@@ -92,15 +93,24 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             SelectComponent(context, dotnetToolComponent);
             SelectCommand(context, commandInfo);
-            SelectCategory(context, commandInfo.DisplayCategory);
+            SelectCategories(context, commandInfo.DisplayCategories);
             return new ValueTask<FlowStepResult>(FlowStepResult.Success);
         }
 
-        private void SelectCategory(IFlowContext context, string categoryName)
+        private void SelectCategories(IFlowContext context, List<string> categories)
         {
             context.Set(new FlowProperty(
-                FlowContextProperties.ScaffoldingCategory,
-                categoryName,
+                FlowContextProperties.ScaffoldingCategories,
+                categories,
+                "Scaffolding Categories",
+                isVisible: false));
+        }
+
+        private void SelectChosenCategory(IFlowContext context, string category)
+        {
+            context.Set(new FlowProperty(
+                FlowContextProperties.ChosenCategory,
+                category,
                 "Scaffolding Category",
                 isVisible: true));
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandDiscovery.cs
@@ -50,9 +50,28 @@ internal class CommandDiscovery
             allCommands = allCommands?.Where(x => x.Key.Equals(_componentPicked.Command)).ToList();
         }
 
-        var scaffoldingCategory = context.GetScaffoldingCategory();
+        List<string> scaffoldingCategories = [];
+        var scaffoldingCategory = context.GetChosenCategory();
+        if (string.IsNullOrEmpty(scaffoldingCategory))
+        {
+            //get all categories for non-interactive scenario (since no chosen one was found)
+            var possibleScaffoldingCategories = context.GetScaffoldingCategories();
+            if (possibleScaffoldingCategories is null || possibleScaffoldingCategories.Count == 0)
+            {
+                return null;
+            }
+            else
+            {
+                scaffoldingCategories.AddRange(possibleScaffoldingCategories);
+            }
+        }
+        else
+        {
+            scaffoldingCategories.Add(scaffoldingCategory);
+        }
+
         var allCommandsByCategory = allCommands?
-            .Where(x => x.Value.DisplayCategory.Equals(scaffoldingCategory))
+            .Where(x => x.Value.DisplayCategories.Intersect(scaffoldingCategories).Any())
             .OrderBy(kvp => kvp.Value.DisplayName)
             .ToList();
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CommandExecuteFlowStep.cs
@@ -48,6 +48,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
 
             var parameterValues = GetAllParameterValues(context, commandObj);
             var envVars = context.GetTelemetryEnvironmentVariables();
+            var chosenCategory = context.GetChosenCategory();
             if (!string.IsNullOrEmpty(dotnetToolInfo.Command) && parameterValues.Count != 0 && !string.IsNullOrEmpty(commandObj.Name))
             {
                 var componentExecutionString = $"{dotnetToolInfo.Command} {string.Join(" ", parameterValues)}";
@@ -63,7 +64,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                             (s) => AnsiConsole.Console.MarkupLineInterpolated($"[red]{s}[/]"));
                     });
 
-                _telemetryService.TrackEvent(new CommandExecuteTelemetryEvent(dotnetToolInfo, commandObj, exitCode));
+                _telemetryService.TrackEvent(new CommandExecuteTelemetryEvent(dotnetToolInfo, commandObj, exitCode, chosenCategory));
                 if (exitCode != null)
                 {
                     if (exitCode != 0)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Telemetry/CommandExecuteTelemetryEvent.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Telemetry/CommandExecuteTelemetryEvent.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics;
 using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
 
@@ -8,14 +9,19 @@ namespace Microsoft.DotNet.Tools.Scaffold.Telemetry;
 internal class CommandExecuteTelemetryEvent : TelemetryEventBase
 {
     private const string TelemetryEventName = "CommandExecute";
-    public CommandExecuteTelemetryEvent(DotNetToolInfo dotnetToolInfo, CommandInfo commandInfo, int? exitCode) : base(TelemetryEventName)
+    public CommandExecuteTelemetryEvent(DotNetToolInfo dotnetToolInfo, CommandInfo commandInfo, int? exitCode, string? chosenCategory = null) : base(TelemetryEventName)
     {
         SetProperty("PackageName", dotnetToolInfo.PackageName);
         SetProperty("Version", dotnetToolInfo.Version);
         SetProperty("ToolName", dotnetToolInfo.Command);
         SetProperty("ToolLevel", dotnetToolInfo.IsGlobalTool ? TelemetryConstants.GlobalTool : TelemetryConstants.LocalTool);
         SetProperty("CommandName", commandInfo.Name);
-        SetProperty("CommandCategory", commandInfo.DisplayCategory);
+        SetProperty("AllCommandCategories", string.Join(",", commandInfo.DisplayCategories));
+        if (!string.IsNullOrEmpty(chosenCategory))
+        {
+            SetProperty("ChosenCategory", chosenCategory);
+        }
+
         SetProperty("Result", exitCode is null ? TelemetryConstants.Unknown : exitCode == 0 ? TelemetryConstants.Success : TelemetryConstants.Failure);
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Telemetry/CommandExecuteTelemetryEvent.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Telemetry/CommandExecuteTelemetryEvent.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Diagnostics;
 using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
+using Microsoft.DotNet.Scaffolding.Internal.Extensions;
 using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
 
 namespace Microsoft.DotNet.Tools.Scaffold.Telemetry;
@@ -16,10 +16,10 @@ internal class CommandExecuteTelemetryEvent : TelemetryEventBase
         SetProperty("ToolName", dotnetToolInfo.Command);
         SetProperty("ToolLevel", dotnetToolInfo.IsGlobalTool ? TelemetryConstants.GlobalTool : TelemetryConstants.LocalTool);
         SetProperty("CommandName", commandInfo.Name);
-        SetProperty("AllCommandCategories", string.Join(",", commandInfo.DisplayCategories));
+        SetProperty("AllCommandCategories", string.Join(",", commandInfo.DisplayCategories).Hash());
         if (!string.IsNullOrEmpty(chosenCategory))
         {
-            SetProperty("ChosenCategory", chosenCategory);
+            SetProperty("ChosenCategory", chosenCategory.Hash());
         }
 
         SetProperty("Result", exitCode is null ? TelemetryConstants.Unknown : exitCode == 0 ? TelemetryConstants.Success : TelemetryConstants.Failure);


### PR DESCRIPTION
previously, scaffolders only were allowed 1 'Category'. Multiple are supported now : 
- changed `Microsoft.DotNet.Scaffolding.Core.Scaffolders.IScaffolder.Category` --> `Microsoft.DotNet.Scaffolding.Core.Scaffolders.IScaffolder.Categories`
- `IScaffoldBuilder.WithCategory` is adding to a `HashSet` now, by default including an `All` category.
- `Microsoft.DotNet.Scaffolding.Core.ComponentModel.DisplayCategory` --> `DisplayCategories` to account for the changes above
- `blazor-identity` now under multiple categories : `Blazor` and `Identity`
- changed telemetry tracking : 
  - previously, only tracking `CommandCategory` for the category for the picked scaffolder.
  - with above changes, tracking `ChosenCategory` for the interactively picked category, and `AllCommandCategories` for all applicable categories for the picked scaffolder. @sayedihashimi would like feedback on these names pls.