### PR TITLE
fix primary key and DbSet detection for dotnet-scaffold-aspnet

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,14 +1,14 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.24573.1",
+    "version": "9.0.100",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.24573.1"
+    "dotnet": "9.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24616.1",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24515.3",
     "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.23607.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,14 +1,14 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100-alpha.1.24573.1",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
   "tools": {
-    "dotnet": "9.0.100"
+    "dotnet": "10.0.100-alpha.1.24573.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24515.3",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24616.1",
     "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.23607.2"
   }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/EfDbContextHelpers.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/EfDbContextHelpers.cs
@@ -13,8 +13,19 @@ public static class EfDbContextHelpers
     {
         if (modelSymbol is INamedTypeSymbol namedTypeSymbol)
         {
-            var allModelProperties = namedTypeSymbol.GetMembers().OfType<IPropertySymbol>();
-            var primaryKey = namedTypeSymbol?.GetMembers().OfType<IPropertySymbol>().FirstOrDefault(IsPrimaryKey);
+            List<IPropertySymbol> propertySymbols = new List<IPropertySymbol>();
+            var currentType = namedTypeSymbol;
+            while (currentType is not null && currentType.SpecialType is not SpecialType.System_Object)
+            {
+                foreach (var propertySymbol in currentType.GetMembers().OfType<IPropertySymbol>())
+                {
+                    propertySymbols.Add(propertySymbol);
+                }
+
+                currentType = currentType.BaseType; // Traverse to the base type
+            }
+
+            var primaryKey = propertySymbols.FirstOrDefault(IsPrimaryKey);
             if (primaryKey != null)
             {
                 EfModelProperties efModelProperties = new()
@@ -24,7 +35,7 @@ public static class EfDbContextHelpers
                     //unwanted values for base types ('Int32' instead of 'int')
                     PrimaryKeyShortTypeName = primaryKey.Type.ToDisplayString(),
                     PrimaryKeyTypeName = primaryKey.Type.ToDisplayString(),
-                    AllModelProperties = allModelProperties.ToList()
+                    AllModelProperties = propertySymbols
                 };
 
                 return efModelProperties;
@@ -61,15 +72,17 @@ public static class EfDbContextHelpers
     /// check for the specific DbSet variable in a given DbContext's ISymbol.
     /// return the DbSet property's name.
     /// </summary>
-    public static string? GetEntitySetVariableName(ISymbol dbContextSymbol, string modelTypeName)
+    public static string? GetEntitySetVariableName(ISymbol dbContextSymbol, string modelTypeName, string modelTypeFullName)
     {
         if (dbContextSymbol is INamedTypeSymbol dbContextTypeSymbol)
         {
             string dbSetType = $"Microsoft.EntityFrameworkCore.DbSet<{modelTypeName}>";
+            string dbSetWithFullType = $"Microsoft.EntityFrameworkCore.DbSet<{modelTypeFullName}>";
             //get the DbSet pertaining our given modelSymbol
             var dbSetProperty = dbContextTypeSymbol.GetMembers().OfType<IPropertySymbol>().FirstOrDefault(p =>
                 p.Type is INamedTypeSymbol &&
-                p.Type.ToDisplayString().Equals(dbSetType));
+                (p.Type.ToDisplayString().Equals(dbSetType) ||
+                p.Type.ToDisplayString().Equals(dbSetWithFullType)));
 
             if (dbSetProperty != null)
             {

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/EfDbContextHelpers.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/EfDbContextHelpers.cs
@@ -72,12 +72,13 @@ public static class EfDbContextHelpers
     /// check for the specific DbSet variable in a given DbContext's ISymbol.
     /// return the DbSet property's name.
     /// </summary>
-    public static string? GetEntitySetVariableName(ISymbol dbContextSymbol, string modelTypeName, string modelTypeFullName)
+    public static string? GetEntitySetVariableName(ISymbol dbContextSymbol, string modelTypeName, string? modelTypeFullName)
     {
         if (dbContextSymbol is INamedTypeSymbol dbContextTypeSymbol)
         {
             string dbSetType = $"Microsoft.EntityFrameworkCore.DbSet<{modelTypeName}>";
-            string dbSetWithFullType = $"Microsoft.EntityFrameworkCore.DbSet<{modelTypeFullName}>";
+            string dbSetWithFullType = string.IsNullOrEmpty(modelTypeFullName) ?
+                string.Empty : $"Microsoft.EntityFrameworkCore.DbSet<{modelTypeFullName}>";
             //get the DbSet pertaining our given modelSymbol
             var dbSetProperty = dbContextTypeSymbol.GetMembers().OfType<IPropertySymbol>().FirstOrDefault(p =>
                 p.Type is INamedTypeSymbol &&

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ClassAnalyzers.cs
@@ -26,7 +26,7 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextClassPath = existingDbContextClass.Locations.FirstOrDefault()?.SourceTree?.FilePath;
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
             dbContextInfo.EntitySetVariableName = modelInfo is null ?
-                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName);
+                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName ?? modelInfo.ModelTypeName);
         }
         //properties for creating a new DbContext
         else

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Common/ClassAnalyzers.cs
@@ -26,7 +26,7 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextClassPath = existingDbContextClass.Locations.FirstOrDefault()?.SourceTree?.FilePath;
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
             dbContextInfo.EntitySetVariableName = modelInfo is null ?
-                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName ?? modelInfo.ModelTypeName);
+                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName);
         }
         //properties for creating a new DbContext
         else

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/EfController/MvcEfController.cs
@@ -103,8 +103,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.EfController
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create([Bind(""ID,Title,ReleaseDate,Genre,Price"")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(" movie)\r\n    {\r\n        if (ModelState.IsValid)\r\n        {\r\n            _context." +
-                    "Add(");
+            this.Write(" ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
+            this.Write(")\r\n    {\r\n        if (ModelState.IsValid)\r\n        {\r\n            _context.Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
             this.Write(");\r\n            await _context.SaveChangesAsync();\r\n            return RedirectTo" +
                     "Action(nameof(Index));\r\n        }\r\n        return View(");
@@ -141,7 +142,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.EfController
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
             this.Write(", [Bind(\"ID,Title,ReleaseDate,Genre,Price\")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(" movie)\r\n    {\r\n        if (");
+            this.Write(" ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
+            this.Write(")\r\n    {\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
             this.Write(" != ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold-aspnet/Templates/EfController/MvcEfController.tt
@@ -76,7 +76,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("ID,Title,ReleaseDate,Genre,Price")] <#= modelName #> movie)
+    public async Task<IActionResult> Create([Bind("ID,Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (ModelState.IsValid)
         {
@@ -108,7 +108,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("ID,Title,ReleaseDate,Genre,Price")] <#= modelName #> movie)
+    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("ID,Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (<#= primaryKeyNameLowerInv #> != <#= modelNameLowerInv #>.<#= primaryKeyName #>)
         {


### PR DESCRIPTION
found in a couple issues using the `MVC Controller w/ Views using EF` scaffolder : 
1. When using an existing DbContext, the correct DbSet name was not used in the resulting controller
2. All model properties were not being detected (properties from a given model's base class, and its base class and so forth)
3. `MvcEfController.tt` had some minor issues ('movie' name being hardcoded instead of the given model's lower invariant name)

fixes : 
- checking for DbSet name using the full model name (includes namespace)
- using `INamedTypeSymbol.BaseType` (in a loop until BaseType is the default object/null) and adding all properties to a list.
- minor fixes in `MvcEfController.tt`