### PR TITLE
fix output paths for a bunch of scaffolders

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/Constants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/Constants.cs
@@ -38,4 +38,15 @@ internal class Constants
         public const string UserClassName = "ApplicationUser";
         public const string DbContextName = "NewIdentityDbContext";
     }
+
+    public class DotnetCommands
+    {
+        public const string RazorPageCommandName = "page";
+        public const string RazorPageCommandOutput = "Pages";
+        public const string RazorComponentCommandName = "razorcomponent";
+        public const string RazorComponentCommandOutput = "Components";
+        public const string ViewCommandName = "view";
+        public const string ViewCommandOutput = "Views";
+        public const string ControllerCommandOutput = "Controllers";
+    }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
@@ -6,6 +6,10 @@ internal class PackageConstants
 {
     public static class EfConstants
     {
+        public const string SqlServerDisplayName = "SQL Server (EntityFramework Core)";
+        public const string SqliteDisplayName = "SQL Server (EntityFramework Core)";
+        public const string CosmosDbDisplayName = "Cosmos DB (EntityFramework Core)";
+        public const string PostgresDisplayName = "Postgres (EntityFramework Core)";
         public const string SqlServer = "sqlserver-efcore";
         public const string SQLite = "sqlite-efcore";
         public const string CosmosDb = "cosmos-efcore";

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/PackageConstants.cs
@@ -6,10 +6,6 @@ internal class PackageConstants
 {
     public static class EfConstants
     {
-        public const string SqlServerDisplayName = "SQL Server (EntityFramework Core)";
-        public const string SqliteDisplayName = "SQL Server (EntityFramework Core)";
-        public const string CosmosDbDisplayName = "Cosmos DB (EntityFramework Core)";
-        public const string PostgresDisplayName = "Postgres (EntityFramework Core)";
         public const string SqlServer = "sqlserver-efcore";
         public const string SQLite = "sqlite-efcore";
         public const string CosmosDb = "cosmos-efcore";

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Program.cs
@@ -39,7 +39,7 @@ public static class Program
                 var context = config.Context;
                 step.ProjectPath = context.GetOptionResult(projectOption);
                 step.FileName = context.GetOptionResult(fileNameOption);
-                step.CommandName = "razorcomponent";
+                step.CommandName = Constants.DotnetCommands.RazorComponentCommandName;
             });
 
         builder.AddScaffolder("razorview-empty")
@@ -54,7 +54,7 @@ public static class Program
                 var context = config.Context;
                 step.ProjectPath = context.GetOptionResult(projectOption);
                 step.FileName = context.GetOptionResult(fileNameOption);
-                step.CommandName = "view";
+                step.CommandName = Constants.DotnetCommands.ViewCommandName;
             });
 
         builder.AddScaffolder("razorpage-empty")
@@ -70,7 +70,7 @@ public static class Program
                 step.ProjectPath = context.GetOptionResult(projectOption);
                 step.NamespaceName = Path.GetFileNameWithoutExtension(step.ProjectPath);
                 step.FileName = context.GetOptionResult(fileNameOption);
-                step.CommandName = "page";
+                step.CommandName = Constants.DotnetCommands.RazorPageCommandName;
             });
 
         builder.AddScaffolder("apicontroller")

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.Internal.CliHelpers;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
 using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -54,13 +55,21 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
 
     private bool InvokeDotnetNew(DotnetNewStepSettings stepSettings)
     {
-        var projectBasePath = Path.GetDirectoryName(stepSettings.Project);
-        //using the project name from the csproj path as namespace currently.
-        //to evaluate the correct namespace is a lot of overhead for a simple 'dotnet new' operation
-        //TODO maybe change this?
+        var outputDirectory = Path.GetDirectoryName(stepSettings.Project);
+        //invoking a command with a specific output folder, if not, use the default output folder (project root)
+        if (!string.IsNullOrEmpty(outputDirectory) &&
+            OutputFolders.TryGetValue(stepSettings.CommandName, out var folderName))
+        {
+            outputDirectory = Path.Combine(outputDirectory, folderName);
+            if (!_fileSystem.DirectoryExists(outputDirectory))
+            {
+                _fileSystem.CreateDirectory(outputDirectory);
+            }
+        }
+
         var projectName = Path.GetFileNameWithoutExtension(stepSettings.Project);
-        if (Directory.Exists(projectBasePath) &&
-            !string.IsNullOrEmpty(projectBasePath))
+        if (_fileSystem.DirectoryExists(outputDirectory) &&
+            !string.IsNullOrEmpty(outputDirectory))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()
@@ -69,7 +78,7 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
                 "--name",
                 stepSettings.Name,
                 "--output",
-                projectBasePath
+                outputDirectory
             };
 
             if (!string.IsNullOrEmpty(stepSettings.NamespaceName))
@@ -113,4 +122,11 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
             CommandName = CommandName
         };
     }
+
+    private readonly static Dictionary<string, string> OutputFolders = new()
+    {
+        { Constants.DotnetCommands.RazorPageCommandName, Constants.DotnetCommands.RazorPageCommandOutput },
+        { Constants.DotnetCommands.RazorComponentCommandName, Constants.DotnetCommands.RazorComponentCommandOutput },
+        { Constants.DotnetCommands.ViewCommandName, Constants.DotnetCommands.ViewCommandOutput }
+    };
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/DotnetNewScaffolderStep.cs
@@ -68,8 +68,8 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
         }
 
         var projectName = Path.GetFileNameWithoutExtension(stepSettings.Project);
-        if (_fileSystem.DirectoryExists(outputDirectory) &&
-            !string.IsNullOrEmpty(outputDirectory))
+        if (!string.IsNullOrEmpty(outputDirectory) &&
+            _fileSystem.DirectoryExists(outputDirectory))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
@@ -56,10 +56,26 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
 
     private bool InvokeDotnetNew(EmptyControllerStepSettings settings)
     {
-        var projectBasePath = Path.GetDirectoryName(settings.Project);
+        var outputDirectory = Path.GetDirectoryName(settings.Project);
+        if (!string.IsNullOrEmpty(outputDirectory))
+        {
+            outputDirectory = Path.Combine(outputDirectory, "Controllers");
+            if (!_fileSystem.DirectoryExists(outputDirectory))
+            {
+                _fileSystem.CreateDirectory(outputDirectory);
+            }
+        }
+        else
+        {
+            _logger.LogError("Failed to determine output path.");
+            return false;
+        }    
+
         var projectName = Path.GetFileNameWithoutExtension(settings.Project);
         var actionsParameter = settings.Actions ? "--actions" : string.Empty;
-        if (Directory.Exists(projectBasePath) && !string.IsNullOrEmpty(projectName))
+        if (!string.IsNullOrEmpty(outputDirectory) &&
+            _fileSystem.DirectoryExists(outputDirectory) &&
+            !string.IsNullOrEmpty(projectName))
         {
             //arguments for 'dotnet new {settings.CommandName}'
             var args = new List<string>()
@@ -68,7 +84,7 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
                 "--name",
                 settings.Name,
                 "--output",
-                projectBasePath,
+                outputDirectory,
                 "--namespace",
                 projectName,
             };

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateEfControllerStep.cs
@@ -60,7 +60,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
         if (efControllerModel is null)
         {
             _logger.LogError("An error occurred.");
-            _telemetryService.TrackEvent(new ValidateScaffolderTelemetryEvent(nameof(ValidateIdentityStep), context.Scaffolder.DisplayName, result: false));
+            _telemetryService.TrackEvent(new ValidateScaffolderTelemetryEvent(nameof(ValidateEfControllerStep), context.Scaffolder.DisplayName, result: false));
             return false;
         }
         else
@@ -209,7 +209,7 @@ internal class ValidateEfControllerStep : ScaffoldStep
             ProjectInfo = projectInfo,
             ModelInfo = modelInfo,
             DbContextInfo = dbContextInfo,
-            ControllerOutputPath = projectDirectory
+            ControllerOutputPath = Path.Combine(projectDirectory, AspNetConstants.DotnetCommands.ControllerCommandOutput)
         };
 
         if (scaffoldingModel.ProjectInfo is not null && scaffoldingModel.ProjectInfo.CodeService is not null)


### PR DESCRIPTION
Currently, there is no consistency between scaffolders and where the templates are outputted. Right now: 
- API Controller ---> project-root
- API Controller with actions, using EF  ---> project-root
- Minimal API (Endpoints file) --> project-root
- MVC Controller --> project-root
- MVC Controller with views, using EF --> project-root and project-root\Views
- Razor Component --> project-root
- Razor Component with EF --> project-root\Components
- Razor Page (Empty) --> project-root
- Razor Page using EF --> project-root\Pages
- Razor View (Empty)--> project-root
- Razor Views --> project-root\Views

with this PR:
- **API Controller ---> project-root\Controllers**
- **API Controller with actions, using EF  ---> project-root\Controllers**
- Minimal API (Endpoints file) --> project-root
- **MVC Controller --> project-root\Controllers**
- **MVC Controller with views, using EF --> project-root\Controllers** and project-root\Views
- **Razor Component --> project-root\Components**
- Razor Component with EF --> project-root\Components
- **Razor Page (Empty) --> project-root\Pages**
- Razor Page using EF --> project-root\Pages
- **Razor View (Empty)--> project-root\Views**
- Razor Views --> project-root\Views

Leaving `minimalapi` as is currently. Planning to add a way for users to add output paths soon. these will be default fallbacks then
