### PR TITLE
Update transitive dependencies

### DIFF
--- a/src/dotnet-scaffolding/Directory.Packages.props
+++ b/src/dotnet-scaffolding/Directory.Packages.props
@@ -30,4 +30,10 @@
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="$(SystemCommandLinePackageVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Pins for Component Governance Alerts -->
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Updating a few transitive dependencies to fix some alerts. The 9.0 versions of these packages still ship net8.0 binaries so we should be ok to update to them.