### PR TITLE
check for valid identifiers for --dataContext option

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/Constants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/Constants.cs
@@ -10,6 +10,7 @@ internal class Constants
     public const string ViewModelExtension = ".cshtml.cs";
     public const string T4TemplateExtension = ".tt";
     public const string GlobalNamespace = "<global namespace>";
+    public const string NewDbContext = nameof(NewDbContext);
 
     public class CliOptions
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Models/IdentityModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Models/IdentityModel.cs
@@ -13,9 +13,6 @@ internal class IdentityModel
     public required string UserClassName { get; internal set; }
     public required string UserClassNamespace { get; internal set; }
     public string? DbContextNamespace { get; set; }
-    public required string DbContextName { get; set; }
-    //Database type eg. SQL Server or SQLite
-    public string? DatabaseProvider { get; set; }
     public required string BaseOutputPath { get; set; }
     public bool Overwrite { get; set; }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateBlazorCrudStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateBlazorCrudStep.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
@@ -10,6 +11,7 @@ using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
 using Microsoft.Extensions.Logging;
 using Constants = Microsoft.DotNet.Scaffolding.Internal.Constants;
+using AspNetConstants = Microsoft.DotNet.Tools.Scaffold.AspNet.Common.Constants;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
 
@@ -93,19 +95,19 @@ internal class ValidateBlazorCrudStep : ScaffoldStep
     {
         if (string.IsNullOrEmpty(Project) || !_fileSystem.FileExists(Project))
         {
-            _logger.LogError("Missing/Invalid --project option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ProjectCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(Model))
         {
-            _logger.LogError("Missing/Invalid --model option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ModelCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(Page))
         {
-            _logger.LogError("Missing/Invalid --page option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.PageTypeOption} option.");
             return null;
         }
         else if (!string.IsNullOrEmpty(Page) && !BlazorCrudHelper.CRUDPages.Contains(Page, StringComparer.OrdinalIgnoreCase))
@@ -116,12 +118,22 @@ internal class ValidateBlazorCrudStep : ScaffoldStep
 
         if (string.IsNullOrEmpty(DataContext))
         {
-            _logger.LogError("Missing/Invalid --dataContext option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.DataContextOption} option.");
             return null;
         }
-        else if (string.IsNullOrEmpty(DatabaseProvider) || !PackageConstants.EfConstants.EfPackagesDict.ContainsKey(DatabaseProvider))
+        else
         {
-            DatabaseProvider = PackageConstants.EfConstants.SqlServer;
+            if (!SyntaxFacts.IsValidIdentifier(DataContext) || DataContext.Equals("DbContext", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation($"Invalid {AspNetConstants.CliOptions.DataContextOption} option");
+                _logger.LogInformation($"Using default '{AspNetConstants.NewDbContext}'");
+                DataContext = AspNetConstants.NewDbContext;
+            }
+
+            if (string.IsNullOrEmpty(DatabaseProvider) || !PackageConstants.EfConstants.EfPackagesDict.ContainsKey(DatabaseProvider))
+            {
+                DatabaseProvider = PackageConstants.EfConstants.SqlServer;
+            }
         }
 
         return new CrudSettings
@@ -149,7 +161,7 @@ internal class ValidateBlazorCrudStep : ScaffoldStep
         var modelClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(settings.Model, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(settings.Model) || modelClassSymbol is null)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid {AspNetConstants.CliOptions.ModelCliOption} '{settings.Model}'");
             return null;
         }
         else
@@ -160,7 +172,7 @@ internal class ValidateBlazorCrudStep : ScaffoldStep
         var validateModelInfoResult = ClassAnalyzers.ValidateModelForCrudScaffolders(modelInfo, _logger);
         if (!validateModelInfoResult)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid {AspNetConstants.CliOptions.ModelCliOption} '{settings.Model}'");
             return null;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
@@ -10,6 +11,7 @@ using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
 using Microsoft.Extensions.Logging;
 using Constants = Microsoft.DotNet.Scaffolding.Internal.Constants;
+using AspNetConstants = Microsoft.DotNet.Tools.Scaffold.AspNet.Common.Constants;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
 
@@ -85,19 +87,19 @@ internal class ValidateEfControllerStep : ScaffoldStep
     {
         if (string.IsNullOrEmpty(Project) || !_fileSystem.FileExists(Project))
         {
-            _logger.LogError("Missing/Invalid --project option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ProjectCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(Model))
         {
-            _logger.LogError("Missing/Invalid --model option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ModelCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(ControllerName))
         {
-            _logger.LogError("Missing/Invalid --controller option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ControllerNameOption} option.");
             return null;
         }
         else
@@ -107,7 +109,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
 
         if (string.IsNullOrEmpty(ControllerType))
         {
-            _logger.LogError($"Missing/Invalid '{nameof(ValidateEfControllerStep.ControllerType)}' value.");
+            _logger.LogError($"Missing/Invalid '{nameof(ControllerType)}' value.");
             return null;
         }
         else if (
@@ -121,12 +123,22 @@ internal class ValidateEfControllerStep : ScaffoldStep
 
         if (string.IsNullOrEmpty(DataContext))
         {
-            _logger.LogError("Missing/Invalid --dataContext option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.DataContextOption} option.");
             return null;
         }
-        else if (string.IsNullOrEmpty(DatabaseProvider) || !PackageConstants.EfConstants.EfPackagesDict.ContainsKey(DatabaseProvider))
+        else
         {
-            DatabaseProvider = PackageConstants.EfConstants.SqlServer;
+            if (!SyntaxFacts.IsValidIdentifier(DataContext) || DataContext.Equals("DbContext", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation($"Invalid {AspNetConstants.CliOptions.DataContextOption} option");
+                _logger.LogInformation($"Using default '{AspNetConstants.NewDbContext}'");
+                DataContext = AspNetConstants.NewDbContext;
+            }
+
+            if (string.IsNullOrEmpty(DatabaseProvider) || !PackageConstants.EfConstants.EfPackagesDict.ContainsKey(DatabaseProvider))
+            {
+                DatabaseProvider = PackageConstants.EfConstants.SqlServer;
+            }
         }
 
         return new EfControllerSettings
@@ -156,7 +168,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
         var modelClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(settings.Model, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(settings.Model) || modelClassSymbol is null)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid  {AspNetConstants.CliOptions.ModelCliOption}  '{settings.Model}'");
             return null;
         }
         else
@@ -167,7 +179,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
         var validateModelInfoResult = ClassAnalyzers.ValidateModelForCrudScaffolders(modelInfo, _logger);
         if (!validateModelInfoResult)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid {AspNetConstants.CliOptions.ModelCliOption} '{settings.Model}'");
             return null;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateViewsStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateViewsStep.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
 using Microsoft.Extensions.Logging;
+using AspNetConstants = Microsoft.DotNet.Tools.Scaffold.AspNet.Common.Constants;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
 
@@ -59,19 +60,19 @@ internal class ValidateViewsStep : ScaffoldStep
     {
         if (string.IsNullOrEmpty(Project) || !_fileSystem.FileExists(Project))
         {
-            _logger.LogError("Missing/Invalid --project option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ProjectCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(Model))
         {
-            _logger.LogError("Missing/Invalid --model option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ModelCliOption} option.");
             return null;
         }
 
         if (string.IsNullOrEmpty(Page))
         {
-            _logger.LogError("Missing/Invalid --page option.");
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.PageTypeOption} option.");
             return null;
         }
         else if (!string.IsNullOrEmpty(Page) && !BlazorCrudHelper.CRUDPages.Contains(Page, StringComparer.OrdinalIgnoreCase))
@@ -102,7 +103,7 @@ internal class ValidateViewsStep : ScaffoldStep
         var modelClassSymbol = allClasses.FirstOrDefault(x => x.Name.Equals(settings.Model, StringComparison.OrdinalIgnoreCase));
         if (string.IsNullOrEmpty(settings.Model) || modelClassSymbol is null)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid {AspNetConstants.CliOptions.ModelCliOption} '{settings.Model}'");
             return null;
         }
         else
@@ -113,7 +114,7 @@ internal class ValidateViewsStep : ScaffoldStep
         var validateModelInfoResult = ClassAnalyzers.ValidateModelForCrudScaffolders(modelInfo, _logger);
         if (!validateModelInfoResult)
         {
-            _logger.LogError($"Invalid --model '{settings.Model}'");
+            _logger.LogError($"Invalid {AspNetConstants.CliOptions.ModelCliOption} '{settings.Model}'");
             return null;
         }
 


### PR DESCRIPTION
scaffolders supporting `--dataContext` classes, any ol non-empty identifier was being allowed to be used for the name of a new DbContext class. Ran into a bug where someone tried to name these classes 'DbContext' which causes error due to it inheriting from 'Microsoft.EntityFrameworkCore.DbContext' 
- checking for valid identifiers using [SyntaxFacts](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Parser/CharacterInfo.cs).IsValidIdentifier
- using constant `NewDbContext` as the default
- updated error messages to include the invalid identifier that was used
- updated all `Validate` steps for `dotnet-scaffold-aspnet` tool.
- removed unused properties in `IdentityModel`.