### PR TITLE
Change the application name from "dotnet-scaffold" to "dotnet scaffold"

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AppBuilder/ScaffoldCommandAppBuilder.cs
@@ -30,7 +30,7 @@ internal class ScaffoldCommandAppBuilder(string[] args)
         commandApp.Configure(config =>
         {
             config
-                .SetApplicationName("dotnet-scaffold")
+                .SetApplicationName("dotnet scaffold")
                 .SetApplicationVersion(ToolHelper.GetToolVersion() ?? _backupDotNetScaffoldVersion)
                 .AddBranch<ToolSettings>("tool", tool =>
                 {


### PR DESCRIPTION
This Application name is used in the `--help` and it was misrepresenting the usage of the command there. the tool is not invoked with `dotnet-scaffold` , but with `dotnet scaffold` this corrects that error:

before:
<img width="647" height="452" alt="image" src="https://github.com/user-attachments/assets/6a23ad84-6fd9-4554-b2ae-a33b4204a0b7" />

after:
<img width="705" height="432" alt="image" src="https://github.com/user-attachments/assets/322fd3c9-83cc-4eb0-817b-195f688232a3" />


