### PR TITLE
Allocate list only when needed

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
@@ -62,16 +62,17 @@ internal static class BlazorCrudScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            var packages = new List<Package>()
-            {
-                PackageConstants.AspNetCorePackages.QuickGridEfAdapterPackage,
-                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
-                PackageConstants.EfConstants.EfCoreToolsPackage
-            };
 
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&
                 commandSettingsObj is CrudSettings commandSettings)
             {
+                var packages = new List<Package>()
+                {
+                    PackageConstants.AspNetCorePackages.QuickGridEfAdapterPackage,
+                    PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
+                    PackageConstants.EfConstants.EfCoreToolsPackage
+                };
+
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
@@ -62,17 +62,16 @@ internal static class BlazorCrudScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            var packages = new List<Package>()
+            {
+                PackageConstants.AspNetCorePackages.QuickGridEfAdapterPackage,
+                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
+                PackageConstants.EfConstants.EfCoreToolsPackage
+            };
 
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&
                 commandSettingsObj is CrudSettings commandSettings)
             {
-                var packages = new List<Package>()
-                {
-                    PackageConstants.AspNetCorePackages.QuickGridEfAdapterPackage,
-                    PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
-                    PackageConstants.EfConstants.EfCoreToolsPackage
-                };
-
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
@@ -238,6 +238,9 @@ internal static class BlazorEntraScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            List<Package> packages = [
+                PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackage
+            ];
 
             if (context.Properties.TryGetValue(nameof(EntraIdSettings), out var entraIdSettings) &&
                 entraIdSettings is EntraIdSettings entraSettings)
@@ -248,7 +251,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 }
 
                 step.ProjectPath = entraSettings.Project;
-                step.Packages = [PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackage];
+                step.Packages = packages;
             }
             else
             {
@@ -277,6 +280,10 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 {
                     step.ProjectPath = projectPath;
 
+                    List<Package> packages = new List<Package>
+                    {
+                        PackageConstants.AspNetCorePackages.AspNetCoreComponentsWebAssemblyAuthenticationPackage
+                    };
                     if (context.Properties.TryGetValue(nameof(EntraIdSettings), out var entraIdSettings) &&
                         entraIdSettings is EntraIdSettings entraSettings)
                     {
@@ -285,7 +292,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                             throw new InvalidOperationException("Project path is not set in EntraIdSettings.");
                         }
 
-                        step.Packages = [PackageConstants.AspNetCorePackages.AspNetCoreComponentsWebAssemblyAuthenticationPackage];
+                        step.Packages = packages;
                     }
                 }
                 else
@@ -430,7 +437,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 step.SkipStep = true;
                 return;
             }
-
+            
             var allBlazorIdentityFiles = templateFolderUtilities.GetAllT4TemplatesForTargetFramework(["BlazorEntraId"], entraIdModel.ProjectInfo.ProjectPath);
             var blazorEntraIdProperties = EntraIdHelper.GetTextTemplatingProperties(allBlazorIdentityFiles, entraIdModel);
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
@@ -238,9 +238,6 @@ internal static class BlazorEntraScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<Package> packages = [
-                PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackage
-            ];
 
             if (context.Properties.TryGetValue(nameof(EntraIdSettings), out var entraIdSettings) &&
                 entraIdSettings is EntraIdSettings entraSettings)
@@ -251,7 +248,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 }
 
                 step.ProjectPath = entraSettings.Project;
-                step.Packages = packages;
+                step.Packages = [PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackage];
             }
             else
             {
@@ -280,10 +277,6 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 {
                     step.ProjectPath = projectPath;
 
-                    List<Package> packages = new List<Package>
-                    {
-                        PackageConstants.AspNetCorePackages.AspNetCoreComponentsWebAssemblyAuthenticationPackage
-                    };
                     if (context.Properties.TryGetValue(nameof(EntraIdSettings), out var entraIdSettings) &&
                         entraIdSettings is EntraIdSettings entraSettings)
                     {
@@ -292,7 +285,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                             throw new InvalidOperationException("Project path is not set in EntraIdSettings.");
                         }
 
-                        step.Packages = packages;
+                        step.Packages = [PackageConstants.AspNetCorePackages.AspNetCoreComponentsWebAssemblyAuthenticationPackage];
                     }
                 }
                 else
@@ -437,7 +430,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 step.SkipStep = true;
                 return;
             }
-            
+
             var allBlazorIdentityFiles = templateFolderUtilities.GetAllT4TemplatesForTargetFramework(["BlazorEntraId"], entraIdModel.ProjectInfo.ProjectPath);
             var blazorEntraIdProperties = EntraIdHelper.GetTextTemplatingProperties(allBlazorIdentityFiles, entraIdModel);
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -120,7 +120,7 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
 
             string? projectPath = context.GetOptionResult<string>(Constants.CliOptions.ProjectCliOption);
             if (string.IsNullOrEmpty(projectPath))
-            {
+            { 
                 step.SkipStep = true;
                 return;
             }
@@ -153,17 +153,16 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            List<Package> packages = [
+                PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
+                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
+                PackageConstants.EfConstants.EfCoreToolsPackage,
+                PackageConstants.EfConstants.EfCoreDesignPackage
+            ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&
                 commandSettingsObj is IdentitySettings commandSettings)
             {
-                List<Package> packages = [
-                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
-                    PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
-                    PackageConstants.EfConstants.EfCoreToolsPackage,
-                    PackageConstants.EfConstants.EfCoreDesignPackage
-                ];
-
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -120,7 +120,7 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
 
             string? projectPath = context.GetOptionResult<string>(Constants.CliOptions.ProjectCliOption);
             if (string.IsNullOrEmpty(projectPath))
-            { 
+            {
                 step.SkipStep = true;
                 return;
             }
@@ -153,16 +153,17 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<Package> packages = [
-                PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
-                PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
-                PackageConstants.EfConstants.EfCoreToolsPackage,
-                PackageConstants.EfConstants.EfCoreDesignPackage
-            ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&
                 commandSettingsObj is IdentitySettings commandSettings)
             {
+                List<Package> packages = [
+                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
+                    PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
+                    PackageConstants.EfConstants.EfCoreToolsPackage,
+                    PackageConstants.EfConstants.EfCoreDesignPackage
+                ];
+
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
@@ -59,10 +59,10 @@ internal static class EfControllerScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
             if (context.Properties.TryGetValue(nameof(EfControllerSettings), out var commandSettingsObj) &&
                 commandSettingsObj is EfControllerSettings commandSettings)
             {
+                List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&
@@ -200,7 +200,7 @@ internal static class EfControllerScaffolderBuilderExtensions
                 var addViews = context.GetOptionResult<bool>(Constants.CliOptions.ViewsOption);
                 string? projectPath = context.GetOptionResult<string>(Constants.CliOptions.ProjectCliOption);
                 if (!addViews || string.IsNullOrEmpty(projectPath))
-                { 
+                {
                     step.SkipStep = true;
                     return;
                 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
@@ -59,10 +59,10 @@ internal static class EfControllerScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
             if (context.Properties.TryGetValue(nameof(EfControllerSettings), out var commandSettingsObj) &&
                 commandSettingsObj is EfControllerSettings commandSettings)
             {
-                List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&
@@ -200,7 +200,7 @@ internal static class EfControllerScaffolderBuilderExtensions
                 var addViews = context.GetOptionResult<bool>(Constants.CliOptions.ViewsOption);
                 string? projectPath = context.GetOptionResult<string>(Constants.CliOptions.ProjectCliOption);
                 if (!addViews || string.IsNullOrEmpty(projectPath))
-                {
+                { 
                     step.SkipStep = true;
                     return;
                 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
@@ -29,16 +29,17 @@ internal static class IdentityScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<Package> packages = [
-                PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
-                PackageConstants.AspNetCorePackages.AspNetCoreIdentityUiPackage,
-                PackageConstants.EfConstants.EfCoreToolsPackage,
-                PackageConstants.EfConstants.EfCoreDesignPackage
-            ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&
                 commandSettingsObj is IdentitySettings commandSettings)
             {
+                List<Package> packages = [
+                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
+                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityUiPackage,
+                    PackageConstants.EfConstants.EfCoreToolsPackage,
+                    PackageConstants.EfConstants.EfCoreDesignPackage
+                ];
+
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
@@ -29,17 +29,16 @@ internal static class IdentityScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            List<Package> packages = [
+                PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
+                PackageConstants.AspNetCorePackages.AspNetCoreIdentityUiPackage,
+                PackageConstants.EfConstants.EfCoreToolsPackage,
+                PackageConstants.EfConstants.EfCoreDesignPackage
+            ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&
                 commandSettingsObj is IdentitySettings commandSettings)
             {
-                List<Package> packages = [
-                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
-                    PackageConstants.AspNetCorePackages.AspNetCoreIdentityUiPackage,
-                    PackageConstants.EfConstants.EfCoreToolsPackage,
-                    PackageConstants.EfConstants.EfCoreDesignPackage
-                ];
-
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -75,10 +75,10 @@ internal static class MinimalApiScaffolderBuilderExtensions
             var step = config.Step;
             var context = config.Context;
             //this scaffolder has a non-EF scenario, only add EF packages if DataContext is provided.
+            List<Package> packages = [];
             if (context.Properties.TryGetValue(nameof(MinimalApiSettings), out var commandSettingsObj) &&
                 commandSettingsObj is MinimalApiSettings commandSettings)
             {
-                List<Package> packages = [];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DataContext) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -75,10 +75,10 @@ internal static class MinimalApiScaffolderBuilderExtensions
             var step = config.Step;
             var context = config.Context;
             //this scaffolder has a non-EF scenario, only add EF packages if DataContext is provided.
-            List<Package> packages = [];
             if (context.Properties.TryGetValue(nameof(MinimalApiSettings), out var commandSettingsObj) &&
                 commandSettingsObj is MinimalApiSettings commandSettings)
             {
+                List<Package> packages = [];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DataContext) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
@@ -110,10 +110,10 @@ internal static class RazorPagesScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
+            List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&
                 commandSettingsObj is CrudSettings commandSettings)
             {
-                List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
@@ -110,10 +110,10 @@ internal static class RazorPagesScaffolderBuilderExtensions
         {
             var step = config.Step;
             var context = config.Context;
-            List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
             if (context.Properties.TryGetValue(nameof(CrudSettings), out var commandSettingsObj) &&
                 commandSettingsObj is CrudSettings commandSettings)
             {
+                List<Package> packages = [PackageConstants.EfConstants.EfCoreToolsPackage];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
                 if (!string.IsNullOrEmpty(commandSettings.DatabaseProvider) &&


### PR DESCRIPTION
### Summary

Addresses the unnecessary package-list allocations.

The affected ASP.NET scaffolder package steps now create package collections only after the required settings are available, avoiding allocations when a step is skipped.

### Root Cause

Several `With*AddPackagesStep` callbacks created a `List<Package>` before validating the scaffolder settings. When the settings were unavailable, the step was skipped even though the package list had already been allocated.

### Changes

- Deferred package-list creation in the Blazor CRUD, Blazor Identity, Identity, EF Controller, Minimal API, and Razor Pages scaffolders.
- Assigned Entra ID and Blazor WebAssembly package collections only within validated execution paths.
- Preserved the existing package selection, project path, prerelease, and database-provider behavior.

### Test Coverage

Ran the focused scaffolder builder-extension test suite:
<img width="1036" height="572" alt="image" src="https://github.com/user-attachments/assets/f0210b1d-e3d9-4e37-a6c4-d44d46e6eda0" />

Fixes #3398