### PR TITLE
Bump Nuget package version to 10.0.0

### DIFF
--- a/scripts/install-scaffold-all.cmd
+++ b/scripts/install-scaffold-all.cmd
@@ -1,4 +1,4 @@
-set VERSION=9.0.1-dev
+set VERSION=10.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/


### PR DESCRIPTION
Bump the package version to ensure that the `install-scaffold-all.cmd` script runs correctly

this is the package version for `microsoft.dotnet-scaffold-aspire` and `microsoft.dotnet-scaffold-aspnet` and `microsoft.dotnet-scaffold`

