### PR TITLE
added MSBuildProjectService

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -129,6 +129,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Scaffoldin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Scaffolding.Roslyn", "src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.Roslyn\Microsoft.DotNet.Scaffolding.Roslyn.csproj", "{2180D82F-38EE-4FD6-927F-03BEE22B789E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet-scaffolding", "dotnet-scaffolding", "{0E27E3F4-C93F-4DF1-8F4D-1E62A6641C75}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Scaffolding.Roslyn.Tests", "test\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.Roslyn.Tests\Microsoft.DotNet.Scaffolding.Roslyn.Tests.csproj", "{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		debug_x86|Any CPU = debug_x86|Any CPU
@@ -826,6 +830,24 @@ Global
 		{2180D82F-38EE-4FD6-927F-03BEE22B789E}.Release|x64.Build.0 = Release|Any CPU
 		{2180D82F-38EE-4FD6-927F-03BEE22B789E}.Release|x86.ActiveCfg = Release|Any CPU
 		{2180D82F-38EE-4FD6-927F-03BEE22B789E}.Release|x86.Build.0 = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|x64.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|x64.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|x86.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.debug_x86|x86.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Debug|x86.Build.0 = Debug|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|x64.Build.0 = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|x86.ActiveCfg = Release|Any CPU
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -877,6 +899,8 @@ Global
 		{A3AAB1D5-5338-476A-8236-1849A326DE3C} = {73FF6F8B-3D15-41F1-9358-A497DAE4AD8B}
 		{45EA1F2F-E3A0-46A1-B337-C3A11675B931} = {73FF6F8B-3D15-41F1-9358-A497DAE4AD8B}
 		{2180D82F-38EE-4FD6-927F-03BEE22B789E} = {73FF6F8B-3D15-41F1-9358-A497DAE4AD8B}
+		{0E27E3F4-C93F-4DF1-8F4D-1E62A6641C75} = {81B64EBF-613D-43AE-82DA-B375FB751921}
+		{83AFCAC3-4AED-49A4-A7C1-61EC051562E4} = {0E27E3F4-C93F-4DF1-8F4D-1E62A6641C75}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {26BCDDB3-5505-4903-9D87-C942ED0D03E6}

--- a/scripts/install-scaffold-all.cmd
+++ b/scripts/install-scaffold-all.cmd
@@ -4,9 +4,7 @@ set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/
 call taskkill /f /im dotnet.exe
 call rd /Q /S artifacts
-call dotnet pack src\dotnet-scaffolding\dotnet-scaffold\dotnet-scaffold.csproj -c Debug
-call dotnet pack src\dotnet-scaffolding\dotnet-scaffold-aspire\dotnet-scaffold-aspire.csproj -c Debug
-call dotnet pack src\dotnet-scaffolding\dotnet-scaffold-aspnet\dotnet-scaffold-aspnet.csproj -c Debug
+call build.cmd
 call dotnet tool uninstall -g Microsoft.dotnet-scaffold
 call dotnet tool uninstall -g Microsoft.dotnet-scaffold-aspire
 call dotnet tool uninstall -g Microsoft.dotnet-scaffold-aspnet

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Helpers/MSBuildProjectServiceHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Helpers/MSBuildProjectServiceHelper.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using Microsoft.Build.Evaluation;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.Scaffolding.Roslyn.Helpers;
 
 internal static class MSBuildProjectServiceHelper
 {
-    // Method to parse version from a TFM string
+    /// <summary>
+    /// Method to parse version from a TFM string.
+    /// Given a short tfm like "net5.0" or "netstandard2.0", it will return a Version object with just major and minor.
+    /// eg, 5.0 or 2.0
+    /// </summary>
     internal static Version ParseFrameworkVersion(string tfm)
     {
         // Remove "net" or "netstandard" prefix to parse the version
@@ -19,6 +22,9 @@ internal static class MSBuildProjectServiceHelper
         return Version.TryParse(versionPart, out var version) ? version : new Version(0, 0);
     }
 
+    /// <summary>
+    /// Get the lowest target framework version from the project.
+    /// </summary>
     internal static string? GetLowestTargetFramework(Build.Evaluation.Project project)
     {
         if (project is null)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Helpers/MSBuildProjectServiceHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Helpers/MSBuildProjectServiceHelper.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.Build.Evaluation;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.Scaffolding.Roslyn.Helpers;
+
+internal static class MSBuildProjectServiceHelper
+{
+    // Method to parse version from a TFM string
+    internal static Version ParseFrameworkVersion(string tfm)
+    {
+        // Remove "net" or "netstandard" prefix to parse the version
+        string versionPart = tfm.StartsWith("netstandard") ?
+            tfm.Replace("netstandard", "") :
+            tfm.Replace("net", "");
+
+        // Parse to Version; assume "0.0" for invalid formats
+        return Version.TryParse(versionPart, out var version) ? version : new Version(0, 0);
+    }
+
+    internal static string? GetLowestTargetFramework(Build.Evaluation.Project project)
+    {
+        if (project is null)
+        {
+            return null;
+        }
+
+        // Check for TargetFramework (single TFM) and TargetFrameworks (multiple TFMs)
+        var targetFramework = project.GetProperty("TargetFramework")?.EvaluatedValue;
+        var targetFrameworks = project.GetProperty("TargetFrameworks")?.EvaluatedValue;
+        if (!string.IsNullOrEmpty(targetFramework))
+        {
+            // Single TFM
+            return targetFramework;
+        }
+        else if (!string.IsNullOrEmpty(targetFrameworks))
+        {
+            // Multiple TFMs: Split and find the lowest version
+            var frameworks = targetFrameworks
+                .Split(';')
+                .Where(x => x.StartsWith("net") || x.StartsWith("netstandard")) // Filter out non-TFM values
+                .OrderBy(ParseFrameworkVersion) // Sort by version to get the lowest
+                .ToList();
+
+            // Return the lowest version TFM as a short string
+            return frameworks.FirstOrDefault();
+        }
+
+        // No TFM found
+        return null;
+    }
+
+    internal static IEnumerable<string> GetProjectCapabilities(Build.Evaluation.Project project)
+    {
+        if (project is not null)
+        {
+            return project.GetItems("ProjectCapability").Select(i => i.EvaluatedInclude);
+        }
+
+        return [];
+    }
+
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Properties/AssemblyInfo.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Runtime.CompilerServices;
+//test
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Scaffolding.Roslyn.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/IMSBuildProjectService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/IMSBuildProjectService.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.DotNet.Scaffolding.Roslyn.Services;
+
+/* NOTE
+ * to use MSBuildProjectService, we need to initialize the MsBuildInitializer
+ * that is because MSBuildLocator.Register fails if Microsoft.Build assemblies are already pulled in
+ * using MSBuildProjectService does that unfortunately so this initialization cannot happen in this service
+*/
+internal interface IMSBuildProjectService
+{
+    string? GetLowestTargetFramework(bool refresh = false);
+    IEnumerable<string> GetProjectCapabilities(bool refresh = false);
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MSBuildProjectService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MSBuildProjectService.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Scaffolding.Roslyn.Helpers;
+
+namespace Microsoft.DotNet.Scaffolding.Roslyn.Services;
+
+public class MSBuildProjectService : IMSBuildProjectService
+{
+    private readonly string _projectPath;
+    private Build.Evaluation.Project? _project;
+    private bool _initialized;
+    private readonly object _initLock = new();
+    public MSBuildProjectService(string projectPath)
+    {
+        _projectPath = projectPath;
+    }
+
+    public string? GetLowestTargetFramework(bool refresh = false)
+    {
+        EnsureInitialized(refresh);
+        if (_project is not null)
+        {
+            return MSBuildProjectServiceHelper.GetLowestTargetFramework(_project);
+        }
+
+        return null;
+    }
+
+    public IEnumerable<string> GetProjectCapabilities(bool refresh = false)
+    {
+        EnsureInitialized();
+        if (_project is not null)
+        {
+            return MSBuildProjectServiceHelper.GetProjectCapabilities(_project);
+        }
+
+        return [];
+    }
+
+    private void Initialize(bool refresh = false)
+    {
+        lock (_initLock)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            if (_project is not null && !refresh)
+            {
+                return;
+            }
+
+            //try loading MSBuild project the faster way.
+            _project = new Project(_projectPath, null, null, new Build.Evaluation.ProjectCollection(), ProjectLoadSettings.IgnoreMissingImports);
+            //if fails, use the longer way using GLobalProjectCollection.
+            if (_project is null)
+            {
+                _project = ProjectCollection.GlobalProjectCollection.LoadProject(_projectPath);
+            }
+        }
+    }
+
+    private void EnsureInitialized(bool refresh = false)
+    {
+        if (!_initialized)
+        {
+            Initialize(refresh);
+        }
+
+        _initialized = true;
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ProjectInfo.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ProjectInfo.cs
@@ -10,4 +10,7 @@ internal class ProjectInfo
     public string? ProjectPath { get; set; }
     public CodeService? CodeService { get; set; }
     public IList<string>? CodeChangeOptions { get; set; }
+    //if multiple are found, use the lowest one
+    public string? LowestTargetFramework { get; set; }
+    public IList<string>? Capabilities { get; set; }
 }

--- a/test/dotnet-scaffolding/Directory.Packages.props
+++ b/test/dotnet-scaffolding/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+    <Import Project="$(RepoRoot)src\dotnet-scaffolding\Directory.Packages.props" />
+    <ItemGroup>
+        <PackageVersion Include="Moq" Version="$(MoqPackageVersion)" />
+        <PackageVersion Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
+        <PackageVersion Include="xunit.skippablefact" Version="$(XunitSkippableFactPackageVersion)" />
+    </ItemGroup>
+</Project>

--- a/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/MSBuildProjectServiceHelperTests.cs
+++ b/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/MSBuildProjectServiceHelperTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using Microsoft.Build.Evaluation;
+using System.IO;
+using System.Xml;
+using Microsoft.Build.Locator;
+using Microsoft.DotNet.Scaffolding.Roslyn.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Scaffolding.Roslyn.Tests;
+
+public class MSBuildProjectServiceHelperTests
+{
+    public MSBuildProjectServiceHelperTests()
+    {
+        // Register the MSBuild assemblies
+        if (!MSBuildLocator.IsRegistered)
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+    }
+
+    [Theory]
+    [InlineData("net5.0", "5.0")]
+    [InlineData("net6.0", "6.0")]
+    [InlineData("netstandard2.0", "2.0")]
+    [InlineData("netstandard2.1", "2.1")]
+    [InlineData("invalid", "0.0")]
+    [InlineData("bleh", "0.0")]
+    [InlineData("", "0.0")]
+    public void ParseFrameworkVersionTests(string shortTfm, string expectedVersion)
+    {
+        // Act
+        var result = MSBuildProjectServiceHelper.ParseFrameworkVersion(shortTfm);
+        // Assert
+        Assert.Equal(new Version(expectedVersion), result);
+    }
+
+    [Fact]
+    public void GetProjectCapabilitiesTest()
+    {
+        // Arrange
+        var csprojContent = @"
+                <Project Sdk=""Microsoft.NET.Sdk"">
+                    <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <ProjectCapability Include=""CapabilityA"" />
+                        <ProjectCapability Include=""CapabilityB"" />
+                    </ItemGroup>
+                </Project>";
+
+        using var reader = XmlReader.Create(new StringReader(csprojContent));
+        var testProject = new Project(reader, null, null, new ProjectCollection(), ProjectLoadSettings.IgnoreMissingImports);
+        // Act
+        var capabilities = MSBuildProjectServiceHelper.GetProjectCapabilities(testProject);
+
+        // Assert
+        Assert.Contains("CapabilityA", capabilities);
+        Assert.Contains("CapabilityB", capabilities);
+    }
+
+    [Fact]
+    public void GetLowestTargetFrameworkTest()
+    {
+        // Arrange
+        var csprojContent = @"
+                <Project Sdk=""Microsoft.NET.Sdk"">
+                    <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                    </PropertyGroup>
+                </Project>";
+
+        using var reader = XmlReader.Create(new StringReader(csprojContent));
+        var testProject = new Project(reader, null, null, new ProjectCollection(), ProjectLoadSettings.IgnoreMissingImports);
+        // Act
+        var lowestTfm = MSBuildProjectServiceHelper.GetLowestTargetFramework(testProject);
+        //Assert
+        Assert.Equal("net9.0", lowestTfm);
+    }
+}

--- a/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/Microsoft.DotNet.Scaffolding.Roslyn.Tests.csproj
+++ b/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/Microsoft.DotNet.Scaffolding.Roslyn.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(StandardTestTfms)</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.Roslyn\Microsoft.DotNet.Scaffolding.Roslyn.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Roslyn (CodeAnalysis) projects do not contain any information about MSBuild properties such as project capabilities, project tfm(s), root namespaces and so forth.

added MSBuildProjectService to help getting such properties
- using `new Microsoft.Build.Project()` to initialize MSBuild project, fallback is to use  `ProjectCollection.GlobalProjectCollection.LoadProject`
- bulk of the logic is in `MSBuildProjectServiceHelper`, helps with unit testing a lot since MSBuild testing is quite annoying.
- made `MsBuildInitializer` public for access, also iterating through possible sdk paths (for registration) if the first option is not found on disk.
- initializing new found info in `ProjectInfo`