### PR TITLE
Fix Blazor Identity output path for renamed project folders

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -132,7 +132,7 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
                 var projectDirectory = Path.GetDirectoryName(commandSettings.Project);
                 if (Directory.Exists(projectDirectory))
                 {
-                    step.BaseOutputDirectory = Path.Combine(projectDirectory, "Components", "Account", "Shared");
+                    step.BaseOutputDirectory = Path.Combine(BlazorIdentityHelper.GetIdentityComponentsPath(projectDirectory), "Shared");
                     step.FileName = "PasskeySubmit.razor.js";
                     return;
                 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorIdentityHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorIdentityHelper.cs
@@ -44,8 +44,8 @@ internal static class BlazorIdentityHelper
                 // Files in Pages and Shared folders are Razor components, others are C# files
                 string extension = templateFullName.StartsWith("Pages", StringComparison.OrdinalIgnoreCase) ||
                                    templateFullName.StartsWith("Shared", StringComparison.OrdinalIgnoreCase) ? ".razor" : ".cs";
-                string templateNameWithNamespace = $"{blazorIdentityModel.IdentityNamespace}.{templateFullName}";
-                string outputFileName = $"{StringUtil.ToPath(templateNameWithNamespace, blazorIdentityModel.BaseOutputPath, projectName)}{extension}";
+                string relativeTemplatePath = templateFullName.Replace('.', Path.DirectorySeparatorChar);
+                string outputFileName = $"{Path.Combine(GetIdentityComponentsPath(blazorIdentityModel.BaseOutputPath), relativeTemplatePath)}{extension}";
                 textTemplatingProperties.Add(new()
                 {
                     TemplateModel = blazorIdentityModel,
@@ -59,6 +59,9 @@ internal static class BlazorIdentityHelper
 
         return textTemplatingProperties;
     }
+
+    internal static string GetIdentityComponentsPath(string projectDirectory)
+        => Path.Combine(projectDirectory, "Components", "Account");
 
     /// <summary>
     /// Retrieves the formatted relative identity file path from the full file name.

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityIntegrationTestsBase.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityIntegrationTestsBase.cs
@@ -43,7 +43,7 @@ public abstract class BlazorIdentityIntegrationTestsBase : IDisposable
     protected BlazorIdentityIntegrationTestsBase()
     {
         _testDirectory = Path.Combine(Path.GetTempPath(), TestClassName, Guid.NewGuid().ToString());
-        _testProjectDir = Path.Combine(_testDirectory, "TestProject");
+        _testProjectDir = Path.Combine(_testDirectory, "RenamedProjectDirectory");
         _testProjectPath = Path.Combine(_testProjectDir, "TestProject.csproj");
         _toolsDirectory = Path.Combine(_testDirectory, "tools");
         _templatesDirectory = Path.Combine(_testDirectory, "Templates");

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityNet10IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityNet10IntegrationTests.cs
@@ -47,6 +47,7 @@ public class BlazorIdentityNet10IntegrationTests : BlazorIdentityIntegrationTest
         var sharedDir = Path.Combine(_testProjectDir, "Components", "Account", "Shared");
         Assert.True(Directory.Exists(sharedDir), "Components/Account/Shared directory should be created.");
         Assert.True(File.Exists(Path.Combine(sharedDir, "ManageNavMenu.razor")), "ManageNavMenu.razor should be created.");
+        Assert.True(File.Exists(Path.Combine(sharedDir, "PasskeySubmit.razor.js")), "PasskeySubmit.razor.js should be created.");
         var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
         Assert.Contains("TestDbContext", programContent);
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityNet11IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/BlazorIdentityNet11IntegrationTests.cs
@@ -56,6 +56,7 @@ public class BlazorIdentityNet11IntegrationTests : BlazorIdentityIntegrationTest
         var sharedDir = Path.Combine(_testProjectDir, "Components", "Account", "Shared");
         Assert.True(Directory.Exists(sharedDir), "Components/Account/Shared directory should be created.");
         Assert.True(File.Exists(Path.Combine(sharedDir, "ManageNavMenu.razor")), "ManageNavMenu.razor should be created.");
+        Assert.True(File.Exists(Path.Combine(sharedDir, "PasskeySubmit.razor.js")), "PasskeySubmit.razor.js should be created.");
         var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
         Assert.Contains("TestDbContext", programContent);
 


### PR DESCRIPTION
Fixes #3716.

Blazor Identity generated component paths through namespace-to-path conversion, which assumes the project directory name matches the project file name. The separately copied `PasskeySubmit.razor.js` already used an explicit `Components/Account/Shared` path, causing the script and its Razor component to be split when a project was copied or renamed.

Centralize the Blazor Identity component root in `BlazorIdentityHelper.GetIdentityComponentsPath` and use it for both generated Identity files and the passkey JavaScript. The shared `StringUtil.ToPath` contract and other scaffolders remain unchanged.

The existing Blazor Identity integration fixture now deliberately uses a directory name that differs from `TestProject.csproj`, so its existing file-placement and post-scaffolding build assertions cover the regression across target frameworks. The .NET 10 and .NET 11 tests also verify that `PasskeySubmit.razor.js` is emitted in the same `Components/Account/Shared` directory as its Razor component.

Validation:
- `dotnet-scaffold` net10.0 build: passed with 0 warnings and 0 errors
- Blazor Identity helper and builder-extension tests: passed
- .NET 10 Blazor Identity renamed-directory integration test: passed
- Full `BlazorWebAppMovies` end-to-end workflow from `BlazorWebAppMoviesAuthorization`: 40 Razor components generated under `Components/Account`, passkey component and script colocated, no extra project-name folder, post-scaffold build succeeded, `/` and `/Account/Login` returned HTTP 200, and the fingerprinted passkey module returned HTTP 200 in Development