### PR TITLE
Avoid invalid framework fallback for latest-version packages

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
@@ -68,7 +68,9 @@ internal class AddPackagesStep : ScaffoldStep
                 // with the project's target framework (e.g. installing a net10.0-only package into a net9.0
                 // project) and produced flaky NU1202 failures in CI. The trailing '-*' keeps the fallback
                 // prerelease-aware so preview target frameworks are still satisfied.
-                if (string.IsNullOrEmpty(packageVersion) && targetFramework.TryGetMajorVersion(out int majorVersion))
+                if (string.IsNullOrEmpty(packageVersion) &&
+                    !resolvedPackage.UseLatestVersion &&
+                    targetFramework.TryGetMajorVersion(out int majorVersion))
                 {
                     packageVersion = $"{majorVersion}.*-*";
                     _logger.LogInformation(


### PR DESCRIPTION
## Summary

- prevent packages marked `UseLatestVersion` from receiving a target-framework-major fallback when NuGet metadata resolution returns no version
- allow packages with independent versioning, such as `SQLitePCLRaw.bundle_e_sqlite3`, to use the latest compatible stable version
- address recurring CI failures where net9 tests attempted to restore the nonexistent `SQLitePCLRaw.bundle_e_sqlite3` version `9.*-*`

## Validation

- built `dotnet-scaffold.Tests` targeting net11.0
- ran all 14 package-resolution tests successfully on net11.0
- ran the full 3,425-test suite locally; remaining integration failures occur before scaffolding because the machine has .NET 11 preview 5 while the repository requires preview 6