### PR TITLE
invoke "dotnet-scaffold aspire" for aspire commands

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/CommandInfoExtensions.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/ComponentModel/CommandInfoExtensions.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Scaffolding.Core.ComponentModel;
+
+internal static class CommandInfoExtensions
+{
+    public static bool IsCommandAnAspireCommand(this CommandInfo commandInfo)
+    {
+        return commandInfo.DisplayCategories.Any(category => string.Equals(category, "Aspire", StringComparison.Ordinal));
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -301,7 +301,6 @@ internal class DotNetToolService : IDotNetToolService
     private static bool IsValidDotNetTool(DotNetToolInfo dotnetToolInfo)
     {
         return
-            !dotnetToolInfo.Command.Equals("dotnet-scaffold", StringComparison.OrdinalIgnoreCase) &&
             !dotnetToolInfo.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
After merging the `aspire` scaffolders into `dotnet-scaffold` the `aspire` scaffolders were not appearing in the interactive mode. The way that the interactive scaffolder command is through running `get-commands` for identified scaffolding tools, but it was ignoring `dotnet-scaffold` explicitly.  Now, `aspire` commands can be run in addition to the `aspnet` commands.

Note: this is a temporary fix. I am going to rework the command identification of our own commands through `get-commands`. I want to do this after I merge `aspnet` into the `dotnet-scaffold`. 


