### PR TITLE
fix telemetry flow

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/DotnetCliRunner.cs
@@ -11,7 +11,7 @@ internal class DotnetCliRunner
 {
     public static DotnetCliRunner CreateDotNet(string commandName, IEnumerable<string> args, IDictionary<string, string>? environmentVariables = null)
     {
-        return Create("dotnet", new[] { commandName }.Concat(args));
+        return Create("dotnet", new[] { commandName }.Concat(args), environmentVariables);
     }
 
     public static DotnetCliRunner Create(string commandName, IEnumerable<string> args, IDictionary<string, string>? environmentVariables = null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/StartupFlowStep.cs
@@ -58,10 +58,11 @@ internal class StartupFlowStep : IFlowStep
             .Start("Initializing dotnet-scaffold", statusContext =>
             {
                 statusContext.Refresh();
-                SelectTelemetryEnvironmentVariables(context, InitializeFirstTimeTelemetry());
+                var envVars = InitializeFirstTimeTelemetry();
+                SelectTelemetryEnvironmentVariables(context, envVars);
                 //initialize 1st party components (dotnet tools)
                 statusContext.Status = "Getting ready";
-                new FirstPartyComponentInitializer(_logger, _dotnetToolService).Initialize();
+                new FirstPartyComponentInitializer(_logger, _dotnetToolService).Initialize(envVars);
                 statusContext.Status = "Done\n";
                 //parse args passed
                 statusContext.Status = "Parsing args.";

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -73,7 +73,7 @@ internal class DotNetToolService : IDotNetToolService
     {
         if (components is null || components.Count == 0)
         {
-            components = GetDotNetTools(refresh: true);
+            components = GetDotNetTools(refresh: true, envVars);
         }
 
         //if any local tools are present, we need to restore them first
@@ -81,7 +81,7 @@ internal class DotNetToolService : IDotNetToolService
         var anyLocalTools = components.FirstOrDefault(x => !x.IsGlobalTool) is not null;
         if (anyLocalTools)
         {
-            var runner = DotnetCliRunner.CreateDotNet("tool", ["restore"]);
+            var runner = DotnetCliRunner.CreateDotNet("tool", ["restore"], envVars);
             runner.ExecuteAndCaptureOutput(out _, out _);
         }
 
@@ -172,14 +172,14 @@ internal class DotNetToolService : IDotNetToolService
         return exitCode == 0;
     }
 
-    public IList<DotNetToolInfo> GetDotNetTools(bool refresh = false)
+    public IList<DotNetToolInfo> GetDotNetTools(bool refresh = false, IDictionary<string, string> ? envVars = null)
     {
         if (refresh || _dotNetTools.Count == 0)
         {
             //only want unique tools, we will try to invoke local tools over global tools
             var dotnetToolList = new List<DotNetToolInfo>();
-            var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"]);
-            var localRunner = DotnetCliRunner.CreateDotNet("tool", ["list"]);
+            var runner = DotnetCliRunner.CreateDotNet("tool", ["list", "-g"], envVars);
+            var localRunner = DotnetCliRunner.CreateDotNet("tool", ["list"], envVars);
             var exitCode = runner.ExecuteAndCaptureOutput(out var stdOut, out _);
             var localExitCode = localRunner.ExecuteAndCaptureOutput(out var localStdOut, out var localStdErr);
             //parse through local dotnet tools first. 

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/FirstPartyComponentInitializer.cs
@@ -15,10 +15,10 @@ internal class FirstPartyComponentInitializer
         _dotnetToolService = dotnetToolService;
     }
 
-    public void Initialize()
+    public void Initialize(IDictionary<string, string> envVars)
     {
         List<string> toolsToInstall = [];
-        var installedTools = _dotnetToolService.GetDotNetTools(refresh: true);
+        var installedTools = _dotnetToolService.GetDotNetTools(refresh: true, envVars);
         foreach (var tool in _firstPartyTools)
         {
             if (installedTools.FirstOrDefault(x => x.PackageName.Equals(tool, System.StringComparison.OrdinalIgnoreCase)) is null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IDotNetToolService.cs
@@ -8,7 +8,7 @@ internal interface IDotNetToolService
 {
     IList<KeyValuePair<string, CommandInfo>> GetAllCommandsParallel(IList<DotNetToolInfo>? components = null, IDictionary<string, string>? envVars = null);
     DotNetToolInfo? GetDotNetTool(string? componentName, string? version = null);
-    IList<DotNetToolInfo> GetDotNetTools(bool refresh = false);
+    IList<DotNetToolInfo> GetDotNetTools(bool refresh = false, IDictionary<string, string>? envVars = null);
     bool InstallDotNetTool(string toolName, string? version = null, bool global = false, bool prerelease = false, string[]? addSources = null, string? configFile = null);
     bool UninstallDotNetTool(string toolName, bool global = false);
     List<CommandInfo> GetCommands(DotNetToolInfo dotnetTool, IDictionary<string, string>? envVars = null);


### PR DESCRIPTION
issue started with first time `dotnet-scaffold` use not detecting any categories, delved deeper and found a bunch of issues.
1. `dotnet-scaffold-aspnet` and `dotnet-scaffold-aspire` first time sentinel files were being created even when invoked through dotnet-scaffold.
2. led to environment variable `TelemetryConstants.DOTNET_SCAFFOLD_TELEMETRY_STATE` not being passed correctly. Passing it in all dotnet invocations now.
3. this subsequently fixed the issue at the top, since first time sentinel text was being presented instead of the appropriate `get-commands` result