### PR TITLE
change EFCore.Design dependency to include assets

### DIFF
--- a/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
+++ b/src/Scaffolding/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
@@ -21,7 +21,11 @@
        without adding EntityFrameworkCore dependency.
        https://github.com/dotnet/scaffolding/issues/434
        -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="All" />
+    <!-- Would ideally have this private but this dependency is failing to load on runtime 
+         starting with VS 17.3 Preview 3. This is a placeholder fix. 
+         Extra deps are pulled into the project but only for 2 scenarios, area and view.
+         The rest of them pull in EF dependencies regardless. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Starting with 9.0.200 (preview right now, will be in VS 17.13 Preview 3+) there is an issue loading transitive dependencies in-proc
- Microsoft.VisualStudio.Web.CodeGeneration.Design --> Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore --> Microsoft.EntityFrameworkCore.Design
- This dependency was set to `PrivateAssets="All"` since it gets loaded by the project when needed (through the scaffolding VS experience)
- However, loading dependencies (assemblies being loaded in proc) has changed in 9.0.200 
  -  the `Microsoft.EntityFrameworkCore.Design/Tools` package install with `<PrivateAssets>all</PrivateAssets>`
       and `<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>`
  - Something has changed in the new sdk where the dependencies are not loading, even with the `runtime` tag. 
  - this is a regression
- this hotfix loads these dependencies as part of the original `Microsoft.VisualStudio.Web.CodeGeneration.Design`
- not ideal but this is older scaffolding code that will be phased out soon.