### PR TITLE
add component help description

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/Command/ScaffoldCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Command/ScaffoldCommand.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
 using Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
 using Microsoft.DotNet.Tools.Scaffold.Services;
@@ -58,6 +59,7 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
         /// <summary>
         /// Gets or sets the component name to scaffold.
         /// </summary>
+        [Description("dotnet-scaffold-aspnet or dotnet-scaffold-aspire")]
         [CommandArgument(0, "[COMPONENT]")]
         public string? ComponentName { get; set; }
 


### PR DESCRIPTION
Part of the work to make the tool's `--help` more robust

Before:
<img width="893" height="295" alt="image" src="https://github.com/user-attachments/assets/993fcf4e-0c36-4e40-86d9-817856d95668" />

after:
<img width="898" height="287" alt="image" src="https://github.com/user-attachments/assets/81284f99-3797-474d-98e3-77900ae4ac61" />



