### PR TITLE
Bump NuGet package versions in install scripts

### DIFF
--- a/scripts/install-scaffold-aspire.cmd
+++ b/scripts/install-scaffold-aspire.cmd
@@ -1,4 +1,4 @@
-set VERSION=9.0.0-dev
+set VERSION=10.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-scaffold-aspnet.cmd
+++ b/scripts/install-scaffold-aspnet.cmd
@@ -1,4 +1,4 @@
-set VERSION=9.0.0-dev
+set VERSION=10.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-scaffold.cmd
+++ b/scripts/install-scaffold.cmd
@@ -1,4 +1,4 @@
-set VERSION=9.0.0-dev
+set VERSION=10.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/


### PR DESCRIPTION
Bump the package version to be 10.0.0dev from 9.0.0dev in the installation scripts. This affects `Microsoft.dotnet-scaffold-aspnet`, `Microsoft.dotnet-scaffold-aspire`, and `Microsoft.dotnet-scaffold` packages. 

