### PR TITLE
when displaying categories, change "All" to "(Show All)"

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Builder/ScaffoldBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 
@@ -8,7 +9,7 @@ namespace Microsoft.DotNet.Scaffolding.Core.Builder;
 
 internal class ScaffoldBuilder(string name) : IScaffoldBuilder
 {
-    private const string DEFAULT_CATEGORY = "All";
+    private const string DEFAULT_CATEGORY = ScaffolderConstants.DEFAULT_CATEGORY;
 
     private readonly List<ScaffolderOption> _options = [];
     private readonly List<ScaffoldStepPreparer> _stepPreparers = [];

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/ScaffolderConstants.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/ScaffolderConstants.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.DotNet.Scaffolding.Core.ComponentModel;
+
+internal static class ScaffolderConstants
+{
+    internal const string DEFAULT_CATEGORY = "All";
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Flow/Steps/CategoryDiscovery.cs
@@ -52,12 +52,28 @@ internal class CategoryDiscovery
             ?.Order()
             ?.ToList();
 
+        //removes 'All' and adds it back at the end
+        displayCategories?.Remove(ScaffolderConstants.DEFAULT_CATEGORY);
+        displayCategories?.Add(ScaffolderConstants.DEFAULT_CATEGORY);
+
         var prompt = new FlowSelectionPrompt<string>()
             .Title("[lightseagreen]Pick a scaffolding category: [/]")
+            .Converter(GetCategoryDisplayName)
             .AddChoices(displayCategories, navigation: context.Navigation);
 
         var result = prompt.Show();
         State = result.State;
         return result.Value;
+    }
+
+    //change 'All' to '(Show All)' only for display, value recorded from the prompt is still 'All'
+    private string GetCategoryDisplayName(string categoryName)
+    {
+        if (categoryName.Equals(ScaffolderConstants.DEFAULT_CATEGORY, StringComparison.OrdinalIgnoreCase))
+        {
+            return "(Show All)";
+        }
+
+        return categoryName;
     }
 }


### PR DESCRIPTION
use `GetCategoryDisplayName` to change "All" category name to "(Show All)"
- use List<string>.Remove and List<string>.Add to remove at the start of the list and then insert again at the end of the list.