### PR TITLE
fix StringUtil.ToPath and some null checks

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/ProjectExtensions.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/ProjectExtensions.cs
@@ -59,10 +59,13 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
 
                 var allFiles = Directory.EnumerateFiles(projectDirectory, extension, SearchOption.AllDirectories);
                 string filePath = allFiles.FirstOrDefault(x => x.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
-                string fileText = fileSystem.ReadAllText(filePath);
-                if (!string.IsNullOrEmpty(fileText))
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    return project.AddDocument(filePath, fileText);
+                    string fileText = fileSystem.ReadAllText(filePath);
+                    if (!string.IsNullOrEmpty(fileText))
+                    {
+                        return project.AddDocument(filePath, fileText);
+                    }
                 }
             }
 

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared
                 }
 
                 // Remove redundant project root namespace folder from basePath if present
-                if (basePath.EndsWith(Path.Combine(projectRootNamespace, "") + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                if (basePath.EndsWith(Path.Combine(projectRootNamespace, string.Empty) + Path.DirectorySeparatorChar, StringComparison.Ordinal))
                 {
                     basePath = basePath.Substring(0, basePath.Length - projectRootNamespace.Length - 1);
                 }

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/General/StringUtil.cs
@@ -40,23 +40,49 @@ namespace Microsoft.DotNet.Scaffolding.Shared
         //converts Project.Namespace.SubNamespace to Project//Namespace//SubNamespace or Project\\Namespace\\SubNamespace (based on OS)
         public static string ToPath(string namespaceName, string basePath, string projectRootNamespace)
         {
-            string path = string.Empty;
-            if (!string.IsNullOrEmpty(basePath) && !string.IsNullOrEmpty(namespaceName))
+            if (string.IsNullOrEmpty(namespaceName) || string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(projectRootNamespace))
             {
-                namespaceName = RemovePrefix(namespaceName, basePath, projectRootNamespace);
-                namespaceName = namespaceName.Replace(".", Path.DirectorySeparatorChar.ToString());
-                try
-                {
-                    basePath = Path.HasExtension(basePath) ? Path.GetDirectoryName(basePath) : basePath;
-                    var combinedPath = Path.Combine(basePath, namespaceName);
-                    path = Path.GetFullPath(combinedPath);
-                }
-                //invalid path
-                catch (Exception ex) when (ex is ArgumentException || ex is PathTooLongException || ex is NotSupportedException)
-                {}
+                return string.Empty;
             }
 
-            return path;
+            try
+            {
+                // Normalize the base path if it is a file
+                if (Path.HasExtension(basePath))
+                {
+                    basePath = Path.GetDirectoryName(basePath);
+                }
+
+                // Ensure basePath ends with a directory separator
+                if (!basePath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                {
+                    basePath += Path.DirectorySeparatorChar;
+                }
+
+                // Remove redundant project root namespace folder from basePath if present
+                if (basePath.EndsWith(Path.Combine(projectRootNamespace, "") + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                {
+                    basePath = basePath.Substring(0, basePath.Length - projectRootNamespace.Length - 1);
+                }
+
+                // Remove the project root namespace prefix from the namespaceName
+                if (namespaceName.StartsWith(projectRootNamespace + ".", StringComparison.Ordinal))
+                {
+                    namespaceName = namespaceName.Substring(projectRootNamespace.Length + 1);
+                }
+
+                // Convert namespaceName into a directory path
+                string relativePath = namespaceName.Replace('.', Path.DirectorySeparatorChar);
+                // Combine the base path with the relative path
+                string combinedPath = Path.Combine(basePath, projectRootNamespace, relativePath);
+                // Get the full path
+                return Path.GetFullPath(combinedPath);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is PathTooLongException || ex is NotSupportedException)
+            {
+                // Handle invalid path scenarios
+                return string.Empty;
+            }
         }
 
         //remove prefix from namespace, used to remove the project name from namespace when creating the path

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DotNet.Scaffolding.Internal;
 internal static class StringUtil
 {
     //converts Project.Namespace.SubNamespace to Project//Namespace//SubNamespace or Project\\Namespace\\SubNamespace (based on OS)
+    //TODO : add string helpers for all the different little checks below.
     public static string? ToPath(string namespaceName, string? basePath, string projectRootNamespace)
     {
         if (string.IsNullOrEmpty(namespaceName) || string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(projectRootNamespace))

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
@@ -27,7 +27,7 @@ internal static class StringUtil
             }
 
             // Remove redundant project root namespace folder from basePath if present
-            if (!string.IsNullOrEmpty(basePath) && basePath.EndsWith(Path.Combine(projectRootNamespace, "") + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(basePath) && basePath.EndsWith(Path.Combine(projectRootNamespace, string.Empty) + Path.DirectorySeparatorChar, StringComparison.Ordinal))
             {
                 basePath = basePath.Substring(0, basePath.Length - projectRootNamespace.Length - 1);
             }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/StringUtil.cs
@@ -5,27 +5,56 @@ namespace Microsoft.DotNet.Scaffolding.Internal;
 internal static class StringUtil
 {
     //converts Project.Namespace.SubNamespace to Project//Namespace//SubNamespace or Project\\Namespace\\SubNamespace (based on OS)
-    public static string ToPath(string namespaceName, string basePath, string projectRootNamespace)
+    public static string? ToPath(string namespaceName, string? basePath, string projectRootNamespace)
     {
-        string path = string.Empty;
-        if (string.IsNullOrEmpty(namespaceName) || string.IsNullOrEmpty(basePath))
+        if (string.IsNullOrEmpty(namespaceName) || string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(projectRootNamespace))
         {
             return string.Empty;
         }
 
-        namespaceName = RemovePrefix(namespaceName, basePath, projectRootNamespace);
-        namespaceName = namespaceName.Replace(".", Path.DirectorySeparatorChar.ToString());
         try
         {
-            basePath = Path.HasExtension(basePath) ? Path.GetDirectoryName(basePath) ?? basePath : basePath;
-            var combinedPath = Path.Combine(basePath, namespaceName);
-            path = Path.GetFullPath(combinedPath);
-        }
-        //invalid path
-        catch (Exception ex) when (ex is ArgumentException || ex is PathTooLongException || ex is NotSupportedException)
-        { }
+            // Normalize the base path if it is a file
+            if (Path.HasExtension(basePath))
+            {
+                basePath = Path.GetDirectoryName(basePath);
+            }
 
-        return path;
+            // Ensure basePath ends with a directory separator
+            if (!string.IsNullOrEmpty(basePath) && !basePath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                basePath += Path.DirectorySeparatorChar;
+            }
+
+            // Remove redundant project root namespace folder from basePath if present
+            if (!string.IsNullOrEmpty(basePath) && basePath.EndsWith(Path.Combine(projectRootNamespace, "") + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            {
+                basePath = basePath.Substring(0, basePath.Length - projectRootNamespace.Length - 1);
+            }
+
+            // Remove the project root namespace prefix from the namespaceName
+            if (namespaceName.StartsWith(projectRootNamespace + ".", StringComparison.Ordinal))
+            {
+                namespaceName = namespaceName.Substring(projectRootNamespace.Length + 1);
+            }
+
+            // Convert namespaceName into a directory path
+            string relativePath = namespaceName.Replace('.', Path.DirectorySeparatorChar);
+            // Combine the base path with the relative path
+            if (string.IsNullOrEmpty(basePath))
+            {
+                return string.Empty;
+            }
+
+            string combinedPath = Path.Combine(basePath, projectRootNamespace, relativePath);
+            // Get the full path
+            return Path.GetFullPath(combinedPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException || ex is PathTooLongException || ex is NotSupportedException)
+        {
+            // Handle invalid path scenarios
+            return string.Empty;
+        }
     }
 
     //normalize the path separators between mac/linux and windows. 

--- a/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.Shared.Tests/StringUtilTests.cs
@@ -76,19 +76,20 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Tests
         {
             get
             {
-                return new[]
-                {
+                return
+                [
                     new object[] { "Project.Namespace.SubNamespace", "C:\\Some\\Path\\Project.csproj", "Project", "C:\\Some\\Path\\Project\\Namespace\\SubNamespace" },
+                    new object[] { "Project.Web.Namespace.SubNamespace", "C:\\Some\\Path\\Project.Web.csproj", "Project.Web", "C:\\Some\\Path\\Project.Web\\Namespace\\SubNamespace" },
                     new object[] { "Project.Namespace.SubNamespace", "C:\\Some\\Path\\", "Project", "C:\\Some\\Path\\Project\\Namespace\\SubNamespace" },
                     //special case : default namespace of a project in VS solution folder
                     new object[] { "Project.Components.Account", "C:\\SomePath\\Project\\Project\\", "Project", "C:\\SomePath\\Project\\Project\\Components\\Account" },
                     //special case : default namespace of a project in just a project folder
                     new object[] { "Project.Components.Account", "C:\\SomePath\\Project\\", "Project", "C:\\SomePath\\Project\\Components\\Account" },
                     new object[] { "Project.Namespace.SubNamespace", "", "Project", "" },
-                    new object[] { "Project", "C:\\Some\\Path\\Project.csproj", "Project", "C:\\Some\\Path\\Project" },
+                    new object[] { "Project", "C:\\Some\\Path\\Project.csproj", "Project", "C:\\Some\\Path\\Project\\Project" },
                     new object[] { "Project", "", "Project", "" },
                     new object[] { "", "C:\\Some\\Path\\Project.csproj", "Project", "" },
-                };
+                ];
             }
         }
 


### PR DESCRIPTION
Blazor Identity and CRUD scenario was broken in projects where project names had '.' characters in them. Due to faulty StringUtil.ToPath method
- fixed the method to account for such project names (both dotnet-aspnet-codegenerator and new dotnet-scaffold)
- added a test case, fixed one as well
- added a missing null check in ProjectExtensions.GetDocumentFromName