### PR TITLE
Resolve Bootstrap 5 Input Group Rendering Issue with ASP Tag Helper __Invariant Field - Fixes #3170

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/wwwroot/css/site.css
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/wwwroot/css/site.css
@@ -81,3 +81,13 @@ body {
   white-space: nowrap;
   line-height: 60px;
 }
+
+/* Bootstrap 5 input group reset to work with ASP Tag Helpers inserting hidden input[name="__Invariant"] elements, for certain field types, starting in .NET 7 */
+.input-group:not(.has-validation) > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating) {
+    border-top-right-radius: var(--bs-border-radius);
+    border-bottom-right-radius: var(--bs-border-radius);
+}
+.input-group:not(.has-validation) > :not(:last-child):not(:has(+ input[type="hidden"]:last-child)):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating) {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}


### PR DESCRIPTION
- Add CSS to VS.Web.CG.Mvc's Bootstrap 5 site.css template, to reset Bootstrap 5 input group styling, to work with hidden __Invariant field that is added by ASP tag helper for certain field types.

Fixes #3170



