### PR TITLE
Fix minor issues in Blazor CRUD scaffolder

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddAspNetConnectionStringStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddAspNetConnectionStringStep.cs
@@ -100,7 +100,7 @@ internal class AddAspNetConnectionStringStep : ScaffoldStep
         if (writeContent && !string.IsNullOrEmpty(appSettingsFile))
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
-            _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options));
+            _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options) + Environment.NewLine);
             _logger.LogInformation($"Updated '{Path.GetFileName(appSettingsFile)}' with connection string '{ConnectionStringName}'");
             _telemetryService.TrackEvent(new AddAspNetConnectionStringTelemetryEvent(context.Scaffolder.Name, TelemetryConstants.Added));
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/UpdateAppSettingsStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/UpdateAppSettingsStep.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings
 
                     try
                     {
-                        _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options));
+                        _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options) + Environment.NewLine);
                         _logger.LogInformation($"Updated '{Path.GetFileName(appSettingsFile)}' with AzureAd configuration");
 
                         // Also check for appsettings.Development.json and update it if present
@@ -261,7 +261,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings
                         devContent["AzureAd"] = content["AzureAd"]?.DeepClone();
 
                         var options = new JsonSerializerOptions { WriteIndented = true };
-                        _fileSystem.WriteAllText(devSettingsPath, devContent.ToJsonString(options));
+                        _fileSystem.WriteAllText(devSettingsPath, devContent.ToJsonString(options) + Environment.NewLine);
                     }
                 }
                 catch (Exception ex)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
                     "\n<h1>Create</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n<div class=\"row\">\r\n    <div class=\"col-md-4\">\r\n        <EditForm m" +
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
             this.Write("\" class=\"form-label\">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write(":</label> \r\n                <");
+            this.Write(":</label>\r\n                <");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputTypeName));
             this.Write(" id=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
@@ -90,13 +90,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
-            this.Write("/> \r\n                <ValidationMessage For=\"() => ");
+            this.Write("/>\r\n                <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(".");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write("\" class=\"text-danger\" /> \r\n            </div>        \r\n            ");
+            this.Write("\" class=\"text-danger\" />\r\n            </div>\r\n            ");
   } 
             this.Write("<button type=\"submit\" class=\"btn btn-primary\">Create</button>\r\n        </EditForm" +
                     ">\r\n    </div>\r\n</div>\r\n\r\n<div>\r\n    <a href=\"/");
@@ -117,8 +117,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +
-                    "To(\"/");
+            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.tt
@@ -25,7 +25,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Create</PageTitle>
 
@@ -46,15 +46,15 @@
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
             #>
 <div class="mb-3"><#= requiredSpanAttributeHtml #>
-                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label> 
-                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/> 
-                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" /> 
-            </div>        
+                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
+                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
+                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
+            </div>
             <#  } #>
 <button type="submit" class="btn btn-primary">Create</button>
         </EditForm>
@@ -77,6 +77,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
                     "\n<h1>Delete</h1>\r\n\r\n<p>Are you sure you want to delete this?</p>\r\n<div>\r\n    <h2" +
                     ">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NotFound();\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NotFound();\r\n    " +
                     "    }\r\n    }\r\n\r\n    private async Task Delete");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
@@ -111,8 +111,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
             this.Write(".Remove(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigat" +
-                    "eTo(\"/");
+            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Delete</PageTitle>
 
@@ -73,7 +73,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -82,6 +82,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= entitySetName #>.Remove(<#= modelNameLowerInv #>!);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
                     "\r\n<h1>Details</h1>\r\n\r\n<div>\r\n    <h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n    <hr />\r\n    @if (");
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NotFound();\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NotFound();\r\n    " +
                     "    }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Details</PageTitle>
 
@@ -71,7 +71,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
                     "h1>Edit</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n@if (");
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
             this.Write("/>\r\n                    <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(@" is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -157,9 +157,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("!.");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
-            this.Write("))\r\n            {\r\n                NavigationManager.NotFound();\r\n   " +
+            this.Write("))\r\n            {\r\n                Navigation.NotFound();\r\n   " +
                     "         }\r\n            else\r\n            {\r\n                throw;\r\n           " +
-                    " }\r\n        }\r\n\r\n        NavigationManager.NavigateTo(\"/");
+                    " }\r\n        }\r\n\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n\r\n    private bool ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.tt
@@ -29,7 +29,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Edit</PageTitle>
 
@@ -57,13 +57,13 @@ else
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
 #>
                 <div class="mb-3"><#= requiredSpanAttributeHtml #>
                     <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
-                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/>
+                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
                     <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
                 </div>
 <#  } #>
@@ -91,7 +91,7 @@ else
 
         if (<#= modelName #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -110,7 +110,7 @@ else
         {
             if (!<#= modelName #>Exists(<#= modelName #>!.<#= primaryKeyName #>))
             {
-                NavigationManager.NotFound();
+                Navigation.NotFound();
             }
             else
             {
@@ -118,7 +118,7 @@ else
             }
         }
 
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 
     private bool <#= modelName #>Exists(<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerInv #>)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -65,7 +64,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
 
             this.Write("@implements IAsyncDisposable\r\n@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
                     "<h1>Index</h1>\r\n\r\n<p>\r\n    <a href=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("/create\">Create New</a>\r\n</p>\r\n\r\n<QuickGrid Class=\"table\" Items=\"context.");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
@@ -9,8 +9,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -36,7 +35,7 @@
 #>
 @implements IAsyncDisposable
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Index</PageTitle>
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
@@ -9,7 +9,8 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
                     "\n<h1>Create</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n<div class=\"row\">\r\n    <div class=\"col-md-4\">\r\n        <EditForm m" +
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
             this.Write("\" class=\"form-label\">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write(":</label> \r\n                <");
+            this.Write(":</label>\r\n                <");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputTypeName));
             this.Write(" id=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
@@ -92,11 +92,11 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
             this.Write("\" ");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
-            this.Write("/> \r\n                <ValidationMessage For=\"() => ");
+            this.Write("/>\r\n                <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(".");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write("\" class=\"text-danger\" /> \r\n            </div>        \r\n            ");
+            this.Write("\" class=\"text-danger\" />\r\n            </div>\r\n            ");
   } 
             this.Write("<button type=\"submit\" class=\"btn btn-primary\">Create</button>\r\n        </EditForm" +
                     ">\r\n    </div>\r\n</div>\r\n\r\n<div>\r\n    <a href=\"/");
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +
+            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigate" +
                     "To(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.tt
@@ -25,7 +25,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Create</PageTitle>
 
@@ -37,7 +37,7 @@
     <div class="col-md-4">
         <EditForm method="post" Model="<#= modelName #>" OnValidSubmit="Add<#= modelName #>" FormName="create" Enhance>
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert"/>
+            <ValidationSummary class="text-danger" role="alert" />
             <#
                 foreach (var property in entityProperties)
                 {
@@ -46,15 +46,15 @@
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
             #>
 <div class="mb-3"><#= requiredSpanAttributeHtml #>
-                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label> 
-                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/> 
-                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" /> 
-            </div>        
+                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
+                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
+                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
+            </div>
             <#  } #>
 <button type="submit" class="btn btn-primary">Create</button>
         </EditForm>
@@ -77,6 +77,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
                     "\n<h1>Delete</h1>\r\n\r\n<p>Are you sure you want to delete this?</p>\r\n<div>\r\n    <h2" +
                     ">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NotFound();\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NotFound();\r\n    " +
                     "    }\r\n    }\r\n\r\n    private async Task Delete");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
             this.Write(".Remove(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigat" +
+                this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigat" +
                     "eTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Delete</PageTitle>
 
@@ -73,7 +73,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -82,6 +82,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= entitySetName #>.Remove(<#= modelNameLowerInv #>!);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
                     "\r\n<h1>Details</h1>\r\n\r\n<div>\r\n    <h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n    <hr />\r\n    @if (");
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NotFound();\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NotFound();\r\n    " +
                     "    }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Details</PageTitle>
 
@@ -71,7 +71,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
                     "h1>Edit</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n@if (");
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write("\" OnValidSubmit=\"Update");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("\" FormName=\"edit\" Enhance>\r\n                <DataAnnotationsValidator />\r\n       " +
-                    "         <ValidationSummary role=\"alert\"/>\r\n                <input type=\"hidden\"" +
+                    "         <ValidationSummary role=\"alert\" />\r\n                <input type=\"hidden\"" +
                     " name=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(".");
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(@" is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -157,9 +157,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("!.");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
-            this.Write("))\r\n            {\r\n                NavigationManager.NotFound();\r\n   " +
+            this.Write("))\r\n            {\r\n                Navigation.NotFound();\r\n   " +
                     "         }\r\n            else\r\n            {\r\n                throw;\r\n           " +
-                    " }\r\n        }\r\n\r\n        NavigationManager.NavigateTo(\"/");
+                    " }\r\n        }\r\n\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n\r\n    private bool ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.tt
@@ -29,7 +29,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Edit</PageTitle>
 
@@ -47,7 +47,7 @@ else
         <div class="col-md-4">
             <EditForm method="post" Model="<#= modelName #>" OnValidSubmit="Update<#= modelName #>" FormName="edit" Enhance>
                 <DataAnnotationsValidator />
-                <ValidationSummary role="alert"/>
+                <ValidationSummary role="alert" />
                 <input type="hidden" name="<#= modelName #>.<#= primaryKeyName #>" value="@<#= modelName #>.<#= primaryKeyName #>" />
 <#
                 foreach (var property in entityProperties)
@@ -57,13 +57,13 @@ else
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
 #>
                 <div class="mb-3"><#= requiredSpanAttributeHtml #>
                     <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
-                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/>
+                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
                     <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
                 </div>
 <#  } #>
@@ -91,7 +91,7 @@ else
 
         if (<#= modelName #> is null)
         {
-            NavigationManager.NotFound();
+            Navigation.NotFound();
         }
     }
 
@@ -110,7 +110,7 @@ else
         {
             if (!<#= modelName #>Exists(<#= modelName #>!.<#= primaryKeyName #>))
             {
-                NavigationManager.NotFound();
+                Navigation.NotFound();
             }
             else
             {
@@ -118,7 +118,7 @@ else
             }
         }
 
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 
     private bool <#= modelName #>Exists(<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerInv #>)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -65,7 +64,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 
             this.Write("@implements IAsyncDisposable\r\n@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
                     "<h1>Index</h1>\r\n\r\n<p>\r\n    <a href=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("/create\">Create New</a>\r\n</p>\r\n\r\n<QuickGrid Class=\"table\" Items=\"context.");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
@@ -9,8 +9,8 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextTypeName = Model.DbContextInfo.DbContextClassName;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -63,7 +63,7 @@
 </QuickGrid>
 
 @code {
-    private <#= dbContextTypeName #> context = default!;
+    private <#= Model.DbContextInfo.DbContextClassName #> context = default!;
 
     protected override void OnInitialized()
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
@@ -9,8 +9,8 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextTypeName = Model.DbContextInfo.DbContextClassName;
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -36,7 +36,7 @@
 #>
 @implements IAsyncDisposable
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Index</PageTitle>
 
@@ -63,7 +63,7 @@
 </QuickGrid>
 
 @code {
-    private <#= Model.DbContextInfo.DbContextClassName #> context = default!;
+    private <#= dbContextTypeName #> context = default!;
 
     protected override void OnInitialized()
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
                     "\n<h1>Create</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n<div class=\"row\">\r\n    <div class=\"col-md-4\">\r\n        <EditForm m" +
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
             this.Write("\" class=\"form-label\">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write(":</label> \r\n                <");
+            this.Write(":</label>\r\n                <");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputTypeName));
             this.Write(" id=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
@@ -89,13 +89,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
-            this.Write("/> \r\n                <ValidationMessage For=\"() => ");
+            this.Write("/>\r\n                <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(".");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write("\" class=\"text-danger\" /> \r\n            </div>        \r\n            ");
+            this.Write("\" class=\"text-danger\" />\r\n            </div>\r\n            ");
   } 
             this.Write("<button type=\"submit\" class=\"btn btn-primary\">Create</button>\r\n        </EditForm" +
                     ">\r\n    </div>\r\n</div>\r\n\r\n<div>\r\n    <a href=\"/");
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +
+            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigate" +
                     "To(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.tt
@@ -23,7 +23,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Create</PageTitle>
 
@@ -35,7 +35,7 @@
     <div class="col-md-4">
         <EditForm method="post" Model="<#= modelName #>" OnValidSubmit="Add<#= modelName #>" FormName="create" Enhance>
             <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert"/>
+            <ValidationSummary class="text-danger" role="alert" />
             <#
                 foreach (var property in entityProperties)
                 {
@@ -44,15 +44,15 @@
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.IsRequired ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.IsRequired ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.IsRequired ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
             #>
 <div class="mb-3"><#= requiredSpanAttributeHtml #>
-                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label> 
-                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/> 
-                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" /> 
-            </div>        
+                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
+                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
+                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
+            </div>
             <#  } #>
 <button type="submit" class="btn btn-primary">Create</button>
         </EditForm>
@@ -73,6 +73,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= Model.ModelMetadata.EntitySetName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
                     "\n<h1>Delete</h1>\r\n\r\n<p>Are you sure you want to delete this?</p>\r\n<div>\r\n    <h2" +
                     ">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NavigateTo(\"notfound\");\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NavigateTo(\"notfound\");\r\n    " +
                     "    }\r\n    }\r\n\r\n    private async Task Delete");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
             this.Write(".Remove(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigat" +
+            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigat" +
                     "eTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.tt
@@ -27,7 +27,7 @@
 <#  }
 #>
 @inject <#= dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Delete</PageTitle>
 
@@ -72,7 +72,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 
@@ -81,6 +81,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= entitySetName #>.Remove(<#= modelNameLowerInv #>!);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
                     "\r\n<h1>Details</h1>\r\n\r\n<div>\r\n    <h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n    <hr />\r\n    @if (");
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NavigateTo(\"notfound\");\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NavigateTo(\"notfound\");\r\n    " +
                     "    }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.tt
@@ -27,7 +27,7 @@
 <#  }
 #>
 @inject <#= dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Details</PageTitle>
 
@@ -70,7 +70,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
                     "h1>Edit</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n@if (");
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
             this.Write("/>\r\n                    <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(@" is null)
         {
-            NavigationManager.NavigateTo(""notfound"");
+            Navigation.NavigateTo(""notfound"");
         }
     }
 
@@ -156,9 +156,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("!.");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
-            this.Write("))\r\n            {\r\n                NavigationManager.NavigateTo(\"notfound\");\r\n   " +
+            this.Write("))\r\n            {\r\n                Navigation.NavigateTo(\"notfound\");\r\n   " +
                     "         }\r\n            else\r\n            {\r\n                throw;\r\n           " +
-                    " }\r\n        }\r\n\r\n        NavigationManager.NavigateTo(\"/");
+                    " }\r\n        }\r\n\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n\r\n    private bool ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.tt
@@ -27,7 +27,7 @@
 <#  }
 #>
 @inject <#= dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Edit</PageTitle>
 
@@ -45,7 +45,7 @@ else
         <div class="col-md-4">
             <EditForm method="post" Model="<#= modelName #>" OnValidSubmit="Update<#= modelName #>" FormName="edit" Enhance>
                 <DataAnnotationsValidator />
-                <ValidationSummary role="alert"/>
+                <ValidationSummary role="alert" />
                 <input type="hidden" name="<#= modelName #>.<#= primaryKeyName #>" value="@<#= modelName #>.<#= primaryKeyName #>" />
 <#
                 foreach (var property in entityProperties)
@@ -55,13 +55,13 @@ else
                     string propertyShortTypeName = property.ShortTypeName.Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.IsRequired ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.IsRequired ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.IsRequired ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
 #>
                 <div class="mb-3"><#= requiredSpanAttributeHtml #>
                     <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
-                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/>
+                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
                     <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
                 </div>
 <#  } #>
@@ -89,7 +89,7 @@ else
 
         if (<#= modelName #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 
@@ -108,7 +108,7 @@ else
         {
             if (!<#= modelName #>Exists(<#= modelName #>!.<#= primaryKeyName #>))
             {
-                NavigationManager.NavigateTo("notfound");
+                Navigation.NavigateTo("notfound");
             }
             else
             {
@@ -116,7 +116,7 @@ else
             }
         }
 
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 
     private bool <#= modelName #>Exists(<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerInv #>)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.tt
@@ -9,7 +9,8 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.ContextTypeName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.tt
@@ -9,8 +9,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextNamespace) ? string.Empty : Model.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.ContextTypeName : $"{dbContextNamespace}.{Model.ContextTypeName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.ContextTypeName}> DbFactory";
     string modelNamespace = Model.Namespace ?? Model.ModelType.Namespace;
     string primaryKeyName = Model.ModelMetadata.PrimaryKeys[0].PropertyName;
     string primaryKeyShortTypeName = Model.ModelMetadata.PrimaryKeys[0].ShortTypeName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Create</PageTitle>\r\n\r" +
                     "\n<h1>Create</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n<div class=\"row\">\r\n    <div class=\"col-md-4\">\r\n        <EditForm m" +
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
             this.Write("\" class=\"form-label\">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write(":</label> \r\n                <");
+            this.Write(":</label>\r\n                <");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputTypeName));
             this.Write(" id=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyNameLowercase));
@@ -90,13 +90,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
-            this.Write("/> \r\n                <ValidationMessage For=\"() => ");
+            this.Write("/>\r\n                <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(".");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
-            this.Write("\" class=\"text-danger\" /> \r\n            </div>        \r\n            ");
+            this.Write("\" class=\"text-danger\" />\r\n            </div>\r\n            ");
   } 
             this.Write("<button type=\"submit\" class=\"btn btn-primary\">Create</button>\r\n        </EditForm" +
                     ">\r\n    </div>\r\n</div>\r\n\r\n<div>\r\n    <a href=\"/");
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +
+            this.Write(");\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigate" +
                     "To(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.tt
@@ -25,7 +25,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Create</PageTitle>
 
@@ -46,15 +46,15 @@
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
             #>
 <div class="mb-3"><#= requiredSpanAttributeHtml #>
-                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label> 
-                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/> 
-                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" /> 
-            </div>        
+                <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
+                <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
+                <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
+            </div>
             <#  } #>
 <button type="submit" class="btn btn-primary">Create</button>
         </EditForm>
@@ -77,6 +77,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Delete</PageTitle>\r\n\r" +
                     "\n<h1>Delete</h1>\r\n\r\n<p>Are you sure you want to delete this?</p>\r\n<div>\r\n    <h2" +
                     ">");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NavigateTo(\"notfound\");\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NavigateTo(\"notfound\");\r\n    " +
                     "    }\r\n    }\r\n\r\n    private async Task Delete");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(entitySetName));
             this.Write(".Remove(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigat" +
+            this.Write("!);\r\n        await context.SaveChangesAsync();\r\n        Navigation.Navigat" +
                     "eTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n}\r\n");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Delete</PageTitle>
 
@@ -73,7 +73,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 
@@ -82,6 +82,6 @@
         using var context = DbFactory.CreateDbContext();
         context.<#= entitySetName #>.Remove(<#= modelNameLowerInv #>!);
         await context.SaveChangesAsync();
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Details</PageTitle>\r\n" +
                     "\r\n<h1>Details</h1>\r\n\r\n<div>\r\n    <h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n    <hr />\r\n    @if (");
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
             this.Write(");\r\n\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
-            this.Write(" is null)\r\n        {\r\n            NavigationManager.NavigateTo(\"notfound\");\r\n    " +
+            this.Write(" is null)\r\n        {\r\n            Navigation.NavigateTo(\"notfound\");\r\n    " +
                     "    }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.tt
@@ -28,7 +28,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Details</PageTitle>
 
@@ -71,7 +71,7 @@
 
         if (<#= modelNameLowerInv #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
 
             this.Write("@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Edit</PageTitle>\r\n\r\n<" +
                     "h1>Edit</h1>\r\n\r\n<h2>");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("</h2>\r\n<hr />\r\n@if (");
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelPropertyName));
             this.Write("\" class=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputClass));
-            this.Write("\" ");
+            this.Write("\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(ariaRequiredAttributeHtml));
             this.Write("/>\r\n                    <ValidationMessage For=\"() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(@" is null)
         {
-            NavigationManager.NavigateTo(""notfound"");
+            Navigation.NavigateTo(""notfound"");
         }
     }
 
@@ -157,9 +157,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("!.");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyName));
-            this.Write("))\r\n            {\r\n                NavigationManager.NavigateTo(\"notfound\");\r\n   " +
+            this.Write("))\r\n            {\r\n                Navigation.NavigateTo(\"notfound\");\r\n   " +
                     "         }\r\n            else\r\n            {\r\n                throw;\r\n           " +
-                    " }\r\n        }\r\n\r\n        NavigationManager.NavigateTo(\"/");
+                    " }\r\n        }\r\n\r\n        Navigation.NavigateTo(\"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("\");\r\n    }\r\n\r\n    private bool ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.tt
@@ -29,7 +29,7 @@
 <#  }
 #>
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Edit</PageTitle>
 
@@ -57,13 +57,13 @@ else
                     string propertyShortTypeName = property.Type.ToDisplayString().Replace("?", string.Empty);
                     var inputTypeName = Model.GetInputType(propertyShortTypeName);
                     var inputClass = Model.GetInputClassType(propertyShortTypeName);
-                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? "aria-required=\"true\"" : string.Empty;
+                    var ariaRequiredAttributeHtml = property.HasRequiredAttribute() ? " aria-required=\"true\"" : string.Empty;
                     var divWhitespace = new string(' ', 16);
                     var requiredSpanAttributeHtml = property.HasRequiredAttribute() ? $"\r\n{divWhitespace}<span class=\"text-danger\">*</span>" : string.Empty;
 #>
                 <div class="mb-3"><#= requiredSpanAttributeHtml #>
                     <label for="<#= modelPropertyNameLowercase #>" class="form-label"><#= modelPropertyName #>:</label>
-                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>" <#= ariaRequiredAttributeHtml #>/>
+                    <<#= inputTypeName #> id="<#= modelPropertyNameLowercase #>" @bind-Value="<#= modelName #>.<#= modelPropertyName #>" class="<#= inputClass #>"<#= ariaRequiredAttributeHtml #>/>
                     <ValidationMessage For="() => <#= modelName #>.<#= modelPropertyName #>" class="text-danger" />
                 </div>
 <#  } #>
@@ -91,7 +91,7 @@ else
 
         if (<#= modelName #> is null)
         {
-            NavigationManager.NavigateTo("notfound");
+            Navigation.NavigateTo("notfound");
         }
     }
 
@@ -110,7 +110,7 @@ else
         {
             if (!<#= modelName #>Exists(<#= modelName #>!.<#= primaryKeyName #>))
             {
-                NavigationManager.NavigateTo("notfound");
+                Navigation.NavigateTo("notfound");
             }
             else
             {
@@ -118,7 +118,7 @@ else
             }
         }
 
-        NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
+        Navigation.NavigateTo("/<#= pluralModelLowerInv #>");
     }
 
     private bool <#= modelName #>Exists(<#= primaryKeyShortTypeName #> <#= primaryKeyNameLowerInv #>)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -65,7 +64,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
 
             this.Write("@implements IAsyncDisposable\r\n@inject ");
             this.Write(this.ToStringHelper.ToStringWithCulture(dbContextFactory));
-            this.Write("\r\n@inject NavigationManager NavigationManager\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
+            this.Write("\r\n@inject NavigationManager Navigation\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n" +
                     "<h1>Index</h1>\r\n\r\n<p>\r\n    <a href=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("/create\">Create New</a>\r\n</p>\r\n\r\n<QuickGrid Class=\"table\" Items=\"context.");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
@@ -9,8 +9,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
-    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
+    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -36,7 +35,7 @@
 #>
 @implements IAsyncDisposable
 @inject <#=dbContextFactory #>
-@inject NavigationManager NavigationManager
+@inject NavigationManager Navigation
 
 <PageTitle>Index</PageTitle>
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
@@ -9,7 +9,8 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string pluralModelLowerInv = pluralModel.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
-    string dbContextFactory = $"IDbContextFactory<{Model.DbContextInfo.DbContextClassName}> DbFactory";
+    string dbContextFullName = string.IsNullOrEmpty(dbContextNamespace) ? Model.DbContextInfo.DbContextClassName : $"{dbContextNamespace}.{Model.DbContextInfo.DbContextClassName}";
+    string dbContextFactory = $"IDbContextFactory<{dbContextFullName}> DbFactory";
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     var entityProperties =  Model.ModelInfo.ModelProperties
         .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/dotnet-scaffolding/dotnet-scaffold/Aspire/ScaffoldSteps/AddAspireConnectionStringStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Aspire/ScaffoldSteps/AddAspireConnectionStringStep.cs
@@ -105,7 +105,7 @@ internal class AddAspireConnectionStringStep : ScaffoldStep
         {
             // Write the updated content to appsettings.json
             JsonSerializerOptions options = new JsonSerializerOptions { WriteIndented = true };
-            _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options));
+            _fileSystem.WriteAllText(appSettingsFile, content.ToJsonString(options) + Environment.NewLine);
             _logger.LogInformation($"Updated '{Path.GetFileName(appSettingsFile)}' with connection string '{ConnectionStringName}'");
             _telemetryService.TrackEvent(new AddAspireConnectionStringTelemetryEvent(context.Scaffolder.Name, TelemetryConstants.Added));
         }


### PR DESCRIPTION
# Fix minor issues in Blazor CRUD scaffolder

## Summary

Fixes the remaining Blazor CRUD scaffolder issues identified in #2743 and aligns generated output with current Blazor documentation conventions across .NET 8, .NET 9, .NET 10, and .NET 11 templates.

## Root Cause

Several template inconsistencies remained in the Blazor CRUD scaffolder:

- Generated CRUD components continued to inject `NavigationManager` using the variable name `NavigationManager` instead of the documentation convention `Navigation`.
- Index templates injected `IDbContextFactory` using a fully-qualified DbContext type even when the namespace was already imported.
- Generated Razor markup contained formatting inconsistencies and unnecessary whitespace.
- `aria-required` attribute generation introduced formatting inconsistencies in scaffolded markup.
- Updates to `appsettings.json` removed the final newline character when rewriting the file.

These issues resulted in generated code differing from current documentation patterns and coding conventions.

## Changes

### Blazor CRUD Templates

- Updated NavigationManager injection from:

```razor
@inject NavigationManager NavigationManager
```

to:

```razor
@inject NavigationManager Navigation
```

- Replaced all generated references from `NavigationManager.*` to `Navigation.*`.
- Applied the update across Create, Edit, Delete, Details, and Index templates for:
  - .NET 8
  - .NET 9
  - .NET 10
  - .NET 11

### Razor Markup Cleanup

- Removed unnecessary whitespace and formatting inconsistencies in generated CRUD components.
- Corrected spacing related to:
  - ValidationSummary
  - ValidationMessage
  - Input elements
  - Required field indicators
  - aria-required rendering

### appsettings Formatting

- Preserved the final newline when updating:
  - `appsettings.json`
  - `appsettings.Development.json`

- Updated:
  - `AddAspNetConnectionStringStep`
  - `UpdateAppSettingsStep`
  - `AddAspireConnectionStringStep`

## Validation

- Generated Blazor CRUD pages using the updated templates.
- Verified template output for .NET 8, .NET 9, .NET 10, and .NET 11 scenarios.
- Confirmed:
  - Navigation injection follows documentation conventions.
  - DbContext type generation is simplified.
  - Generated Razor markup formatting is consistent.
  - Connection-string updates preserve file formatting and final newlines.
  - Successfully built generated applications after scaffolding.

Fixes: #2743