### PR TITLE
Just use simple projects in MSBuildProjectServiceHelperTests

### DIFF
--- a/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/MSBuildProjectServiceHelperTests.cs
+++ b/test/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Roslyn.Tests/MSBuildProjectServiceHelperTests.cs
@@ -42,7 +42,7 @@ public class MSBuildProjectServiceHelperTests
     {
         // Arrange
         var csprojContent = @"
-                <Project Sdk=""Microsoft.NET.Sdk"">
+                <Project>
                     <PropertyGroup>
                         <TargetFramework>net9.0</TargetFramework>
                     </PropertyGroup>
@@ -67,7 +67,7 @@ public class MSBuildProjectServiceHelperTests
     {
         // Arrange
         var csprojContent = @"
-                <Project Sdk=""Microsoft.NET.Sdk"">
+                <Project>
                     <PropertyGroup>
                         <TargetFramework>net9.0</TargetFramework>
                     </PropertyGroup>


### PR DESCRIPTION
- we should just use simple projects without SDK reference in order to make tests more reliable.
- this avoids having a dependency on the SDK for tests which do not need anything from the SDK

We are making this change due to the tests failing from breaking SDK changes which would impact the virtual project here. If we wanted a complete end to end, we could use the SDK locator to properly load the SDK, or inject the imports with the complete paths into the csprojectContent
