### PR TITLE
add missing EfCore.Tools package to dotnet-scaffold-aspnet scaffolders.

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
@@ -49,7 +49,8 @@ internal static class BlazorCrudScaffolderBuilderExtensions
             var packageList = new List<string>()
             {
                 PackageConstants.AspNetCorePackages.QuickGridEfAdapterPackageName,
-                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackageName
+                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackageName,
+                PackageConstants.EfConstants.EfCoreToolsPackageName
             };
 
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/EfControllerScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/EfControllerScaffolderBuilderExtensions.cs
@@ -46,7 +46,7 @@ internal static class EfControllerScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<string> packageList = [];
+            List<string> packageList = [PackageConstants.EfConstants.EfCoreToolsPackageName];
             if (context.Properties.TryGetValue(nameof(EfControllerSettings), out var commandSettingsObj) &&
                 commandSettingsObj is EfControllerSettings commandSettings)
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -62,7 +62,7 @@ internal static class MinimalApiScaffolderBuilderExtensions
             var step = config.Step;
             var context = config.Context;
             //add Microsoft.EntityFrameworkCore.Tools package regardless of the DatabaseProvider
-            List<string> packageList = [];
+            List<string> packageList = [PackageConstants.EfConstants.EfCoreToolsPackageName];
             if (context.Properties.TryGetValue(nameof(MinimalApiSettings), out var commandSettingsObj) &&
                 commandSettingsObj is MinimalApiSettings commandSettings)
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -61,16 +61,18 @@ internal static class MinimalApiScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            //add Microsoft.EntityFrameworkCore.Tools package regardless of the DatabaseProvider
-            List<string> packageList = [PackageConstants.EfConstants.EfCoreToolsPackageName];
+            //this scaffolder has a non-EF scenario, only add EF packages if DataContext is provided.
+            List<string> packageList = [];
             if (context.Properties.TryGetValue(nameof(MinimalApiSettings), out var commandSettingsObj) &&
                 commandSettingsObj is MinimalApiSettings commandSettings)
             {
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
-                if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&
+                if (!string.IsNullOrEmpty(commandSettings.DataContext) &&
+                    !string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&
                     PackageConstants.EfConstants.EfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out string? projectPackageName))
                 {
+                    packageList.Add(PackageConstants.EfConstants.EfCoreToolsPackageName);
                     packageList.Add(projectPackageName);
                 }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
@@ -84,7 +84,7 @@ internal static class RazorPagesScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<string> packageList = [];
+            List<string> packageList = [PackageConstants.EfConstants.EfCoreToolsPackageName];
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&
                 commandSettingsObj is CrudSettings commandSettings)
             {


### PR DESCRIPTION
`Microsoft.EntityFrameworkCore.Tools` package was not being added as part of the EF scaffolders. We need to to perform ef migrations and update the database.
- added to all EF scaffolders