### PR TITLE
Fix cross-platform deadlock in ProjectDescriptionReader tests

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
@@ -185,18 +185,13 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                                 string replaceFrom = element.ValueKind == JsonValueKind.Number
                                     ? element.GetInt32().ToString(CultureInfo.InvariantCulture)
                                     : element.ToString()!;
-                                string settingValue = propertyMapping.Represents == "Application.CalledApiScopes"
-                                    && element.ValueKind == JsonValueKind.Array
-                                        ? string.Join(" ", element.EnumerateArray().Select(scope => scope.GetString()))
-                                        : replaceFrom;
 
                                 UpdatePropertyRepresents(
                                     projectAuthenticationSettings,
                                     filePath,
                                     propertyMapping,
                                     index,
-                                    replaceFrom,
-                                    settingValue);
+                                    replaceFrom);
                             }
                         }
 
@@ -243,14 +238,13 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             string filePath,
             PropertyMapping propertyMapping,
             int index,
-            string replaceFrom,
-            string? settingValue = null)
+            string replaceFrom)
         {
             if (!string.IsNullOrEmpty(propertyMapping.Represents))
             {
                 ReadCodeSetting(
                     propertyMapping.Represents,
-                    settingValue ?? replaceFrom,
+                    replaceFrom,
                     propertyMapping.Default,
                     projectAuthenticationSettings);
                 int length = replaceFrom.Length;

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeReader.cs
@@ -185,13 +185,18 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
                                 string replaceFrom = element.ValueKind == JsonValueKind.Number
                                     ? element.GetInt32().ToString(CultureInfo.InvariantCulture)
                                     : element.ToString()!;
+                                string settingValue = propertyMapping.Represents == "Application.CalledApiScopes"
+                                    && element.ValueKind == JsonValueKind.Array
+                                        ? string.Join(" ", element.EnumerateArray().Select(scope => scope.GetString()))
+                                        : replaceFrom;
 
                                 UpdatePropertyRepresents(
                                     projectAuthenticationSettings,
                                     filePath,
                                     propertyMapping,
                                     index,
-                                    replaceFrom);
+                                    replaceFrom,
+                                    settingValue);
                             }
                         }
 
@@ -238,13 +243,14 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
             string filePath,
             PropertyMapping propertyMapping,
             int index,
-            string replaceFrom)
+            string replaceFrom,
+            string? settingValue = null)
         {
             if (!string.IsNullOrEmpty(propertyMapping.Represents))
             {
                 ReadCodeSetting(
                     propertyMapping.Represents,
-                    replaceFrom,
+                    settingValue ?? replaceFrom,
                     propertyMapping.Default,
                     projectAuthenticationSettings);
                 int length = replaceFrom.Length;

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_web.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_web.json
@@ -110,6 +110,23 @@
       ]
     },
     {
+      "FileRelativePath": "Program.cs",
+        "Properties": [
+            {
+                "MatchAny": [ ".AddMicrosoftIdentityWebApp", ".AddMicrosoftIdentityWebApi" ],
+                "Sets": "HasAuthentication"
+            },
+            {
+                "MatchAny": [ ".AddMicrosoftGraph", ".AddMicrosoftGraphBeta" ],
+                "Sets": "CallsMicrosoftGraph"
+            },
+            {
+                "MatchAny": [ ".EnableTokenAcquisitionToCallDownstreamApi", ".AddDownstreamApi" ],
+                "Sets": "CallsDownstreamApi"
+            }
+      ]
+    },
+    {
       "FileRelativePath": "Properties\\launchSettings.json",
       "Properties": [
         {

--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_web.json
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/ProjectDescriptions/dotnet_web.json
@@ -110,23 +110,6 @@
       ]
     },
     {
-      "FileRelativePath": "Program.cs",
-        "Properties": [
-            {
-                "MatchAny": [ ".AddMicrosoftIdentityWebApp", ".AddMicrosoftIdentityWebApi" ],
-                "Sets": "HasAuthentication"
-            },
-            {
-                "MatchAny": [ ".AddMicrosoftGraph", ".AddMicrosoftGraphBeta" ],
-                "Sets": "CallsMicrosoftGraph"
-            },
-            {
-                "MatchAny": [ ".EnableTokenAcquisitionToCallDownstreamApi", ".AddDownstreamApi" ],
-                "Sets": "CallsDownstreamApi"
-            }
-      ]
-    },
-    {
       "FileRelativePath": "Properties\\launchSettings.json",
       "Properties": [
         {

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
@@ -23,21 +23,26 @@ namespace Tests
 
         readonly CodeReader _codeReader = new CodeReader();
 
-        [InlineData(@"mvc\mvc-b2c", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp-mvc", true)]
-        [InlineData(@"mvc\mvc-b2c-callswebapi", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp-mvc", true)]
-        [InlineData(@"mvc\mvc-singleorg", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp-mvc")]
-        [InlineData(@"mvc\mvc-singleorg-callsgraph", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp-mvc")]
-        [InlineData(@"mvc\mvc-singleorg-callswebapi", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp-mvc")]
-        [InlineData(@"webapi\webapi-b2c", "dotnet new webapi --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-minimal_api", true)]
-        [InlineData(@"webapi\webapi-singleorg", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-minimal_api")]
-        [InlineData(@"webapi\webapi-singleorg-callsgraph", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-minimal_api")]
-        [InlineData(@"webapi\webapi-singleorg-callswebapi", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-minimal_api")]
+        [InlineData(@"blazorserver\blazorserver-b2c", "dotnet new blazorserver --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
+        [InlineData(@"blazorserver\blazorserver-b2c-callswebapi", "dotnet new blazorserver --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
+        [InlineData(@"blazorserver\blazorserver-singleorg", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
+        [InlineData(@"blazorserver\blazorserver-singleorg-callsgraph", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
+        [InlineData(@"blazorserver\blazorserver-singleorg-callswebapi", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
+        [InlineData(@"mvc\mvc-b2c", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
+        [InlineData(@"mvc\mvc-b2c-callswebapi", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
+        [InlineData(@"mvc\mvc-singleorg", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
+        [InlineData(@"mvc\mvc-singleorg-callsgraph", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
+        [InlineData(@"mvc\mvc-singleorg-callswebapi", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
+        [InlineData(@"webapi\webapi-b2c", "dotnet new webapi --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapi", true)]
+        [InlineData(@"webapi\webapi-singleorg", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapi")]
+        [InlineData(@"webapi\webapi-singleorg-callsgraph", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapi")]
+        [InlineData(@"webapi\webapi-singleorg-callswebapi", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapi")]
         [InlineData(@"webapp\webapp-b2c", "dotnet new webapp --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
         [InlineData(@"webapp\webapp-b2c-callswebapi", "dotnet new webapp --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
         [InlineData(@"webapp\webapp-singleorg", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
         [InlineData(@"webapp\webapp-singleorg-callsgraph", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
         [InlineData(@"webapp\webapp-singleorg-callswebapi", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
-        [Theory]
+        [Theory(Skip = "Test gets stuck on macOS and Linux. Tracking https://github.com/dotnet/Scaffolding/issues/1598 for fix.")]
         public void TestProjectDescriptionReader(string folderPath, string command, string expectedProjectType, bool isB2C = false)
         {
             string createdProjectFolder = CreateProjectIfNeeded(folderPath, command, "ProjectDescriptionReaderTests");
@@ -115,6 +120,33 @@ namespace Tests
                 Assert.Equal(TestConstants.DefaultDomain, authenticationSettings.ApplicationParameters.Domain1);
                 Assert.Equal(TestConstants.BlazorWasmAuthority, authenticationSettings.ApplicationParameters.Authority);
             }
+        }
+
+        [InlineData(@"blazorwasm\blazorwasm-b2c-hosted", "dotnet new blazorwasm --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --api-client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --hosted", "dotnet-blazorwasm-hosted")]
+        //[InlineData(@"blazorwasm\blazorwasm-singleorg-callsgraph-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph --hosted", "dotnet-blazorwasm-hosted")]
+        //[InlineData(@"blazorwasm\blazorwasm-singleorg-callswebapi-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\" --hosted", "dotnet-blazorwasm-hosted")]
+        [InlineData(@"blazorwasm\blazorwasm-singleorg-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com  --hosted", "dotnet-blazorwasm-hosted")]
+        [Theory(Skip = "Test gets stuck on macOS and Linux. Tracking https://github.com/dotnet/Scaffolding/issues/1598 for fix.")]
+        public void TestProjectDescriptionReader_TemplatesWithBlazorWasmHosted(string folderPath, string command, string expectedProjectType)
+        {
+            string createdProjectFolder = CreateProjectIfNeeded(folderPath, command, "ProjectDescriptionReaderTests");
+            var files = Directory.EnumerateFiles(createdProjectFolder);
+            var projectDescriptionReader = new ProjectDescriptionReader(files);
+
+            var projectDescription = projectDescriptionReader.GetProjectDescription(string.Empty);
+
+            Assert.NotNull(projectDescription);
+            Assert.Equal(expectedProjectType, projectDescription.Identifier);
+
+            var authenticationSettings = _codeReader.ReadFromFiles(
+                           projectDescription,
+                           projectDescriptionReader.ProjectDescriptions,
+                           files);
+
+            // Blazorwasm now delegates twice (once to the Client [Blazor], and once to the
+            // Server [Web API]
+            Assert.True(authenticationSettings.ApplicationParameters.IsBlazorWasm);
+            Assert.True(authenticationSettings.ApplicationParameters.IsWebApi);
         }
 
         [InlineData(@"blazorserver\blazorserver-noauth", "dotnet new blazorserver", "dotnet-webapp")]

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/ProjectDescriptionReaderTests.cs
@@ -23,26 +23,21 @@ namespace Tests
 
         readonly CodeReader _codeReader = new CodeReader();
 
-        [InlineData(@"blazorserver\blazorserver-b2c", "dotnet new blazorserver --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
-        [InlineData(@"blazorserver\blazorserver-b2c-callswebapi", "dotnet new blazorserver --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
-        [InlineData(@"blazorserver\blazorserver-singleorg", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
-        [InlineData(@"blazorserver\blazorserver-singleorg-callsgraph", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
-        [InlineData(@"blazorserver\blazorserver-singleorg-callswebapi", "dotnet new blazorserver --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
-        [InlineData(@"mvc\mvc-b2c", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
-        [InlineData(@"mvc\mvc-b2c-callswebapi", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
-        [InlineData(@"mvc\mvc-singleorg", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
-        [InlineData(@"mvc\mvc-singleorg-callsgraph", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
-        [InlineData(@"mvc\mvc-singleorg-callswebapi", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
-        [InlineData(@"webapi\webapi-b2c", "dotnet new webapi --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapi", true)]
-        [InlineData(@"webapi\webapi-singleorg", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapi")]
-        [InlineData(@"webapi\webapi-singleorg-callsgraph", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapi")]
-        [InlineData(@"webapi\webapi-singleorg-callswebapi", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapi")]
+        [InlineData(@"mvc\mvc-b2c", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp-mvc", true)]
+        [InlineData(@"mvc\mvc-b2c-callswebapi", "dotnet new mvc --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp-mvc", true)]
+        [InlineData(@"mvc\mvc-singleorg", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp-mvc")]
+        [InlineData(@"mvc\mvc-singleorg-callsgraph", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp-mvc")]
+        [InlineData(@"mvc\mvc-singleorg-callswebapi", "dotnet new mvc --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp-mvc")]
+        [InlineData(@"webapi\webapi-b2c", "dotnet new webapi --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-minimal_api", true)]
+        [InlineData(@"webapi\webapi-singleorg", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-minimal_api")]
+        [InlineData(@"webapi\webapi-singleorg-callsgraph", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-minimal_api")]
+        [InlineData(@"webapi\webapi-singleorg-callswebapi", "dotnet new webapi --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-minimal_api")]
         [InlineData(@"webapp\webapp-b2c", "dotnet new webapp --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com", "dotnet-webapp", true)]
         [InlineData(@"webapp\webapp-b2c-callswebapi", "dotnet new webapp --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --called-api-url \"https://fabrikamb2chello.azurewebsites.net/hello\" --called-api-scopes \"https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read\"", "dotnet-webapp", true)]
         [InlineData(@"webapp\webapp-singleorg", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com", "dotnet-webapp")]
         [InlineData(@"webapp\webapp-singleorg-callsgraph", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph", "dotnet-webapp")]
         [InlineData(@"webapp\webapp-singleorg-callswebapi", "dotnet new webapp --auth SingleOrg --client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\"", "dotnet-webapp")]
-        [Theory(Skip = "Test gets stuck on macOS and Linux. Tracking https://github.com/dotnet/Scaffolding/issues/1598 for fix.")]
+        [Theory]
         public void TestProjectDescriptionReader(string folderPath, string command, string expectedProjectType, bool isB2C = false)
         {
             string createdProjectFolder = CreateProjectIfNeeded(folderPath, command, "ProjectDescriptionReaderTests");
@@ -120,33 +115,6 @@ namespace Tests
                 Assert.Equal(TestConstants.DefaultDomain, authenticationSettings.ApplicationParameters.Domain1);
                 Assert.Equal(TestConstants.BlazorWasmAuthority, authenticationSettings.ApplicationParameters.Authority);
             }
-        }
-
-        [InlineData(@"blazorwasm\blazorwasm-b2c-hosted", "dotnet new blazorwasm --auth IndividualB2C --aad-b2c-instance https://fabrikamb2c.b2clogin.com --api-client-id fdb91ff5-5ce6-41f3-bdbd-8267c817015d --domain fabrikamb2c.onmicrosoft.com --hosted", "dotnet-blazorwasm-hosted")]
-        //[InlineData(@"blazorwasm\blazorwasm-singleorg-callsgraph-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --calls-graph --hosted", "dotnet-blazorwasm-hosted")]
-        //[InlineData(@"blazorwasm\blazorwasm-singleorg-callswebapi-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com --called-api-url \"https://graph.microsoft.com/beta/me\" --called-api-scopes \"user.read\" --hosted", "dotnet-blazorwasm-hosted")]
-        [InlineData(@"blazorwasm\blazorwasm-singleorg-hosted", "dotnet new blazorwasm --auth SingleOrg --api-client-id 86699d80-dd21-476a-bcd1-7c1a3d471f75 --domain msidentitysamplestesting.onmicrosoft.com  --hosted", "dotnet-blazorwasm-hosted")]
-        [Theory(Skip = "Test gets stuck on macOS and Linux. Tracking https://github.com/dotnet/Scaffolding/issues/1598 for fix.")]
-        public void TestProjectDescriptionReader_TemplatesWithBlazorWasmHosted(string folderPath, string command, string expectedProjectType)
-        {
-            string createdProjectFolder = CreateProjectIfNeeded(folderPath, command, "ProjectDescriptionReaderTests");
-            var files = Directory.EnumerateFiles(createdProjectFolder);
-            var projectDescriptionReader = new ProjectDescriptionReader(files);
-
-            var projectDescription = projectDescriptionReader.GetProjectDescription(string.Empty);
-
-            Assert.NotNull(projectDescription);
-            Assert.Equal(expectedProjectType, projectDescription.Identifier);
-
-            var authenticationSettings = _codeReader.ReadFromFiles(
-                           projectDescription,
-                           projectDescriptionReader.ProjectDescriptions,
-                           files);
-
-            // Blazorwasm now delegates twice (once to the Client [Blazor], and once to the
-            // Server [Web API]
-            Assert.True(authenticationSettings.ApplicationParameters.IsBlazorWasm);
-            Assert.True(authenticationSettings.ApplicationParameters.IsWebApi);
         }
 
         [InlineData(@"blazorserver\blazorserver-noauth", "dotnet new blazorserver", "dotnet-webapp")]

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
@@ -11,6 +11,8 @@ namespace Tests
 {
     internal static class TestUtilities
     {
+        private static readonly TimeSpan ProcessTimeout = TimeSpan.FromMinutes(10);
+
         /// <summary>
         /// Create the test project
         /// </summary>
@@ -19,6 +21,11 @@ namespace Tests
         /// <param name="folder">Folder in which to run the command</param>
         /// <param name="postFix">Additionnal command appended to the command</param>
         public static void RunProcess(ITestOutputHelper testOutput, string command, string folder, string postFix = "")
+        {
+            RunProcess(testOutput, command, folder, ProcessTimeout, postFix);
+        }
+
+        internal static void RunProcess(ITestOutputHelper testOutput, string command, string folder, TimeSpan timeout, string postFix = "")
         {
             Directory.CreateDirectory(folder);
             ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", command.Replace("dotnet ", string.Empty) + postFix);
@@ -30,11 +37,27 @@ namespace Tests
             using Process process = Process.Start(processStartInfo);
             var outputTask = process.StandardOutput.ReadToEndAsync();
             var errorTask = process.StandardError.ReadToEndAsync();
-            process.WaitForExit();
+            bool exited = process.WaitForExit((int)timeout.TotalMilliseconds);
+            if (!exited)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException) when (process.HasExited)
+                {
+                }
+
+                process.WaitForExit();
+            }
+
             string output = outputTask.GetAwaiter().GetResult();
             testOutput.WriteLine(output);
             string errors = errorTask.GetAwaiter().GetResult();
             testOutput.WriteLine(errors);
+            Assert.True(
+                exited,
+                $"'{command + postFix}' timed out after {timeout}.{Environment.NewLine}{errors}");
             Assert.True(
                 process.ExitCode == 0,
                 $"'{command + postFix}' exited with code {process.ExitCode}.{Environment.NewLine}{errors}");

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
@@ -27,13 +27,17 @@ namespace Tests
             processStartInfo.RedirectStandardError = true;
             Environment.GetEnvironmentVariables();
             processStartInfo.WorkingDirectory = folder;
-            Process process = Process.Start(processStartInfo);
+            using Process process = Process.Start(processStartInfo);
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
             process.WaitForExit();
-            string output = process.StandardOutput.ReadToEnd();
+            string output = outputTask.GetAwaiter().GetResult();
             testOutput.WriteLine(output);
-            string errors = process.StandardError.ReadToEnd();
+            string errors = errorTask.GetAwaiter().GetResult();
             testOutput.WriteLine(errors);
-            Assert.Equal(string.Empty, errors);
+            Assert.True(
+                process.ExitCode == 0,
+                $"'{command + postFix}' exited with code {process.ExitCode}.{Environment.NewLine}{errors}");
         }
     }
 }

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilities.cs
@@ -27,17 +27,13 @@ namespace Tests
             processStartInfo.RedirectStandardError = true;
             Environment.GetEnvironmentVariables();
             processStartInfo.WorkingDirectory = folder;
-            using Process process = Process.Start(processStartInfo);
-            var outputTask = process.StandardOutput.ReadToEndAsync();
-            var errorTask = process.StandardError.ReadToEndAsync();
+            Process process = Process.Start(processStartInfo);
             process.WaitForExit();
-            string output = outputTask.GetAwaiter().GetResult();
+            string output = process.StandardOutput.ReadToEnd();
             testOutput.WriteLine(output);
-            string errors = errorTask.GetAwaiter().GetResult();
+            string errors = process.StandardError.ReadToEnd();
             testOutput.WriteLine(errors);
-            Assert.True(
-                process.ExitCode == 0,
-                $"'{command + postFix}' exited with code {process.ExitCode}.{Environment.NewLine}{errors}");
+            Assert.Equal(string.Empty, errors);
         }
     }
 }

--- a/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilitiesTests.cs
+++ b/test/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity.Tests/TestUtilitiesTests.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class TestUtilitiesTests
+    {
+        private readonly ITestOutputHelper _testOutput;
+
+        public TestUtilitiesTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
+        [Fact]
+        public void RunProcess_DrainsLargeRedirectedOutput()
+        {
+            string testFolder = Path.Combine(Path.GetTempPath(), nameof(TestUtilitiesTests), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(testFolder);
+
+            try
+            {
+                string messages = string.Concat(Enumerable.Repeat(
+                    "<Message Text=\"This output verifies that redirected process streams are drained concurrently.\" Importance=\"High\" />",
+                    2048));
+                File.WriteAllText(
+                    Path.Combine(testFolder, "LargeOutput.proj"),
+                    $"<Project><Target Name=\"WriteLargeOutput\">{messages}</Target></Project>");
+
+                TestUtilities.RunProcess(
+                    _testOutput,
+                    "dotnet msbuild LargeOutput.proj --target:WriteLargeOutput",
+                    testFolder);
+            }
+            finally
+            {
+                Directory.Delete(testFolder, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void RunProcess_TerminatesProcessAfterTimeout()
+        {
+            string testFolder = Path.Combine(Path.GetTempPath(), nameof(TestUtilitiesTests), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(testFolder);
+
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(testFolder, "Timeout.csproj"),
+                    "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net11.0</TargetFramework></PropertyGroup></Project>");
+                File.WriteAllText(
+                    Path.Combine(testFolder, "Program.cs"),
+                    "using System;\nusing System.IO;\nusing System.Threading;\nFile.WriteAllText(args[0], Environment.ProcessId.ToString());\nThread.Sleep(Timeout.Infinite);");
+
+                TestUtilities.RunProcess(
+                    _testOutput,
+                    "dotnet build Timeout.csproj --nologo",
+                    testFolder);
+
+                Exception exception = Record.Exception(() => TestUtilities.RunProcess(
+                    _testOutput,
+                    "dotnet bin/Debug/net11.0/Timeout.dll process.pid",
+                    testFolder,
+                    TimeSpan.FromSeconds(2)));
+
+                Assert.NotNull(exception);
+                Assert.Contains("timed out after", exception.Message);
+
+                int processId = int.Parse(File.ReadAllText(Path.Combine(testFolder, "process.pid")));
+                try
+                {
+                    using Process childProcess = Process.GetProcessById(processId);
+                    Assert.True(childProcess.HasExited, $"Child process {processId} is still running after the timeout.");
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+            finally
+            {
+                Directory.Delete(testFolder, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Fixes the macOS and Linux test hang reported and re-enables the supported ProjectDescriptionReader theory cases.

### Root Cause

TestUtilities.RunProcess redirected stdout and stderr but waited for the child process to exit before reading either stream.

When a pipe buffer became full, the child waited for its output to be consumed while the parent waited for the child to exit, causing a deadlock.

### Changes

- Drain stdout and stderr asynchronously before waiting for process completion.
- Add a 10-minute timeout for genuinely stuck child processes.
- Terminate the entire child-process tree when the timeout expires.
- Report timeout, exit code, and stderr details in test failures.
- Dispose child-process resources correctly.
- Update project detection for current minimal-hosting templates.
- Normalize JSON-array API scopes into the expected space-delimited value.
- Update MVC and minimal API project-type expectations.
- Re-enable supported ProjectDescriptionReader theory cases.
- Remove obsolete Blazor Server and hosted WebAssembly cases unsupported by current .NET templates.

### Test Coverage

Added focused regression tests that verify:

- Large redirected output is drained without deadlocking.
- A stuck child process times out and is terminated.

<img width="724" height="56" alt="image" src="https://github.com/user-attachments/assets/faf53191-c998-4918-ab7b-91976b5c7bb9" />

Fixes: #1598
