### PR TITLE
fix AccountLayout, also MSBuildProjectService for blazor projects.

### DIFF
--- a/eng/Versions.DotNetScaffold.props
+++ b/eng/Versions.DotNetScaffold.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-<VersionPrefix>9.0.0</VersionPrefix>
+<VersionPrefix>9.0.1</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>10</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>

--- a/scripts/install-scaffold-all.cmd
+++ b/scripts/install-scaffold-all.cmd
@@ -1,4 +1,4 @@
-set VERSION=10.0.0-dev
+set VERSION=9.0.1-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MSBuildProjectService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn/Services/MSBuildProjectService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Scaffolding.Roslyn.Services;
 public class MSBuildProjectService : IMSBuildProjectService
 {
     private readonly string _projectPath;
-    private Build.Evaluation.Project? _project;
+    private Project? _project;
     private bool _initialized;
     private readonly object _initLock = new();
     public MSBuildProjectService(string projectPath)
@@ -53,13 +53,12 @@ public class MSBuildProjectService : IMSBuildProjectService
                 return;
             }
 
-            //try loading MSBuild project the faster way.
-            _project = new Project(_projectPath, null, null, new Build.Evaluation.ProjectCollection(), ProjectLoadSettings.IgnoreMissingImports);
-            //if fails, use the longer way using GLobalProjectCollection.
-            if (_project is null)
+            try
             {
-                _project = ProjectCollection.GlobalProjectCollection.LoadProject(_projectPath);
+                //try loading MSBuild project the faster way.
+                _project = new Project(_projectPath, null, null, new ProjectCollection(), ProjectLoadSettings.IgnoreMissingImports);
             }
+            catch (Exception) { }
         }
     }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateIdentityStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/ScaffoldSteps/ValidateIdentityStep.cs
@@ -162,10 +162,12 @@ internal class ValidateIdentityStep : ScaffoldStep
 
         string identityNamespace = string.Empty;
         string userClassNamespace = string.Empty;
+        string identityLayoutNamespace = string.Empty;
         var projectName = Path.GetFileNameWithoutExtension(settings.Project);
         if (!string.IsNullOrEmpty(projectName))
         {
             identityNamespace = settings.BlazorScenario ? $"{projectName}.Components.Account" : $"{projectName}.Areas.Identity";
+            identityLayoutNamespace = settings.BlazorScenario ? $"{projectName}.Components.Layout.MainLayout" : string.Empty;
             userClassNamespace = $"{projectName}.Data";
         }
 
@@ -176,6 +178,7 @@ internal class ValidateIdentityStep : ScaffoldStep
             IdentityNamespace = identityNamespace,
             UserClassName = AspNetConstants.Identity.UserClassName,
             UserClassNamespace = userClassNamespace,
+            IdentityLayoutNamespace = identityLayoutNamespace,
             BaseOutputPath = projectDirectory,
             Overwrite = settings.Overwrite
         };

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorIdentity/Shared/AccountLayout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorIdentity/Shared/AccountLayout.cs
@@ -122,8 +122,8 @@ if ((ModelValueAcquired == false))
         }
         else
         {
-            this.Error("The type \'Microsoft.DotNet.Tools.Scaffold.AspNet.Models.BlazorIdentityModel\' of t" +
-                    "he parameter \'Model\' did not match the type of the data passed to the template.");
+            this.Error("The type \'Microsoft.DotNet.Tools.Scaffold.AspNet.Models.IdentityModel\' of the par" +
+                    "ameter \'Model\' did not match the type of the data passed to the template.");
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorIdentity/Shared/AccountLayout.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/BlazorIdentity/Shared/AccountLayout.tt
@@ -6,9 +6,9 @@
 @using <#= Model.UserClassNamespace #>
 @inherits LayoutComponentBase
 <#
-if (!string.IsNullOrEmpty(Model.BlazorLayoutNamespace))
+if (!string.IsNullOrEmpty(Model.IdentityLayoutNamespace))
 {
-#>@layout <#= Model.BlazorLayoutNamespace #>
+#>@layout <#= Model.IdentityLayoutNamespace #>
 <#} #>
 @inject NavigationManager NavigationManager
 


### PR DESCRIPTION
AccountLayout had an incorrect `@layout` reference. Fixing that reference.
- adding a try catch to MSBuildProjectService.Initialize. Loading MSBuild projects fails for blazor projects with no real solution afaik so will dig into this later.  The MSBuildProjectService is nullable friendly so no issues.
- fixed `@layout` reference to `IdentityModel.IdentityLayoutNamespace` and initializing this property correctly.
- updated version from 9.0.0 to 9.0.1.