### PR TITLE
feat(scaffolder): adding Ignite UI for Blazor scaffolder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -654,6 +654,7 @@ For feature requests:
 - **Getting Started**: [docs/Getting-Started.md](docs/Getting-Started.md)
 - **Known Flaky/Skipped Tests**: [docs/KNOWN_FLAKY_TESTS.md](docs/KNOWN_FLAKY_TESTS.md)
 - **Entra ID Scaffolder**: [docs/ENTRA_ID_SCAFFOLDER_DOCUMENTATION.md](docs/ENTRA_ID_SCAFFOLDER_DOCUMENTATION.md)
+- **Ignite UI for Blazor Scaffolder**: [docs/IGNITEUI_BLAZOR_SCAFFOLDER_DOCUMENTATION.md](docs/IGNITEUI_BLAZOR_SCAFFOLDER_DOCUMENTATION.md)
 - **Main README**: [README.md](README.md)
 
 ### Related Projects

--- a/docs/IGNITEUI_BLAZOR_SCAFFOLDER_DOCUMENTATION.md
+++ b/docs/IGNITEUI_BLAZOR_SCAFFOLDER_DOCUMENTATION.md
@@ -1,0 +1,228 @@
+# Ignite UI for Blazor Scaffolder Documentation
+
+## Table of Contents
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Command Usage](#command-usage)
+- [Options Reference](#options-reference)
+- [What the Scaffolder Does](#what-the-scaffolder-does)
+- [Supported Project Types](#supported-project-types)
+- [Render Mode Requirements](#render-mode-requirements)
+- [Re-running the Scaffolder](#re-running-the-scaffolder)
+- [Troubleshooting](#troubleshooting)
+- [Implementation Notes](#implementation-notes)
+
+---
+
+## Overview
+
+The **Ignite UI for Blazor Scaffolder** (`dotnet scaffold aspnet blazor-igniteui`) adds the open-source
+(MIT licensed) Ignite UI for Blazor packages from Infragistics to an **existing** Blazor project:
+
+| Package | Contents | Service registration |
+|---------|----------|----------------------|
+| `IgniteUI.Blazor.Lite` | Core UI components (inputs, buttons, dialogs, combo, ...) | `builder.Services.AddIgniteUIBlazor()` |
+| `IgniteUI.Blazor.GridLite` | Lightweight data grid (`<IgbGridLite>`) | None required |
+
+The scaffolder performs the manual setup steps described in the Ignite UI documentation:
+
+1. Installs the selected NuGet package(s).
+2. Registers `builder.Services.AddIgniteUIBlazor()` in `Program.cs` (only when `IgniteUI.Blazor.Lite` is added).
+3. Adds `@using IgniteUI.Blazor.Controls` to `_Imports.razor`.
+4. Links a theme stylesheet in the host page (`Components/App.razor`, `Pages/_Host.cshtml`,
+   `Pages/_Layout.cshtml` or `wwwroot/index.html`).
+5. For a Blazor Web App with a WebAssembly client project, repeats steps 1–3 in the client project.
+
+---
+
+## Prerequisites
+
+- .NET SDK 8.0 or later (the packages target `net8.0`, `net9.0` and `net10.0`; `net11.0` projects consume the `net10.0` assets).
+- The `dotnet scaffold` tool.
+- An existing Blazor project (Blazor Web App, Blazor Server or standalone Blazor WebAssembly).
+- Network access to your NuGet feeds (the packages are installed with `dotnet add package`).
+
+---
+
+## Command Usage
+
+```bash
+# Interactive
+dotnet scaffold aspnet blazor-igniteui
+
+# Add both packages with the default light bootstrap theme
+dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp.csproj --package All
+
+# Add only the grid with the dark material theme
+dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp.csproj --package GridLite --theme material --theme-variant dark
+
+# Add the core components using prerelease package versions
+dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp.csproj --package Lite --prerelease
+
+# Blazor Web App with a WebAssembly client project: target the SERVER project.
+# The referenced MyBlazorApp.Client project is detected and updated automatically.
+dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp/MyBlazorApp.csproj --package All
+```
+
+---
+
+## Options Reference
+
+| Option | Required | Values | Default | Description |
+|--------|----------|--------|---------|-------------|
+| `--project` | Yes | path to `.csproj` | | The Blazor project to modify. For a Blazor Web App with a `.Client` project, pass the **server** project; the client is updated automatically (see [section 5](#5-blazor-web-app-with-a-webassembly-client-project)). |
+| `--package` | Yes | `Lite`, `GridLite`, `All` | | Which Ignite UI package(s) to add. |
+| `--theme` | No | `bootstrap`, `material`, `fluent`, `indigo` | `bootstrap` | Theme stylesheet to link. |
+| `--theme-variant` | No | `light`, `dark` | `light` | Variant of the theme stylesheet. |
+| `--prerelease` | No | flag | `false` | Install prerelease package versions. |
+
+Unknown `--theme` / `--theme-variant` values fall back to the defaults with an informational message.
+
+---
+
+## What the Scaffolder Does
+
+### 1. NuGet packages
+
+`IgniteUI.Blazor.Lite` and/or `IgniteUI.Blazor.GridLite` are added with `dotnet add package`. The packages are not
+versioned in lockstep with .NET, so the latest stable version is installed (or the latest prerelease with `--prerelease`).
+
+### 2. Service registration (`Program.cs`)
+
+Only `IgniteUI.Blazor.Lite` needs service registration. When it is selected, the scaffolder adds:
+
+```csharp
+using IgniteUI.Blazor.Controls;
+// ...
+builder.Services.AddIgniteUIBlazor();
+```
+
+- ASP.NET Core hosted projects (Blazor Web App / Blazor Server): inserted before `var app = builder.Build();`
+  using `CodeModificationConfigs/igniteUIBlazorChanges.json`.
+- Blazor WebAssembly projects (standalone, or the `.Client` project of a Blazor Web App): inserted before
+  `await builder.Build().RunAsync();` using `CodeModificationConfigs/igniteUIBlazorWasmChanges.json`.
+
+The change is skipped when `AddIgniteUIBlazor` is already present. To trim the initial payload you can later pass
+module types explicitly, e.g. `builder.Services.AddIgniteUIBlazor(typeof(IgbInputModule), typeof(IgbComboModule));`.
+
+### 3. `_Imports.razor`
+
+`@using IgniteUI.Blazor.Controls` is appended to `Components/_Imports.razor` (Blazor Web App) or the project root
+`_Imports.razor` (Blazor WebAssembly / Blazor Server). The file is created when it does not exist. The directive is
+not duplicated when it is already present.
+
+### 4. Theme stylesheet
+
+Exactly one theme stylesheet is linked in the `<head>` of the host page:
+
+| Scenario | Stylesheet |
+|----------|------------|
+| `IgniteUI.Blazor.Lite` is added or already referenced | `_content/IgniteUI.Blazor/themes/{variant}/{theme}.css` |
+| Only `IgniteUI.Blazor.GridLite` is used | `_content/IgniteUI.Blazor.GridLite/css/themes/{variant}/{theme}.css` |
+
+The `<link>` is inserted after the last existing `<link>` in `<head>` and matches its indentation. When the host page
+is a `.razor` file that already uses the fingerprinted asset collection (`@Assets["..."]`, .NET 9+), the new link uses
+the same syntax:
+
+```razor
+<link rel="stylesheet" href="@Assets["_content/IgniteUI.Blazor/themes/light/bootstrap.css"]" />
+```
+
+Otherwise:
+
+```html
+<link href="_content/IgniteUI.Blazor/themes/light/bootstrap.css" rel="stylesheet" />
+```
+
+If a different Ignite UI theme is already linked, its `href` is swapped for the requested theme so the application never
+loads two themes at once.
+
+### 5. Blazor Web App with a WebAssembly client project
+
+**Always target the server project**, i.e. the project that references `MyApp.Client`. The scaffolder runs
+`dotnet reference list` on it and `dotnet package list --format json` on every referenced project; a referenced project
+whose packages include the implicit `Microsoft.NET.Sdk.WebAssembly` pack is treated as the Blazor WebAssembly client, and
+the package(s), the service registration and the `@using` directive are applied to it as well (using
+`igniteUIBlazorWasmChanges.json` for its `Program.cs`). The host page only exists in the server project, so the stylesheet
+is linked once. The tool logs `Detected Blazor WebAssembly project via package reference: ...` when the client was found.
+
+Requirements and limits:
+
+- The client project must have been restored at least once (any build, or opening the solution in Visual Studio, does
+  this). `dotnet package list` fails without `obj/project.assets.json`, and the client is then skipped without an error.
+- Passing the `.Client` project instead treats it as a standalone WebAssembly app: only the client is updated, and no host
+  page is found because a Web App client project has no `wwwroot/index.html`.
+- Only the first referenced WebAssembly project is handled, which matches the `dotnet new blazor -int WebAssembly` /
+  `-int Auto` layout.
+
+---
+
+## Supported Project Types
+
+| Project type | Host page | `_Imports.razor` | Program.cs config |
+|--------------|-----------|------------------|-------------------|
+| Blazor Web App (server project, .NET 8+) | `Components/App.razor` | `Components/_Imports.razor` | `igniteUIBlazorChanges.json` |
+| Blazor Web App `.Client` project (updated automatically when the **server** project is targeted) | n/a | `_Imports.razor` | `igniteUIBlazorWasmChanges.json` |
+| Standalone Blazor WebAssembly | `wwwroot/index.html` | `_Imports.razor` | `igniteUIBlazorWasmChanges.json` |
+| Blazor Server (.NET 7 and earlier layouts) | `Pages/_Layout.cshtml` or `Pages/_Host.cshtml` | `_Imports.razor` | `igniteUIBlazorChanges.json` |
+
+Blazor Hybrid (MAUI) projects are not targeted by this scaffolder; follow the manual steps in the Ignite UI documentation.
+
+---
+
+## Render Mode Requirements
+
+Ignite UI components need an **interactive** render mode; static server-side rendering renders nothing usable. The
+scaffolder does not change render modes (that is an application architecture decision) but it does inspect Blazor Web
+Apps and logs guidance:
+
+- A **warning** when `Program.cs` registers neither `.AddInteractiveServerComponents()` nor
+  `.AddInteractiveWebAssemblyComponents()`.
+- An **informational message** when no `@rendermode` is declared on `<Routes />` (`App.razor`) or in `Routes.razor`,
+  reminding you to add `@rendermode InteractiveServer` (or `InteractiveWebAssembly` / `InteractiveAuto`) to the pages
+  that use Ignite UI, or to set `<Routes @rendermode="InteractiveAuto" />` globally.
+
+---
+
+## Re-running the Scaffolder
+
+The scaffolder is idempotent:
+
+- Packages already referenced are left as they are (`dotnet add package` updates the version at most).
+- `AddIgniteUIBlazor` and `@using IgniteUI.Blazor.Controls` are never duplicated.
+- Re-running with a different `--theme` / `--theme-variant` swaps the linked theme.
+- Running `--package GridLite` on a project that already references `IgniteUI.Blazor.Lite` keeps the
+  `IgniteUI.Blazor` theme stylesheet (the GridLite-only stylesheet must not be used alongside other Ignite UI components).
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `Could not find a host page ... Add the following line to the <head> of your host page manually` | None of the known host pages contains a `</head>` element. Add the printed `<link>` to your host page. |
+| Components render but are unstyled | The theme stylesheet is missing or the path is wrong. Check the `<link>` in the host page and that the package restore succeeded. |
+| Components render nothing in a Blazor Web App | Add an interactive render mode (see [Render Mode Requirements](#render-mode-requirements)). |
+| `dotnet add package` fails | Verify network access and that your `NuGet.config` can reach nuget.org (or a mirror). Use `--prerelease` to allow prerelease versions. |
+| `error: There are no versions available for the package 'IgniteUI.Blazor.Lite'` (or `GridLite`) followed by `Failed.` | The project's `NuGet.config` only lists feeds that do not carry third-party packages (for example curated Microsoft mirror feeds). The scaffolder continues with the remaining steps; add nuget.org (or your organization's mirror of it) as a package source and re-run the scaffolder, or run `dotnet add package IgniteUI.Blazor.Lite` manually. |
+| `Program.cs` was not modified | The step only runs for `--package Lite` / `All`. It inserts before `var app = builder.Build();` (hosted) or `await builder.Build().RunAsync();` (WebAssembly); other bootstrapping shapes must be edited manually. |
+| The `.Client` project of a Blazor Web App was not updated | Either `--project` pointed at the client instead of the server project, or the client had never been restored so `dotnet package list` could not inspect it. Target the server project, build or restore the solution once, and re-run the scaffolder (it is idempotent). The log should then contain `Detected Blazor WebAssembly project via package reference`. |
+
+---
+
+## Implementation Notes
+
+Source locations (see [CONTRIBUTING.md](../CONTRIBUTING.md) for the general layout):
+
+- Registration: `src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs` (`blazor-igniteui`)
+- Options / strings: `AspNet/Commands/AspNetOptions.cs`, `AspNet/Commands/AspnetStrings.cs`, `AspNet/Common/Constants.cs`
+- Packages: `AspNet/Common/PackageConstants.cs` (`IgniteUIPackages`)
+- Steps: `AspNet/ScaffoldSteps/ValidateIgniteUIBlazorStep.cs`, `AddRazorImportsStep.cs`, `AddIgniteUIThemeStylesheetStep.cs`
+  (plus the shared `DetectBlazorWasmStep`, `WrappedAddPackagesStep` and `WrappedCodeModificationStep`)
+- Builder extensions: `AspNet/Extensions/IgniteUIBlazorScaffolderBuilderExtensions.cs`
+- Helper / model / settings: `AspNet/Helpers/IgniteUIBlazorHelper.cs`, `AspNet/Models/IgniteUIBlazorModel.cs`,
+  `AspNet/ScaffoldSteps/Settings/IgniteUIBlazorSettings.cs`
+- Code modification configs: `AspNet/Templates/{tfm}/CodeModificationConfigs/igniteUIBlazorChanges.json` and
+  `igniteUIBlazorWasmChanges.json` for `net8.0`, `net9.0`, `net10.0` and `net11.0`
+- Tests: `test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/**/*IgniteUI*`, `AspNet/ScaffoldSteps/AddRazorImportsStepTests.cs`
+  and `AspNet/Integration/Blazor/BlazorIgniteUI*IntegrationTests.cs`

--- a/eng/pipelines/scaffold-integration-matrix.yml
+++ b/eng/pipelines/scaffold-integration-matrix.yml
@@ -95,7 +95,7 @@ jobs:
         _Family: 'apicontroller|minimalapi'
         _FamilyLabel: API
       Blazor:
-        _Family: 'blazor-crud|blazor-empty'
+        _Family: 'blazor-crud|blazor-empty|blazor-igniteui'
         _FamilyLabel: Blazor
       MVC:
         _Family: 'mvccontroller|mvccontroller-crud|razorviews|razorview-empty|area'

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 typeof(AddAspNetConnectionStringStep),
                 typeof(AddDbSetToExistingContextStep),
                 typeof(AddFileStep),
+                typeof(AddIgniteUIThemeStylesheetStep),
+                typeof(AddRazorImportsStep),
                 typeof(AreaScaffolderStep),
                 typeof(DetectBlazorWasmStep),
                 typeof(DotnetNewScaffolderStep),
@@ -38,6 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 typeof(ValidateEfControllerStep),
                 typeof(ValidateEntraIdStep),
                 typeof(ValidateIdentityStep),
+                typeof(ValidateIgniteUIBlazorStep),
                 typeof(ValidateMinimalApiStep),
                 typeof(ValidateRazorPagesStep),
                 typeof(ValidateViewsStep),
@@ -371,6 +374,32 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                     .WithEntraIdCodeChangeStep()
                     .WithEntraIdBlazorWasmCodeChangeStep()
                     .WithEntraIdTextTemplatingStep();
+
+            _builder.AddScaffolder(ScaffolderCatagory.AspNet, AspnetStrings.Blazor.IgniteUI)
+                .WithDisplayName(AspnetStrings.Blazor.IgniteUIDisplayName)
+                .WithCategory(AspnetStrings.Catagories.Blazor)
+                .WithDescription(AspnetStrings.Blazor.IgniteUIDescription)
+                .WithExample(AspnetStrings.Blazor.IgniteUIExample1, AspnetStrings.Blazor.IgniteUIExample1Description)
+                .WithExample(AspnetStrings.Blazor.IgniteUIExample2, AspnetStrings.Blazor.IgniteUIExample2Description)
+                .WithOptions([options.Project, options.IgniteUIPackage, options.IgniteUITheme, options.IgniteUIThemeVariant, options.Prerelease])
+                .WithStep<ValidateIgniteUIBlazorStep>(config =>
+                {
+                    var step = config.Step;
+                    var context = config.Context;
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Package = context.GetOptionResult(options.IgniteUIPackage);
+                    step.Theme = context.GetOptionResult(options.IgniteUITheme);
+                    step.ThemeVariant = context.GetOptionResult(options.IgniteUIThemeVariant);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                })
+                .WithIgniteUIBlazorDetectBlazorWasmStep()
+                .WithIgniteUIBlazorAddPackagesStep()
+                .WithIgniteUIBlazorWasmAddPackagesStep()
+                .WithIgniteUIBlazorCodeChangeStep()
+                .WithIgniteUIBlazorWasmCodeChangeStep()
+                .WithIgniteUIBlazorImportsStep()
+                .WithIgniteUIBlazorWasmImportsStep()
+                .WithIgniteUIBlazorThemeStylesheetStep();
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
@@ -30,6 +30,9 @@ internal class AspNetOptions
     public ScaffolderOption<bool> Views { get; }
     public ScaffolderOption<bool> Overwrite { get; }
     public ScaffolderOption<bool> UseExistingApplication { get; }
+    public ScaffolderOption<string> IgniteUIPackage { get; }
+    public ScaffolderOption<string> IgniteUITheme { get; }
+    public ScaffolderOption<string> IgniteUIThemeVariant { get; }
 
     private ScaffolderOption<string>? _username = null;
     private ScaffolderOption<string>? _tenantId = null;
@@ -201,6 +204,36 @@ internal class AspNetOptions
             CliOption = Constants.CliOptions.UseExistingApplicationOption,
             Required = true,
             PickerType = InteractivePickerType.YesNo
+        };
+
+        IgniteUIPackage = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.IgniteUIPackage.DisplayName,
+            CliOption = Constants.CliOptions.IgniteUIPackageOption,
+            Description = AspnetStrings.Options.IgniteUIPackage.Description,
+            Required = true,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = IgniteUIBlazorHelper.PackageOptions
+        };
+
+        IgniteUITheme = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.IgniteUITheme.DisplayName,
+            CliOption = Constants.CliOptions.IgniteUIThemeOption,
+            Description = AspnetStrings.Options.IgniteUITheme.Description,
+            Required = false,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = IgniteUIBlazorHelper.Themes
+        };
+
+        IgniteUIThemeVariant = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.IgniteUIThemeVariant.DisplayName,
+            CliOption = Constants.CliOptions.IgniteUIThemeVariantOption,
+            Description = AspnetStrings.Options.IgniteUIThemeVariant.Description,
+            Required = false,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = IgniteUIBlazorHelper.ThemeVariants
         };
     }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspnetStrings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspnetStrings.cs
@@ -26,6 +26,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
             internal const string CrudExample1Description = "Generate all CRUD pages for Product model:";
             internal const string CrudExample2 = "dotnet scaffold aspnet blazor-crud --project C:/MyApp/MyApp.csproj --model Customer --data-context ShopContext --database-provider PostgreSQL --page List,Edit";
             internal const string CrudExample2Description = "Generate only List and Edit pages with PostgreSQL:";
+
+            internal const string IgniteUI = "blazor-igniteui";
+            internal const string IgniteUIDisplayName = "Ignite UI for Blazor";
+            internal const string IgniteUIDescription = "Add Ignite UI for Blazor (IgniteUI.Blazor.Lite and/or IgniteUI.Blazor.GridLite, MIT licensed) to a Blazor project: installs the NuGet package(s), registers the services, imports the IgniteUI.Blazor.Controls namespace and links a theme stylesheet in the host page.";
+            internal const string IgniteUIExample1 = "dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp.csproj --package All";
+            internal const string IgniteUIExample1Description = "Add IgniteUI.Blazor.Lite and IgniteUI.Blazor.GridLite with the default light bootstrap theme:";
+            internal const string IgniteUIExample2 = "dotnet scaffold aspnet blazor-igniteui --project C:/MyBlazorApp/MyBlazorApp.csproj --package GridLite --theme material --theme-variant dark";
+            internal const string IgniteUIExample2Description = "Add only the IgniteUI.Blazor.GridLite grid with the dark material theme:";
         }
 
         internal class RazorView
@@ -263,6 +271,24 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands
             {
                 internal const string DisplayName = "Select Existing Application";
                 internal const string Description = "Select existing application";
+            }
+
+            internal static class IgniteUIPackage
+            {
+                internal const string DisplayName = "Ignite UI package(s)";
+                internal const string Description = "Ignite UI for Blazor package(s) to add: 'Lite' (IgniteUI.Blazor.Lite core UI components), 'GridLite' (IgniteUI.Blazor.GridLite lightweight grid) or 'All' (both).";
+            }
+
+            internal static class IgniteUITheme
+            {
+                internal const string DisplayName = "Ignite UI theme";
+                internal const string Description = "Ignite UI theme stylesheet to link in the host page: bootstrap (default), material, fluent or indigo.";
+            }
+
+            internal static class IgniteUIThemeVariant
+            {
+                internal const string DisplayName = "Ignite UI theme variant";
+                internal const string Description = "Variant of the Ignite UI theme stylesheet to link: light (default) or dark.";
             }
         }
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/Constants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/Constants.cs
@@ -45,6 +45,10 @@ internal class Constants
         public const string TenantIdOption = "--tenantId";
         public const string UseExistingApplicationOption = "--use-existing-application";
         public const string ApplicationIdOption = "--applicationId";
+        //ignite ui for blazor options
+        public const string IgniteUIPackageOption = "--package";
+        public const string IgniteUIThemeOption = "--theme";
+        public const string IgniteUIThemeVariantOption = "--theme-variant";
     }
 
     /// <summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
@@ -79,4 +79,14 @@ internal class PackageConstants
         public static readonly Package AspNetCoreAuthenticationOpenIdConnectPackage = new("Microsoft.AspNetCore.Authentication.OpenIdConnect", IsVersionRequired: true);
         public static readonly Package MicrosoftIdentityWebPackage = new("Microsoft.Identity.Web");
     }
+
+    /// <summary>
+    /// Constants for Ignite UI for Blazor (Infragistics, MIT licensed) NuGet package names.
+    /// These packages are not versioned in lockstep with .NET, so the latest stable version is installed.
+    /// </summary>
+    public static class IgniteUIPackages
+    {
+        public static readonly Package IgniteUIBlazorLitePackage = new("IgniteUI.Blazor.Lite");
+        public static readonly Package IgniteUIBlazorGridLitePackage = new("IgniteUI.Blazor.GridLite");
+    }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IgniteUIBlazorScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IgniteUIBlazorScaffolderBuilderExtensions.cs
@@ -1,0 +1,271 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Helpers;
+using Microsoft.DotNet.Scaffolding.Core.Model;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Internal;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
+
+namespace Microsoft.DotNet.Scaffolding.Core.Hosting;
+
+/// <summary>
+/// Provides extension methods for <see cref="IScaffoldBuilder"/> to add Ignite UI for Blazor scaffolding steps.
+/// The steps cover the project passed via '--project' and, for Blazor Web Apps with a WebAssembly client
+/// project (detected by <see cref="DetectBlazorWasmStep"/>), the client project as well.
+/// </summary>
+internal static class IgniteUIBlazorScaffolderBuilderExtensions
+{
+    /// <summary>Code modification config for ASP.NET Core hosted Blazor projects (Blazor Web App / Blazor Server).</summary>
+    internal const string CodeModificationConfigFileName = "igniteUIBlazorChanges.json";
+    /// <summary>Code modification config for Blazor WebAssembly projects (standalone or the Web App client project).</summary>
+    internal const string WasmCodeModificationConfigFileName = "igniteUIBlazorWasmChanges.json";
+
+    /// <summary>
+    /// Adds a step that detects whether the project references a Blazor WebAssembly client project.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorDetectBlazorWasmStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<DetectBlazorWasmStep>(config =>
+        {
+            var model = GetModel(config.Context);
+            config.Step.ProjectPath = model.ProjectPath;
+            // A failure to enumerate project references must not abort the scaffolder.
+            config.Step.ContinueOnError = true;
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that installs the selected Ignite UI NuGet package(s) into the project.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorAddPackagesStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<WrappedAddPackagesStep>(config =>
+        {
+            var step = config.Step;
+            var model = GetModel(config.Context);
+            var settings = GetSettings(config.Context);
+            step.ProjectPath = model.ProjectPath;
+            step.Prerelease = settings.Prerelease;
+            step.Packages = GetPackages(model);
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that installs the selected Ignite UI NuGet package(s) into the Blazor WebAssembly client
+    /// project of a Blazor Web App. Skipped when no client project was detected.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorWasmAddPackagesStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<WrappedAddPackagesStep>(config =>
+        {
+            var step = config.Step;
+            if (!TryGetClientProjectPath(config.Context, out var clientProjectPath))
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            var model = GetModel(config.Context);
+            var settings = GetSettings(config.Context);
+            step.ProjectPath = clientProjectPath;
+            step.Prerelease = settings.Prerelease;
+            step.Packages = GetPackages(model);
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that registers 'builder.Services.AddIgniteUIBlazor()' in the project's Program.cs.
+    /// Skipped when only IgniteUI.Blazor.GridLite is added, since GridLite needs no service registration.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorCodeChangeStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<WrappedCodeModificationStep>(config =>
+        {
+            var step = config.Step;
+            var model = GetModel(config.Context);
+            if (!model.RequiresServiceRegistration)
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            var configFileName = model.IsWebAssemblyProject ? WasmCodeModificationConfigFileName : CodeModificationConfigFileName;
+            if (!TryConfigureCodeModificationStep(step, config.Context, model.ProjectPath, configFileName, model.ProjectInfo.CodeChangeOptions))
+            {
+                step.SkipStep = true;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that registers 'builder.Services.AddIgniteUIBlazor()' in the Program.cs of the Blazor
+    /// WebAssembly client project of a Blazor Web App. Skipped when no client project was detected or when
+    /// only IgniteUI.Blazor.GridLite is added.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorWasmCodeChangeStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<WrappedCodeModificationStep>(config =>
+        {
+            var step = config.Step;
+            var model = GetModel(config.Context);
+            if (!model.RequiresServiceRegistration || !TryGetClientProjectPath(config.Context, out var clientProjectPath))
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            if (!TryConfigureCodeModificationStep(step, config.Context, clientProjectPath, WasmCodeModificationConfigFileName, model.ProjectInfo.CodeChangeOptions))
+            {
+                step.SkipStep = true;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that imports the 'IgniteUI.Blazor.Controls' namespace in the project's _Imports.razor.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorImportsStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<AddRazorImportsStep>(config =>
+        {
+            var model = GetModel(config.Context);
+            config.Step.ImportsFilePath = model.ImportsFilePath;
+            config.Step.Namespaces = [IgniteUIBlazorHelper.ControlsNamespace];
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that imports the 'IgniteUI.Blazor.Controls' namespace in the _Imports.razor of the Blazor
+    /// WebAssembly client project of a Blazor Web App. Skipped when no client project was detected.
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorWasmImportsStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<AddRazorImportsStep>(config =>
+        {
+            var step = config.Step;
+            if (!TryGetClientProjectPath(config.Context, out var clientProjectPath))
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            var clientProjectDirectory = Path.GetDirectoryName(clientProjectPath);
+            if (string.IsNullOrEmpty(clientProjectDirectory))
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            step.ImportsFilePath = GetClientImportsFilePath(clientProjectDirectory);
+            step.Namespaces = [IgniteUIBlazorHelper.ControlsNamespace];
+        });
+    }
+
+    /// <summary>
+    /// Adds a step that links the selected Ignite UI theme stylesheet in the project's host page.
+    /// Skipped when no host page could be resolved (guidance is logged by <see cref="ValidateIgniteUIBlazorStep"/>).
+    /// </summary>
+    public static IScaffoldBuilder WithIgniteUIBlazorThemeStylesheetStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<AddIgniteUIThemeStylesheetStep>(config =>
+        {
+            var step = config.Step;
+            var model = GetModel(config.Context);
+            if (string.IsNullOrEmpty(model.HostPagePath))
+            {
+                step.SkipStep = true;
+                return;
+            }
+
+            step.HostPagePath = model.HostPagePath;
+            step.StylesheetPath = model.StylesheetPath;
+        });
+    }
+
+    /// <summary>
+    /// Returns the NuGet packages to install for the given model.
+    /// </summary>
+    internal static List<Package> GetPackages(IgniteUIBlazorModel model)
+    {
+        List<Package> packages = [];
+        if (model.IncludeLite)
+        {
+            packages.Add(PackageConstants.IgniteUIPackages.IgniteUIBlazorLitePackage);
+        }
+
+        if (model.IncludeGridLite)
+        {
+            packages.Add(PackageConstants.IgniteUIPackages.IgniteUIBlazorGridLitePackage);
+        }
+
+        return packages;
+    }
+
+    /// <summary>
+    /// Resolves the _Imports.razor of a Blazor WebAssembly client project (root '_Imports.razor' by convention,
+    /// 'Components/_Imports.razor' when that is what the project uses).
+    /// </summary>
+    internal static string GetClientImportsFilePath(string clientProjectDirectory)
+    {
+        var rootImports = Path.Combine(clientProjectDirectory, "_Imports.razor");
+        var componentsImports = Path.Combine(clientProjectDirectory, "Components", "_Imports.razor");
+        return !File.Exists(rootImports) && File.Exists(componentsImports) ? componentsImports : rootImports;
+    }
+
+    private static bool TryConfigureCodeModificationStep(WrappedCodeModificationStep step, ScaffolderContext context, string projectPath, string configFileName, IList<string>? codeChangeOptions)
+    {
+        string targetFrameworkFolder = TargetFrameworkHelpers.GetTargetFrameworkFolder(projectPath);
+        string? codeModificationFilePath = GlobalToolFileFinder.FindCodeModificationConfigFile(configFileName, System.Reflection.Assembly.GetExecutingAssembly(), targetFrameworkFolder);
+        if (string.IsNullOrEmpty(codeModificationFilePath))
+        {
+            return false;
+        }
+
+        step.CodeModifierConfigPath = codeModificationFilePath;
+        step.ProjectPath = projectPath;
+        step.CodeChangeOptions = codeChangeOptions ?? [];
+        if (context.Properties.TryGetValue(Internal.Constants.StepConstants.CodeModifierProperties, out var codeModifierPropertiesObj) &&
+            codeModifierPropertiesObj is Dictionary<string, string> codeModifierProperties)
+        {
+            foreach (var kvp in codeModifierProperties)
+            {
+                step.CodeModifierProperties.TryAdd(kvp.Key, kvp.Value);
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetClientProjectPath(ScaffolderContext context, out string clientProjectPath)
+    {
+        clientProjectPath = string.Empty;
+        if (context.Properties.TryGetValue("IsBlazorWasmProject", out var isBlazorWasm) && isBlazorWasm is true &&
+            context.Properties.TryGetValue("BlazorWasmClientProjectPath", out var clientProjectPathObj) &&
+            clientProjectPathObj is string path && !string.IsNullOrEmpty(path))
+        {
+            clientProjectPath = path;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IgniteUIBlazorModel GetModel(ScaffolderContext context)
+    {
+        context.Properties.TryGetValue(nameof(IgniteUIBlazorModel), out var modelObj);
+        return modelObj as IgniteUIBlazorModel ??
+            throw new InvalidOperationException("missing 'IgniteUIBlazorModel' in 'ScaffolderContext.Properties'");
+    }
+
+    private static IgniteUIBlazorSettings GetSettings(ScaffolderContext context)
+    {
+        context.Properties.TryGetValue(nameof(IgniteUIBlazorSettings), out var settingsObj);
+        return settingsObj as IgniteUIBlazorSettings ??
+            throw new InvalidOperationException("missing 'IgniteUIBlazorSettings' in 'ScaffolderContext.Properties'");
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/IgniteUIBlazorHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/IgniteUIBlazorHelper.cs
@@ -1,0 +1,231 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+
+/// <summary>
+/// Helper methods and constants for the Ignite UI for Blazor scaffolder
+/// (IgniteUI.Blazor.Lite and IgniteUI.Blazor.GridLite).
+/// </summary>
+internal static class IgniteUIBlazorHelper
+{
+    /// <summary>Picker value that adds only the IgniteUI.Blazor.Lite package.</summary>
+    internal const string LitePackageOption = "Lite";
+    /// <summary>Picker value that adds only the IgniteUI.Blazor.GridLite package.</summary>
+    internal const string GridLitePackageOption = "GridLite";
+    /// <summary>Picker value that adds both packages.</summary>
+    internal const string AllPackagesOption = "All";
+    /// <summary>All valid values for the '--package' option.</summary>
+    internal static readonly List<string> PackageOptions = [LitePackageOption, GridLitePackageOption, AllPackagesOption];
+
+    /// <summary>Default theme.</summary>
+    internal const string DefaultTheme = "bootstrap";
+    /// <summary>All themes shipped by Ignite UI for Blazor.</summary>
+    internal static readonly List<string> Themes = [DefaultTheme, "material", "fluent", "indigo"];
+
+    /// <summary>Default theme variant.</summary>
+    internal const string DefaultThemeVariant = "light";
+    /// <summary>All theme variants shipped by Ignite UI for Blazor.</summary>
+    internal static readonly List<string> ThemeVariants = [DefaultThemeVariant, "dark"];
+
+    /// <summary>The namespace that must be imported in _Imports.razor (and Program.cs for service registration).</summary>
+    internal const string ControlsNamespace = "IgniteUI.Blazor.Controls";
+    /// <summary>Static web asset root of the IgniteUI.Blazor.Lite package.</summary>
+    internal const string LiteStaticAssetsRoot = "_content/IgniteUI.Blazor";
+    /// <summary>Static web asset root of the IgniteUI.Blazor.GridLite package.</summary>
+    internal const string GridLiteStaticAssetsRoot = "_content/IgniteUI.Blazor.GridLite";
+
+    /// <summary>
+    /// Matches any Ignite UI theme stylesheet path (Lite or GridLite, any theme, any variant) so an
+    /// existing link can be detected and swapped instead of linking two themes at once.
+    /// </summary>
+    internal static readonly Regex ThemeStylesheetRegex = new(
+        @"_content/IgniteUI\.Blazor(?:\.GridLite)?/(?:css/)?themes/(?:light|dark)/(?:bootstrap|material|fluent|indigo)\.css",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns true when the given '--package' value is one of <see cref="PackageOptions"/> (case-insensitive).
+    /// </summary>
+    internal static bool IsValidPackageOption(string? package)
+        => !string.IsNullOrEmpty(package) && PackageOptions.Contains(package, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when the IgniteUI.Blazor.Lite package is part of the given '--package' selection.
+    /// </summary>
+    internal static bool IncludesLite(string? package)
+        => string.Equals(package, LitePackageOption, StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(package, AllPackagesOption, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when the IgniteUI.Blazor.GridLite package is part of the given '--package' selection.
+    /// </summary>
+    internal static bool IncludesGridLite(string? package)
+        => string.Equals(package, GridLitePackageOption, StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(package, AllPackagesOption, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Normalizes the theme name; falls back to <see cref="DefaultTheme"/> when null, empty or unknown.
+    /// </summary>
+    internal static string NormalizeTheme(string? theme)
+        => Themes.FirstOrDefault(t => t.Equals(theme, StringComparison.OrdinalIgnoreCase)) ?? DefaultTheme;
+
+    /// <summary>
+    /// Normalizes the theme variant; falls back to <see cref="DefaultThemeVariant"/> when null, empty or unknown.
+    /// </summary>
+    internal static string NormalizeThemeVariant(string? variant)
+        => ThemeVariants.FirstOrDefault(v => v.Equals(variant, StringComparison.OrdinalIgnoreCase)) ?? DefaultThemeVariant;
+
+    /// <summary>
+    /// Builds the project-relative path of the theme stylesheet to link.
+    /// The GridLite stylesheet is only used when the project uses GridLite exclusively; whenever
+    /// IgniteUI.Blazor.Lite is (or becomes) referenced, the main theme stylesheet must be used instead.
+    /// </summary>
+    /// <param name="useLiteStylesheet">True to link the IgniteUI.Blazor.Lite theme; false for the GridLite-only theme.</param>
+    /// <param name="theme">Theme name (see <see cref="Themes"/>).</param>
+    /// <param name="variant">Theme variant (see <see cref="ThemeVariants"/>).</param>
+    internal static string GetThemeStylesheetPath(bool useLiteStylesheet, string? theme, string? variant)
+    {
+        var normalizedTheme = NormalizeTheme(theme);
+        var normalizedVariant = NormalizeThemeVariant(variant);
+        return useLiteStylesheet
+            ? $"{LiteStaticAssetsRoot}/themes/{normalizedVariant}/{normalizedTheme}.css"
+            : $"{GridLiteStaticAssetsRoot}/css/themes/{normalizedVariant}/{normalizedTheme}.css";
+    }
+
+    /// <summary>
+    /// Returns true when the project file already references the IgniteUI.Blazor.Lite package.
+    /// </summary>
+    internal static bool ProjectReferencesLitePackage(string? projectFileContent)
+    {
+        if (string.IsNullOrEmpty(projectFileContent))
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(projectFileContent,
+            @"<PackageReference\s+[^>]*Include\s*=\s*""IgniteUI\.Blazor\.Lite""",
+            RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>
+    /// Detects whether the project is a standalone Blazor WebAssembly project, i.e. uses the
+    /// 'Microsoft.NET.Sdk.BlazorWebAssembly' SDK or bootstraps with 'WebAssemblyHostBuilder'.
+    /// </summary>
+    /// <param name="projectFileContent">The .csproj content.</param>
+    /// <param name="programFileContent">The Program.cs content, or null when the file does not exist.</param>
+    internal static bool IsWebAssemblyProject(string? projectFileContent, string? programFileContent)
+    {
+        if (!string.IsNullOrEmpty(projectFileContent) &&
+            Regex.IsMatch(projectFileContent,
+                @"Sdk\s*=\s*""Microsoft\.NET\.Sdk\.BlazorWebAssembly""|<Sdk\s+Name\s*=\s*""Microsoft\.NET\.Sdk\.BlazorWebAssembly""",
+                RegexOptions.IgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrEmpty(programFileContent) &&
+               programFileContent.Contains("WebAssemblyHostBuilder", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Host page candidates, in priority order, relative to the project directory.
+    /// </summary>
+    internal static readonly string[] HostPageCandidates =
+    [
+        Path.Combine("Components", "App.razor"),     // Blazor Web App (.NET 8+)
+        Path.Combine("Pages", "_Layout.cshtml"),     // Blazor Server (.NET 6 layout page)
+        Path.Combine("Pages", "_Host.cshtml"),       // Blazor Server (.NET 7 and earlier)
+        Path.Combine("wwwroot", "index.html"),       // Blazor WebAssembly standalone / Blazor Hybrid
+    ];
+
+    /// <summary>
+    /// Finds the page that hosts the document &lt;head&gt; for the given project directory.
+    /// Returns null when no known host page containing a &lt;/head&gt; tag exists.
+    /// </summary>
+    internal static string? FindHostPage(IFileSystem fileSystem, string projectDirectory)
+    {
+        foreach (var candidate in HostPageCandidates)
+        {
+            var path = Path.Combine(projectDirectory, candidate);
+            if (fileSystem.FileExists(path) && ContainsHeadClosingTag(fileSystem.ReadAllText(path)))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the _Imports.razor that should receive the Ignite UI using directive. Prefers
+    /// 'Components/_Imports.razor' (Blazor Web App), then the project root '_Imports.razor'
+    /// (Blazor WebAssembly / Blazor Server). When neither exists, returns the path where a new
+    /// file should be created: under 'Components' if that folder exists, otherwise the project root.
+    /// </summary>
+    internal static string GetImportsFilePath(IFileSystem fileSystem, string projectDirectory)
+    {
+        var componentsImports = Path.Combine(projectDirectory, "Components", "_Imports.razor");
+        if (fileSystem.FileExists(componentsImports))
+        {
+            return componentsImports;
+        }
+
+        var rootImports = Path.Combine(projectDirectory, "_Imports.razor");
+        if (fileSystem.FileExists(rootImports))
+        {
+            return rootImports;
+        }
+
+        return fileSystem.DirectoryExists(Path.Combine(projectDirectory, "Components"))
+            ? componentsImports
+            : rootImports;
+    }
+
+    /// <summary>
+    /// Returns true when the given host page content contains a closing &lt;/head&gt; tag.
+    /// </summary>
+    internal static bool ContainsHeadClosingTag(string? content)
+        => !string.IsNullOrEmpty(content) && content.Contains("</head>", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when a .razor host page already uses the fingerprinted static asset collection
+    /// (<c>@Assets["..."]</c>, .NET 9+), in which case the new link should use the same syntax.
+    /// </summary>
+    internal static bool UsesAssetsCollection(string? hostPagePath, string? content)
+        => !string.IsNullOrEmpty(hostPagePath) &&
+           hostPagePath.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) &&
+           !string.IsNullOrEmpty(content) &&
+           content.Contains("@Assets[", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Builds the &lt;link&gt; element for the theme stylesheet.
+    /// </summary>
+    internal static string BuildStylesheetLink(string stylesheetPath, bool useAssetsCollection)
+        => useAssetsCollection
+            ? $"<link rel=\"stylesheet\" href=\"@Assets[\"{stylesheetPath}\"]\" />"
+            : $"<link href=\"{stylesheetPath}\" rel=\"stylesheet\" />";
+
+    /// <summary>
+    /// Returns true when the Program.cs of a Blazor Web App registers an interactive render mode
+    /// (server, WebAssembly or both). Ignite UI components render nothing usable under static SSR.
+    /// </summary>
+    internal static bool HasInteractiveRenderModeServices(string? programFileContent)
+        => !string.IsNullOrEmpty(programFileContent) &&
+           (programFileContent.Contains("AddInteractiveServerComponents", StringComparison.Ordinal) ||
+            programFileContent.Contains("AddInteractiveWebAssemblyComponents", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Returns true when the given razor content declares a render mode (<c>@rendermode</c> directive
+    /// or a <c>@rendermode="..."</c> attribute, e.g. on &lt;Routes /&gt; in App.razor).
+    /// </summary>
+    internal static bool DeclaresRenderMode(string? razorContent)
+        => !string.IsNullOrEmpty(razorContent) && razorContent.Contains("@rendermode", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Detects the dominant line ending of the given text ("\r\n" or "\n").
+    /// </summary>
+    internal static string DetectLineEnding(string? content)
+        => !string.IsNullOrEmpty(content) && content.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Models/IgniteUIBlazorModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Models/IgniteUIBlazorModel.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+
+/// <summary>
+/// Represents the model for Ignite UI for Blazor scaffolding, containing the resolved project
+/// layout (host page, _Imports.razor), the selected packages and the theme stylesheet to link.
+/// </summary>
+internal class IgniteUIBlazorModel
+{
+    /// <summary>
+    /// Gets the project information.
+    /// </summary>
+    public required ProjectInfo ProjectInfo { get; init; }
+    /// <summary>
+    /// Gets the path to the project file (.csproj).
+    /// </summary>
+    public required string ProjectPath { get; init; }
+    /// <summary>
+    /// Gets the project directory.
+    /// </summary>
+    public required string BaseOutputPath { get; init; }
+    /// <summary>
+    /// Gets a value indicating whether the IgniteUI.Blazor.Lite package is being added.
+    /// </summary>
+    public required bool IncludeLite { get; init; }
+    /// <summary>
+    /// Gets a value indicating whether the IgniteUI.Blazor.GridLite package is being added.
+    /// </summary>
+    public required bool IncludeGridLite { get; init; }
+    /// <summary>
+    /// Gets the selected theme name ('bootstrap', 'material', 'fluent' or 'indigo').
+    /// </summary>
+    public required string Theme { get; init; }
+    /// <summary>
+    /// Gets the selected theme variant ('light' or 'dark').
+    /// </summary>
+    public required string ThemeVariant { get; init; }
+    /// <summary>
+    /// Gets the project-relative stylesheet path to link, e.g. '_content/IgniteUI.Blazor/themes/light/bootstrap.css'.
+    /// </summary>
+    public required string StylesheetPath { get; init; }
+    /// <summary>
+    /// Gets a value indicating whether the target project is a standalone Blazor WebAssembly project
+    /// (as opposed to a Blazor Web App / Blazor Server project hosted by ASP.NET Core).
+    /// </summary>
+    public required bool IsWebAssemblyProject { get; init; }
+    /// <summary>
+    /// Gets the resolved host page that contains the &lt;head&gt; element (Components/App.razor,
+    /// Pages/_Host.cshtml, Pages/_Layout.cshtml or wwwroot/index.html), or null when none was found.
+    /// </summary>
+    public string? HostPagePath { get; init; }
+    /// <summary>
+    /// Gets the _Imports.razor file that should receive the '@using IgniteUI.Blazor.Controls' directive.
+    /// The file is created when it does not exist yet.
+    /// </summary>
+    public required string ImportsFilePath { get; init; }
+    /// <summary>
+    /// Gets a value indicating whether 'builder.Services.AddIgniteUIBlazor()' must be registered.
+    /// Only the IgniteUI.Blazor.Lite package requires service registration; GridLite does not.
+    /// </summary>
+    public bool RequiresServiceRegistration => IncludeLite;
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddIgniteUIThemeStylesheetStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddIgniteUIThemeStylesheetStep.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Core.Steps;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Telemetry;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+
+/// <summary>
+/// Scaffold step that links an Ignite UI theme stylesheet in the host page of a Blazor application
+/// (Components/App.razor, Pages/_Host.cshtml, Pages/_Layout.cshtml or wwwroot/index.html).
+/// <list type="bullet">
+/// <item>When the requested stylesheet is already linked, nothing changes.</item>
+/// <item>When a different Ignite UI theme is linked, its href is swapped so only one theme is active.</item>
+/// <item>Otherwise a &lt;link&gt; element is inserted after the last existing &lt;link&gt; in &lt;head&gt;
+/// (or right before &lt;/head&gt; when there is none), using <c>@Assets["..."]</c> when the .razor host page already does.</item>
+/// </list>
+/// The edit is applied directly on disk because wwwroot/index.html is not part of the Roslyn workspace.
+/// </summary>
+internal class AddIgniteUIThemeStylesheetStep : ScaffoldStep
+{
+    /// <summary>
+    /// Gets or sets the full path of the host page that contains the &lt;head&gt; element.
+    /// </summary>
+    public required string HostPagePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the project-relative stylesheet path, e.g. '_content/IgniteUI.Blazor/themes/light/bootstrap.css'.
+    /// </summary>
+    public required string StylesheetPath { get; set; }
+
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    private readonly ITelemetryService _telemetryService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddIgniteUIThemeStylesheetStep"/> class.
+    /// </summary>
+    public AddIgniteUIThemeStylesheetStep(ILogger<AddIgniteUIThemeStylesheetStep> logger, IFileSystem fileSystem, ITelemetryService telemetryService)
+    {
+        _logger = logger;
+        _fileSystem = fileSystem;
+        _telemetryService = telemetryService;
+        ContinueOnError = true;
+    }
+
+    /// <inheritdoc />
+    public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
+    {
+        bool result = Execute();
+        _telemetryService.TrackEvent(new WrappedStepTelemetryEvent(nameof(AddIgniteUIThemeStylesheetStep), context.Scaffolder.DisplayName, result));
+        return Task.FromResult(result);
+    }
+
+    private bool Execute()
+    {
+        if (string.IsNullOrEmpty(HostPagePath) || string.IsNullOrEmpty(StylesheetPath))
+        {
+            _logger.LogError("Host page path or stylesheet path was not provided.");
+            return false;
+        }
+
+        if (!_fileSystem.FileExists(HostPagePath))
+        {
+            _logger.LogError($"Host page '{HostPagePath}' was not found.");
+            return false;
+        }
+
+        var fileName = Path.GetFileName(HostPagePath);
+        var content = _fileSystem.ReadAllText(HostPagePath) ?? string.Empty;
+        var updatedContent = ApplyStylesheetLink(HostPagePath, content, StylesheetPath, out var outcome);
+
+        switch (outcome)
+        {
+            case StylesheetLinkOutcome.AlreadyLinked:
+                _logger.LogInformation($"'{fileName}' already links '{StylesheetPath}'.");
+                return true;
+            case StylesheetLinkOutcome.NoHeadElement:
+                _logger.LogWarning($"Could not find a </head> element in '{fileName}'. Add the following line to the <head> of your host page manually:");
+                _logger.LogWarning($"    {IgniteUIBlazorHelper.BuildStylesheetLink(StylesheetPath, useAssetsCollection: false)}");
+                return false;
+            case StylesheetLinkOutcome.Replaced:
+                _logger.LogInformation($"Updating the Ignite UI theme in '{fileName}' to '{StylesheetPath}'...");
+                break;
+            default:
+                _logger.LogInformation($"Linking '{StylesheetPath}' in '{fileName}'...");
+                break;
+        }
+
+        _fileSystem.WriteAllText(HostPagePath, updatedContent);
+        _logger.LogInformation("Done");
+        return true;
+    }
+
+    /// <summary>
+    /// Describes what <see cref="ApplyStylesheetLink"/> did to the host page content.
+    /// </summary>
+    internal enum StylesheetLinkOutcome
+    {
+        /// <summary>The requested stylesheet was already linked; content unchanged.</summary>
+        AlreadyLinked,
+        /// <summary>An existing Ignite UI theme link was swapped for the requested stylesheet.</summary>
+        Replaced,
+        /// <summary>A new &lt;link&gt; element was inserted into &lt;head&gt;.</summary>
+        Inserted,
+        /// <summary>No &lt;/head&gt; element was found; content unchanged.</summary>
+        NoHeadElement
+    }
+
+    /// <summary>
+    /// Returns the host page content with the theme stylesheet linked (see class remarks for the rules).
+    /// </summary>
+    /// <param name="hostPagePath">Path of the host page (used to decide on <c>@Assets</c> syntax).</param>
+    /// <param name="content">Current host page content.</param>
+    /// <param name="stylesheetPath">Project-relative stylesheet path to link.</param>
+    /// <param name="outcome">What was done to the content.</param>
+    internal static string ApplyStylesheetLink(string hostPagePath, string? content, string stylesheetPath, out StylesheetLinkOutcome outcome)
+    {
+        content ??= string.Empty;
+        if (content.Contains(stylesheetPath, StringComparison.OrdinalIgnoreCase))
+        {
+            outcome = StylesheetLinkOutcome.AlreadyLinked;
+            return content;
+        }
+
+        // A different Ignite UI theme is linked already: swap it so the app never loads two themes.
+        if (IgniteUIBlazorHelper.ThemeStylesheetRegex.IsMatch(content))
+        {
+            outcome = StylesheetLinkOutcome.Replaced;
+            return IgniteUIBlazorHelper.ThemeStylesheetRegex.Replace(content, stylesheetPath);
+        }
+
+        var headCloseIndex = content.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
+        if (headCloseIndex < 0)
+        {
+            outcome = StylesheetLinkOutcome.NoHeadElement;
+            return content;
+        }
+
+        var lineEnding = IgniteUIBlazorHelper.DetectLineEnding(content);
+        var useAssets = IgniteUIBlazorHelper.UsesAssetsCollection(hostPagePath, content);
+        var link = IgniteUIBlazorHelper.BuildStylesheetLink(stylesheetPath, useAssets);
+        var head = content.Substring(0, headCloseIndex);
+
+        // Prefer inserting right after the last <link ...> element inside <head>, matching its indentation.
+        // '\r?' keeps the match working for CRLF files: in .NET, '$' with Multiline only matches before '\n'.
+        var lastLink = Regex.Matches(head, @"^([ \t]*)<link\b[^>]*>[ \t]*\r?$", RegexOptions.Multiline | RegexOptions.IgnoreCase)
+            .Cast<Match>()
+            .LastOrDefault();
+        if (lastLink is not null)
+        {
+            var insertAt = lastLink.Index + lastLink.Length;
+            // include the line break that terminates the matched <link> line (if any)
+            if (insertAt < content.Length && content[insertAt] == '\r')
+            {
+                insertAt++;
+            }
+
+            if (insertAt < content.Length && content[insertAt] == '\n')
+            {
+                insertAt++;
+            }
+
+            outcome = StylesheetLinkOutcome.Inserted;
+            return content.Insert(insertAt, $"{lastLink.Groups[1].Value}{link}{lineEnding}");
+        }
+
+        // No <link> yet: insert on its own line right before </head>, indented one level deeper than </head>.
+        outcome = StylesheetLinkOutcome.Inserted;
+        var lineStart = content.LastIndexOf('\n', headCloseIndex) + 1;
+        var headPrefix = content.Substring(lineStart, headCloseIndex - lineStart);
+        if (string.IsNullOrWhiteSpace(headPrefix))
+        {
+            // </head> starts its own line: insert a full line above it.
+            return content.Insert(lineStart, $"{headPrefix}    {link}{lineEnding}");
+        }
+
+        // </head> shares a line with other markup (e.g. '<head>...</head>'): break the line before it.
+        return content.Insert(headCloseIndex, $"{lineEnding}    {link}{lineEnding}");
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddRazorImportsStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddRazorImportsStep.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Core.Steps;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Telemetry;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+
+/// <summary>
+/// Scaffold step that adds one or more <c>@using</c> directives to an <c>_Imports.razor</c> file.
+/// Directives that are already present are left untouched; the file is created when it does not exist.
+/// The edit is applied directly on disk so it works for any project layout (Blazor Web App server
+/// project, Blazor WebAssembly client project, Blazor Server) and does not depend on the Roslyn
+/// workspace exposing the razor file as an additional document.
+/// </summary>
+internal class AddRazorImportsStep : ScaffoldStep
+{
+    /// <summary>
+    /// Gets or sets the full path of the _Imports.razor file to update (created when missing).
+    /// </summary>
+    public required string ImportsFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespaces to import, e.g. 'IgniteUI.Blazor.Controls'.
+    /// </summary>
+    public required IList<string> Namespaces { get; set; }
+
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+    private readonly ITelemetryService _telemetryService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddRazorImportsStep"/> class.
+    /// </summary>
+    public AddRazorImportsStep(ILogger<AddRazorImportsStep> logger, IFileSystem fileSystem, ITelemetryService telemetryService)
+    {
+        _logger = logger;
+        _fileSystem = fileSystem;
+        _telemetryService = telemetryService;
+        ContinueOnError = true;
+    }
+
+    /// <inheritdoc />
+    public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
+    {
+        bool result = Execute();
+        _telemetryService.TrackEvent(new WrappedStepTelemetryEvent(nameof(AddRazorImportsStep), context.Scaffolder.DisplayName, result));
+        return Task.FromResult(result);
+    }
+
+    private bool Execute()
+    {
+        if (string.IsNullOrEmpty(ImportsFilePath))
+        {
+            _logger.LogError("No _Imports.razor path was provided.");
+            return false;
+        }
+
+        var namespaces = Namespaces?.Where(ns => !string.IsNullOrWhiteSpace(ns)).Select(ns => ns.Trim()).Distinct().ToList() ?? [];
+        if (namespaces.Count == 0)
+        {
+            return true;
+        }
+
+        var fileName = Path.GetFileName(ImportsFilePath);
+        if (!_fileSystem.FileExists(ImportsFilePath))
+        {
+            var directory = Path.GetDirectoryName(ImportsFilePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                _fileSystem.CreateDirectoryIfNotExists(directory);
+            }
+
+            _logger.LogInformation($"Creating '{fileName}'...");
+            var newContent = string.Join(Environment.NewLine, namespaces.Select(ns => $"@using {ns}")) + Environment.NewLine;
+            _fileSystem.WriteAllText(ImportsFilePath, newContent);
+            _logger.LogInformation("Done");
+            return true;
+        }
+
+        var content = _fileSystem.ReadAllText(ImportsFilePath) ?? string.Empty;
+        var updatedContent = AddUsings(content, namespaces, out var addedNamespaces);
+        if (addedNamespaces.Count == 0)
+        {
+            _logger.LogInformation($"'{fileName}' already imports {string.Join(", ", namespaces)}.");
+            return true;
+        }
+
+        _logger.LogInformation($"Updating '{fileName}'...");
+        _fileSystem.WriteAllText(ImportsFilePath, updatedContent);
+        _logger.LogInformation("Done");
+        return true;
+    }
+
+    /// <summary>
+    /// Appends <c>@using</c> directives for the namespaces that are not yet imported by <paramref name="content"/>.
+    /// </summary>
+    /// <param name="content">Existing _Imports.razor content.</param>
+    /// <param name="namespaces">Namespaces that must be imported.</param>
+    /// <param name="addedNamespaces">The namespaces that were appended.</param>
+    /// <returns>The updated content (unchanged when nothing had to be added).</returns>
+    internal static string AddUsings(string? content, IEnumerable<string> namespaces, out IList<string> addedNamespaces)
+    {
+        addedNamespaces = [];
+        content ??= string.Empty;
+        var lineEnding = IgniteUIBlazorHelper.DetectLineEnding(content);
+        var updated = content;
+
+        foreach (var ns in namespaces)
+        {
+            if (ContainsUsing(updated, ns))
+            {
+                continue;
+            }
+
+            if (updated.Length > 0 && !updated.EndsWith('\n'))
+            {
+                updated += lineEnding;
+            }
+
+            updated += $"@using {ns}{lineEnding}";
+            addedNamespaces.Add(ns);
+        }
+
+        return updated;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="content"/> already contains an <c>@using</c> directive for <paramref name="ns"/>.
+    /// </summary>
+    internal static bool ContainsUsing(string? content, string ns)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return false;
+        }
+
+        var pattern = $@"^\s*@using\s+{Regex.Escape(ns)}\s*;?\s*$";
+        return Regex.IsMatch(content, pattern, RegexOptions.Multiline);
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/DetectBlazorWasmStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/DetectBlazorWasmStep.cs
@@ -51,13 +51,12 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps
                     {
                         foreach (var reference in references)
                         {
-                            var projectInfo = ClassAnalyzers.GetProjectInfo(reference, _logger);
-
-                            var baseDirectory = Path.GetDirectoryName(ProjectPath);
-                            if (baseDirectory is not null)
+                            // This step was throwing in a non-wasm (e.g. Blazor Server) project when trying to list 
+                            // packages for the reference with a relative project path.
+                            // Changed it to use GetReferenceFullPath to ensure the full path is correctly resolved.
+                            var fullPath = GetReferenceFullPath(ProjectPath, reference);
+                            if (fullPath is not null)
                             {
-                                var fullPath = Path.GetFullPath(reference, baseDirectory);
-
                                 var projectRunner = DotnetCliRunner.CreateDotNet("package", new[] { "list", "--project", fullPath, "--format", "json" });
                                 int packageExitCode = projectRunner.ExecuteAndCaptureOutput(out var packageStdOut, out var packageStdErr);
 
@@ -114,6 +113,26 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps
             }
 
             return Task.FromResult(false);
+        }
+
+        /// <summary>
+        /// Resolves a project reference, as printed by 'dotnet reference list' (relative to the referencing project),
+        /// to a full path. The referencing project path may itself be relative to the current directory (e.g.
+        /// '--project .\App\App.csproj'), so it is fully qualified first: <see cref="Path.GetFullPath(string, string)"/>
+        /// throws when its base path is not fully qualified.
+        /// </summary>
+        /// <param name="projectPath">Path of the referencing project (absolute or relative to the current directory).</param>
+        /// <param name="reference">Referenced project path as listed by 'dotnet reference list'.</param>
+        /// <returns>The full path of the referenced project, or null when either input is empty.</returns>
+        internal static string? GetReferenceFullPath(string? projectPath, string? reference)
+        {
+            if (string.IsNullOrEmpty(projectPath) || string.IsNullOrEmpty(reference))
+            {
+                return null;
+            }
+
+            var baseDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+            return string.IsNullOrEmpty(baseDirectory) ? null : Path.GetFullPath(reference, baseDirectory);
         }
     }
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/Settings/IgniteUIBlazorSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/Settings/IgniteUIBlazorSettings.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
+
+/// <summary>
+/// Settings for the Ignite UI for Blazor scaffolding steps.
+/// </summary>
+internal class IgniteUIBlazorSettings : BaseSettings
+{
+    /// <summary>
+    /// Which Ignite UI package set to add: 'Lite', 'GridLite' or 'All'.
+    /// </summary>
+    public required string Package { get; set; }
+    /// <summary>
+    /// The theme to link ('bootstrap', 'material', 'fluent' or 'indigo').
+    /// </summary>
+    public required string Theme { get; set; }
+    /// <summary>
+    /// The theme variant to link ('light' or 'dark').
+    /// </summary>
+    public required string ThemeVariant { get; set; }
+    /// <summary>
+    /// Indicates if prerelease package versions should be installed.
+    /// </summary>
+    public bool Prerelease { get; set; }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/ValidateIgniteUIBlazorStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/ValidateIgniteUIBlazorStep.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Core.Steps;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.Settings;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Telemetry;
+using Microsoft.Extensions.Logging;
+using AspNetConstants = Microsoft.DotNet.Tools.Scaffold.AspNet.Common.Constants;
+using Constants = Microsoft.DotNet.Scaffolding.Internal.Constants;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+
+/// <summary>
+/// Scaffold step that validates the Ignite UI for Blazor options and initializes the
+/// <see cref="IgniteUIBlazorModel"/> (resolved host page, _Imports.razor, packages and theme stylesheet).
+/// </summary>
+internal class ValidateIgniteUIBlazorStep : ScaffoldStep
+{
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger _logger;
+    private readonly ITelemetryService _telemetryService;
+
+    /// <summary>
+    /// Path to the project file.
+    /// </summary>
+    public string? Project { get; set; }
+    /// <summary>
+    /// Which Ignite UI package set to add: 'Lite', 'GridLite' or 'All'.
+    /// </summary>
+    public string? Package { get; set; }
+    /// <summary>
+    /// The theme to link ('bootstrap', 'material', 'fluent' or 'indigo'). Defaults to 'bootstrap'.
+    /// </summary>
+    public string? Theme { get; set; }
+    /// <summary>
+    /// The theme variant to link ('light' or 'dark'). Defaults to 'light'.
+    /// </summary>
+    public string? ThemeVariant { get; set; }
+    /// <summary>
+    /// Indicates if prerelease package versions should be installed.
+    /// </summary>
+    public bool Prerelease { get; set; }
+
+    /// <summary>
+    /// Constructor for ValidateIgniteUIBlazorStep.
+    /// </summary>
+    /// <param name="fileSystem">File system service.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="telemetryService">Telemetry service.</param>
+    public ValidateIgniteUIBlazorStep(
+        IFileSystem fileSystem,
+        ILogger<ValidateIgniteUIBlazorStep> logger,
+        ITelemetryService telemetryService)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+        _telemetryService = telemetryService;
+    }
+
+    /// <summary>
+    /// Executes the step to validate the Ignite UI settings and initialize the <see cref="IgniteUIBlazorModel"/>.
+    /// </summary>
+    public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
+    {
+        var settings = ValidateSettings();
+        if (settings is null)
+        {
+            _telemetryService.TrackEvent(new ValidateScaffolderTelemetryEvent(nameof(ValidateIgniteUIBlazorStep), context.Scaffolder.DisplayName, false));
+            return Task.FromResult(false);
+        }
+
+        context.Properties.Add(nameof(IgniteUIBlazorSettings), settings);
+
+        _logger.LogInformation("Initializing Ignite UI for Blazor scaffolding model...");
+        var model = GetModel(context, settings);
+        if (model is null)
+        {
+            _logger.LogError("An error occurred while initializing the Ignite UI for Blazor scaffolding model.");
+            _telemetryService.TrackEvent(new ValidateScaffolderTelemetryEvent(nameof(ValidateIgniteUIBlazorStep), context.Scaffolder.DisplayName, false));
+            return Task.FromResult(false);
+        }
+
+        context.Properties.Add(nameof(IgniteUIBlazorModel), model);
+        // No template variables are needed by the Ignite UI code modification configs, but the
+        // code change steps expect the dictionary to be present (shared pattern across scaffolders).
+        context.Properties.Add(Constants.StepConstants.CodeModifierProperties, new Dictionary<string, string>());
+
+        LogRenderModeGuidance(model);
+        _telemetryService.TrackEvent(new ValidateScaffolderTelemetryEvent(nameof(ValidateIgniteUIBlazorStep), context.Scaffolder.DisplayName, true));
+        return Task.FromResult(true);
+    }
+
+    /// <summary>
+    /// Validates the options provided by the user.
+    /// </summary>
+    /// <returns>The validated settings, or null when validation failed.</returns>
+    private IgniteUIBlazorSettings? ValidateSettings()
+    {
+        if (string.IsNullOrEmpty(Project) || !_fileSystem.FileExists(Project))
+        {
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.ProjectCliOption} option.");
+            return null;
+        }
+
+        if (!IgniteUIBlazorHelper.IsValidPackageOption(Package))
+        {
+            _logger.LogError($"Missing/Invalid {AspNetConstants.CliOptions.IgniteUIPackageOption} option. Expected one of: {string.Join(", ", IgniteUIBlazorHelper.PackageOptions)}.");
+            return null;
+        }
+
+        var theme = IgniteUIBlazorHelper.NormalizeTheme(Theme);
+        if (!string.IsNullOrEmpty(Theme) && !theme.Equals(Theme, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation($"Invalid {AspNetConstants.CliOptions.IgniteUIThemeOption} option '{Theme}'. Using default '{theme}'.");
+        }
+
+        var themeVariant = IgniteUIBlazorHelper.NormalizeThemeVariant(ThemeVariant);
+        if (!string.IsNullOrEmpty(ThemeVariant) && !themeVariant.Equals(ThemeVariant, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation($"Invalid {AspNetConstants.CliOptions.IgniteUIThemeVariantOption} option '{ThemeVariant}'. Using default '{themeVariant}'.");
+        }
+
+        // '--project' may be relative to the current directory; every later step (host page, _Imports.razor,
+        // code modification, package installation, WebAssembly client detection) expects a fully qualified path.
+        return new IgniteUIBlazorSettings
+        {
+            Project = Path.GetFullPath(Project),
+            Package = Package!,
+            Theme = theme,
+            ThemeVariant = themeVariant,
+            Prerelease = Prerelease
+        };
+    }
+
+    /// <summary>
+    /// Initializes and returns the <see cref="IgniteUIBlazorModel"/> for scaffolding.
+    /// </summary>
+    private IgniteUIBlazorModel? GetModel(ScaffolderContext context, IgniteUIBlazorSettings settings)
+    {
+        ProjectInfo projectInfo = ClassAnalyzers.GetProjectInfo(settings.Project, _logger);
+        context.SetSpecifiedTargetFramework(projectInfo.LowestSupportedTargetFramework);
+        var projectDirectory = Path.GetDirectoryName(projectInfo.ProjectPath);
+        if (projectInfo.CodeService is null || string.IsNullOrEmpty(projectDirectory))
+        {
+            return null;
+        }
+
+        var projectFileContent = _fileSystem.ReadAllText(settings.Project);
+        var programFilePath = Path.Combine(projectDirectory, "Program.cs");
+        var programFileContent = _fileSystem.FileExists(programFilePath) ? _fileSystem.ReadAllText(programFilePath) : null;
+
+        bool includeLite = IgniteUIBlazorHelper.IncludesLite(settings.Package);
+        bool includeGridLite = IgniteUIBlazorHelper.IncludesGridLite(settings.Package);
+        // The GridLite stylesheet is only appropriate when GridLite is the only Ignite UI package in use.
+        bool useLiteStylesheet = includeLite || IgniteUIBlazorHelper.ProjectReferencesLitePackage(projectFileContent);
+        if (includeGridLite && !includeLite && useLiteStylesheet)
+        {
+            _logger.LogInformation("The project already references IgniteUI.Blazor.Lite; linking the IgniteUI.Blazor theme stylesheet instead of the GridLite-only stylesheet.");
+        }
+
+        var hostPagePath = IgniteUIBlazorHelper.FindHostPage(_fileSystem, projectDirectory);
+        var stylesheetPath = IgniteUIBlazorHelper.GetThemeStylesheetPath(useLiteStylesheet, settings.Theme, settings.ThemeVariant);
+        if (hostPagePath is null)
+        {
+            _logger.LogWarning($"Could not find a host page ({string.Join(", ", IgniteUIBlazorHelper.HostPageCandidates)}) in '{projectDirectory}'.");
+            _logger.LogWarning("Add the following line to the <head> of your host page manually:");
+            _logger.LogWarning($"    {IgniteUIBlazorHelper.BuildStylesheetLink(stylesheetPath, useAssetsCollection: false)}");
+        }
+
+        // No option-filtered blocks exist in the Ignite UI code modification configs.
+        projectInfo.CodeChangeOptions = [];
+
+        return new IgniteUIBlazorModel
+        {
+            ProjectInfo = projectInfo,
+            ProjectPath = settings.Project,
+            BaseOutputPath = projectDirectory,
+            IncludeLite = includeLite,
+            IncludeGridLite = includeGridLite,
+            Theme = settings.Theme,
+            ThemeVariant = settings.ThemeVariant,
+            StylesheetPath = stylesheetPath,
+            IsWebAssemblyProject = IgniteUIBlazorHelper.IsWebAssemblyProject(projectFileContent, programFileContent),
+            HostPagePath = hostPagePath,
+            ImportsFilePath = IgniteUIBlazorHelper.GetImportsFilePath(_fileSystem, projectDirectory)
+        };
+    }
+
+    /// <summary>
+    /// Ignite UI components need an interactive render mode; static server-side rendering renders nothing usable.
+    /// Logs guidance for Blazor Web Apps that do not register or declare an interactive render mode.
+    /// Blazor WebAssembly and Blazor Server applications are always interactive, so nothing is logged for them.
+    /// </summary>
+    private void LogRenderModeGuidance(IgniteUIBlazorModel model)
+    {
+        if (model.IsWebAssemblyProject ||
+            model.HostPagePath is null ||
+            !model.HostPagePath.EndsWith("App.razor", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var programFilePath = Path.Combine(model.BaseOutputPath, "Program.cs");
+        var programFileContent = _fileSystem.FileExists(programFilePath) ? _fileSystem.ReadAllText(programFilePath) : null;
+        if (!IgniteUIBlazorHelper.HasInteractiveRenderModeServices(programFileContent))
+        {
+            _logger.LogWarning("Ignite UI components require an interactive render mode, but this Blazor Web App does not register interactive components.");
+            _logger.LogWarning("Chain '.AddInteractiveServerComponents()' and/or '.AddInteractiveWebAssemblyComponents()' after 'builder.Services.AddRazorComponents()' in Program.cs, then set '@rendermode InteractiveServer' (or InteractiveWebAssembly / InteractiveAuto) on the components that use Ignite UI.");
+            return;
+        }
+
+        var appRazorContent = _fileSystem.ReadAllText(model.HostPagePath);
+        var routesRazorPath = Path.Combine(Path.GetDirectoryName(model.HostPagePath) ?? model.BaseOutputPath, "Routes.razor");
+        var routesRazorContent = _fileSystem.FileExists(routesRazorPath) ? _fileSystem.ReadAllText(routesRazorPath) : null;
+        if (!IgniteUIBlazorHelper.DeclaresRenderMode(appRazorContent) && !IgniteUIBlazorHelper.DeclaresRenderMode(routesRazorContent))
+        {
+            _logger.LogInformation("No global render mode is set on <Routes /> in App.razor. Ignite UI components need an interactive render mode: add '@rendermode InteractiveServer' (or InteractiveWebAssembly / InteractiveAuto) to the pages that use them, or set '<Routes @rendermode=\"InteractiveAuto\" />' globally.");
+        }
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/CodeModificationConfigs/igniteUIBlazorChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/CodeModificationConfigs/igniteUIBlazorChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();", "WebApplication.CreateBuilder.Build()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "WebApplication.CreateBuilder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "await builder.Build().RunAsync();", "builder.Build().RunAsync()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "builder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/CodeModificationConfigs/igniteUIBlazorChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/CodeModificationConfigs/igniteUIBlazorChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();", "WebApplication.CreateBuilder.Build()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "WebApplication.CreateBuilder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "await builder.Build().RunAsync();", "builder.Build().RunAsync()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "builder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/CodeModificationConfigs/igniteUIBlazorChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/CodeModificationConfigs/igniteUIBlazorChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();", "WebApplication.CreateBuilder.Build()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "WebApplication.CreateBuilder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "await builder.Build().RunAsync();", "builder.Build().RunAsync()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "builder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/CodeModificationConfigs/igniteUIBlazorChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/CodeModificationConfigs/igniteUIBlazorChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();", "WebApplication.CreateBuilder.Build()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "WebApplication.CreateBuilder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/CodeModificationConfigs/igniteUIBlazorWasmChanges.json
@@ -1,0 +1,24 @@
+{
+  "Files": [
+    {
+      "FileName": "Program.cs",
+      "Methods": {
+        "Global": {
+          "CodeChanges": [
+            {
+              "InsertBefore": [ "await builder.Build().RunAsync();", "builder.Build().RunAsync()" ],
+              "CheckBlock": "AddIgniteUIBlazor",
+              "Block": "builder.Services.AddIgniteUIBlazor()",
+              "LeadingTrivia": {
+                "Newline": true
+              }
+            }
+          ]
+        }
+      },
+      "Usings": [
+        "IgniteUI.Blazor.Controls"
+      ]
+    }
+  ]
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Extensions/IgniteUIBlazorScaffolderBuilderExtensionsTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Extensions/IgniteUIBlazorScaffolderBuilderExtensionsTests.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Hosting;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Extensions;
+
+public class IgniteUIBlazorScaffolderBuilderExtensionsTests
+{
+    private static Mock<IScaffoldBuilder> CreateBuilder<TStep>() where TStep : Microsoft.DotNet.Scaffolding.Core.Steps.ScaffoldStep
+    {
+        Mock<IScaffoldBuilder> mockBuilder = new Mock<IScaffoldBuilder>();
+        mockBuilder.Setup(b => b.WithStep<TStep>(It.IsAny<Action<ScaffoldStepConfigurator<TStep>>>(), It.IsAny<Action<ScaffoldStepConfigurator<TStep>>>()))
+            .Returns(mockBuilder.Object);
+        return mockBuilder;
+    }
+
+    private static void VerifyStepAdded<TStep>(Mock<IScaffoldBuilder> mockBuilder) where TStep : Microsoft.DotNet.Scaffolding.Core.Steps.ScaffoldStep
+        => mockBuilder.Verify(b => b.WithStep<TStep>(It.IsAny<Action<ScaffoldStepConfigurator<TStep>>>(), It.IsAny<Action<ScaffoldStepConfigurator<TStep>>>()), Times.Once);
+
+    [Fact]
+    public void WithIgniteUIBlazorDetectBlazorWasmStep_AddsDetectBlazorWasmStep()
+    {
+        var mockBuilder = CreateBuilder<DetectBlazorWasmStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorDetectBlazorWasmStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<DetectBlazorWasmStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorAddPackagesStep_AddsWrappedAddPackagesStep()
+    {
+        var mockBuilder = CreateBuilder<WrappedAddPackagesStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorAddPackagesStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<WrappedAddPackagesStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorWasmAddPackagesStep_AddsWrappedAddPackagesStep()
+    {
+        var mockBuilder = CreateBuilder<WrappedAddPackagesStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorWasmAddPackagesStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<WrappedAddPackagesStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorCodeChangeStep_AddsWrappedCodeModificationStep()
+    {
+        var mockBuilder = CreateBuilder<WrappedCodeModificationStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorCodeChangeStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<WrappedCodeModificationStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorWasmCodeChangeStep_AddsWrappedCodeModificationStep()
+    {
+        var mockBuilder = CreateBuilder<WrappedCodeModificationStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorWasmCodeChangeStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<WrappedCodeModificationStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorImportsStep_AddsAddRazorImportsStep()
+    {
+        var mockBuilder = CreateBuilder<AddRazorImportsStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorImportsStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<AddRazorImportsStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorWasmImportsStep_AddsAddRazorImportsStep()
+    {
+        var mockBuilder = CreateBuilder<AddRazorImportsStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorWasmImportsStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<AddRazorImportsStep>(mockBuilder);
+    }
+
+    [Fact]
+    public void WithIgniteUIBlazorThemeStylesheetStep_AddsAddIgniteUIThemeStylesheetStep()
+    {
+        var mockBuilder = CreateBuilder<AddIgniteUIThemeStylesheetStep>();
+
+        IScaffoldBuilder result = mockBuilder.Object.WithIgniteUIBlazorThemeStylesheetStep();
+
+        Assert.NotNull(result);
+        VerifyStepAdded<AddIgniteUIThemeStylesheetStep>(mockBuilder);
+    }
+
+    [Theory]
+    [InlineData(true, false, "IgniteUI.Blazor.Lite")]
+    [InlineData(false, true, "IgniteUI.Blazor.GridLite")]
+    [InlineData(true, true, "IgniteUI.Blazor.Lite", "IgniteUI.Blazor.GridLite")]
+    public void GetPackages_ReturnsSelectedPackages(bool includeLite, bool includeGridLite, params string[] expectedPackageNames)
+    {
+        var model = CreateModel(includeLite, includeGridLite);
+
+        var packages = IgniteUIBlazorScaffolderBuilderExtensions.GetPackages(model);
+
+        Assert.Equal(expectedPackageNames, packages.ConvertAll(p => p.Name));
+        Assert.All(packages, p => Assert.False(p.IsVersionRequired));
+    }
+
+    [Fact]
+    public void Model_RequiresServiceRegistration_OnlyWhenLiteIncluded()
+    {
+        Assert.True(CreateModel(includeLite: true, includeGridLite: false).RequiresServiceRegistration);
+        Assert.True(CreateModel(includeLite: true, includeGridLite: true).RequiresServiceRegistration);
+        Assert.False(CreateModel(includeLite: false, includeGridLite: true).RequiresServiceRegistration);
+    }
+
+    [Fact]
+    public void CodeModificationConfigFileNames_AreStable()
+    {
+        Assert.Equal("igniteUIBlazorChanges.json", IgniteUIBlazorScaffolderBuilderExtensions.CodeModificationConfigFileName);
+        Assert.Equal("igniteUIBlazorWasmChanges.json", IgniteUIBlazorScaffolderBuilderExtensions.WasmCodeModificationConfigFileName);
+    }
+
+    private static IgniteUIBlazorModel CreateModel(bool includeLite, bool includeGridLite)
+    {
+        var projectDirectory = Path.Combine("C:", "src", "MyApp");
+        return new IgniteUIBlazorModel
+        {
+            ProjectInfo = new ProjectInfo(null),
+            ProjectPath = Path.Combine(projectDirectory, "MyApp.csproj"),
+            BaseOutputPath = projectDirectory,
+            IncludeLite = includeLite,
+            IncludeGridLite = includeGridLite,
+            Theme = "bootstrap",
+            ThemeVariant = "light",
+            StylesheetPath = "_content/IgniteUI.Blazor/themes/light/bootstrap.css",
+            IsWebAssemblyProject = false,
+            HostPagePath = Path.Combine(projectDirectory, "Components", "App.razor"),
+            ImportsFilePath = Path.Combine(projectDirectory, "Components", "_Imports.razor")
+        };
+    }
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/IgniteUIBlazorHelperTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/IgniteUIBlazorHelperTests.cs
@@ -1,0 +1,295 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.IO;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Helpers;
+
+public class IgniteUIBlazorHelperTests
+{
+    private static readonly string s_projectDir = Path.Combine("C:", "src", "MyApp");
+
+    #region --package option
+
+    [Theory]
+    [InlineData("Lite")]
+    [InlineData("GridLite")]
+    [InlineData("All")]
+    [InlineData("lite")]
+    [InlineData("GRIDLITE")]
+    [InlineData("all")]
+    public void IsValidPackageOption_AcceptsKnownValuesCaseInsensitively(string package)
+        => Assert.True(IgniteUIBlazorHelper.IsValidPackageOption(package));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Grid")]
+    [InlineData("IgniteUI.Blazor.Lite")]
+    public void IsValidPackageOption_RejectsUnknownValues(string? package)
+        => Assert.False(IgniteUIBlazorHelper.IsValidPackageOption(package));
+
+    [Theory]
+    [InlineData("Lite", true, false)]
+    [InlineData("GridLite", false, true)]
+    [InlineData("All", true, true)]
+    [InlineData("all", true, true)]
+    [InlineData(null, false, false)]
+    public void IncludesLite_And_IncludesGridLite_MatchSelection(string? package, bool expectLite, bool expectGridLite)
+    {
+        Assert.Equal(expectLite, IgniteUIBlazorHelper.IncludesLite(package));
+        Assert.Equal(expectGridLite, IgniteUIBlazorHelper.IncludesGridLite(package));
+    }
+
+    #endregion
+
+    #region Theme normalization
+
+    [Theory]
+    [InlineData("bootstrap", "bootstrap")]
+    [InlineData("Material", "material")]
+    [InlineData("FLUENT", "fluent")]
+    [InlineData("indigo", "indigo")]
+    [InlineData(null, "bootstrap")]
+    [InlineData("", "bootstrap")]
+    [InlineData("unknown", "bootstrap")]
+    public void NormalizeTheme_ReturnsKnownThemeOrDefault(string? theme, string expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.NormalizeTheme(theme));
+
+    [Theory]
+    [InlineData("light", "light")]
+    [InlineData("Dark", "dark")]
+    [InlineData(null, "light")]
+    [InlineData("", "light")]
+    [InlineData("night", "light")]
+    public void NormalizeThemeVariant_ReturnsKnownVariantOrDefault(string? variant, string expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.NormalizeThemeVariant(variant));
+
+    [Fact]
+    public void Themes_ContainAllShippedThemes()
+    {
+        Assert.Equal(new[] { "bootstrap", "material", "fluent", "indigo" }, IgniteUIBlazorHelper.Themes);
+        Assert.Equal(new[] { "light", "dark" }, IgniteUIBlazorHelper.ThemeVariants);
+        Assert.Equal(new[] { "Lite", "GridLite", "All" }, IgniteUIBlazorHelper.PackageOptions);
+    }
+
+    #endregion
+
+    #region Stylesheet path
+
+    [Fact]
+    public void GetThemeStylesheetPath_UsesLiteRoot_WhenLiteStylesheetRequested()
+        => Assert.Equal("_content/IgniteUI.Blazor/themes/light/bootstrap.css",
+            IgniteUIBlazorHelper.GetThemeStylesheetPath(useLiteStylesheet: true, "bootstrap", "light"));
+
+    [Fact]
+    public void GetThemeStylesheetPath_UsesGridLiteRoot_WhenGridLiteOnly()
+        => Assert.Equal("_content/IgniteUI.Blazor.GridLite/css/themes/dark/material.css",
+            IgniteUIBlazorHelper.GetThemeStylesheetPath(useLiteStylesheet: false, "material", "dark"));
+
+    [Fact]
+    public void GetThemeStylesheetPath_NormalizesThemeAndVariant()
+        => Assert.Equal("_content/IgniteUI.Blazor/themes/light/bootstrap.css",
+            IgniteUIBlazorHelper.GetThemeStylesheetPath(useLiteStylesheet: true, "not-a-theme", null));
+
+    [Theory]
+    [InlineData("_content/IgniteUI.Blazor/themes/light/bootstrap.css")]
+    [InlineData("_content/IgniteUI.Blazor/themes/dark/indigo.css")]
+    [InlineData("_content/IgniteUI.Blazor.GridLite/css/themes/light/fluent.css")]
+    [InlineData("_CONTENT/IGNITEUI.BLAZOR/THEMES/DARK/MATERIAL.CSS")]
+    public void ThemeStylesheetRegex_MatchesEveryGeneratedPath(string path)
+        => Assert.Matches(IgniteUIBlazorHelper.ThemeStylesheetRegex, path);
+
+    [Theory]
+    [InlineData("_content/IgniteUI.Blazor/app.bundle.js")]
+    [InlineData("css/app.css")]
+    [InlineData("_content/IgniteUI.Blazor/themes/light/custom.css")]
+    public void ThemeStylesheetRegex_DoesNotMatchOtherAssets(string path)
+        => Assert.DoesNotMatch(IgniteUIBlazorHelper.ThemeStylesheetRegex, path);
+
+    [Fact]
+    public void BuildStylesheetLink_UsesPlainHref_ByDefault()
+        => Assert.Equal("<link href=\"_content/IgniteUI.Blazor/themes/light/bootstrap.css\" rel=\"stylesheet\" />",
+            IgniteUIBlazorHelper.BuildStylesheetLink("_content/IgniteUI.Blazor/themes/light/bootstrap.css", useAssetsCollection: false));
+
+    [Fact]
+    public void BuildStylesheetLink_UsesAssetsCollection_WhenRequested()
+        => Assert.Equal("<link rel=\"stylesheet\" href=\"@Assets[\"_content/IgniteUI.Blazor/themes/light/bootstrap.css\"]\" />",
+            IgniteUIBlazorHelper.BuildStylesheetLink("_content/IgniteUI.Blazor/themes/light/bootstrap.css", useAssetsCollection: true));
+
+    #endregion
+
+    #region Project inspection
+
+    [Theory]
+    [InlineData("<Project Sdk=\"Microsoft.NET.Sdk.Web\"><ItemGroup><PackageReference Include=\"IgniteUI.Blazor.Lite\" Version=\"0.1.1\" /></ItemGroup></Project>", true)]
+    [InlineData("<Project Sdk=\"Microsoft.NET.Sdk.Web\"><ItemGroup><PackageReference Version=\"0.1.1\" Include=\"igniteui.blazor.lite\" /></ItemGroup></Project>", true)]
+    [InlineData("<Project Sdk=\"Microsoft.NET.Sdk.Web\"><ItemGroup><PackageReference Include=\"IgniteUI.Blazor.GridLite\" Version=\"0.9.2\" /></ItemGroup></Project>", false)]
+    [InlineData("<Project Sdk=\"Microsoft.NET.Sdk.Web\" />", false)]
+    [InlineData(null, false)]
+    public void ProjectReferencesLitePackage_DetectsPackageReference(string? csproj, bool expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.ProjectReferencesLitePackage(csproj));
+
+    [Fact]
+    public void IsWebAssemblyProject_TrueForBlazorWebAssemblySdkAttribute()
+        => Assert.True(IgniteUIBlazorHelper.IsWebAssemblyProject("<Project Sdk=\"Microsoft.NET.Sdk.BlazorWebAssembly\"></Project>", null));
+
+    [Fact]
+    public void IsWebAssemblyProject_TrueForBlazorWebAssemblySdkElement()
+        => Assert.True(IgniteUIBlazorHelper.IsWebAssemblyProject("<Project>\n  <Sdk Name=\"Microsoft.NET.Sdk.BlazorWebAssembly\" />\n</Project>", null));
+
+    [Fact]
+    public void IsWebAssemblyProject_TrueWhenProgramUsesWebAssemblyHostBuilder()
+        => Assert.True(IgniteUIBlazorHelper.IsWebAssemblyProject("<Project Sdk=\"Microsoft.NET.Sdk.Web\"></Project>",
+            "var builder = WebAssemblyHostBuilder.CreateDefault(args);"));
+
+    [Fact]
+    public void IsWebAssemblyProject_FalseForWebSdkWithWebApplicationBuilder()
+        => Assert.False(IgniteUIBlazorHelper.IsWebAssemblyProject("<Project Sdk=\"Microsoft.NET.Sdk.Web\"></Project>",
+            "var builder = WebApplication.CreateBuilder(args);"));
+
+    [Fact]
+    public void IsWebAssemblyProject_FalseForNullInputs()
+        => Assert.False(IgniteUIBlazorHelper.IsWebAssemblyProject(null, null));
+
+    [Theory]
+    [InlineData("builder.Services.AddRazorComponents().AddInteractiveServerComponents();", true)]
+    [InlineData("builder.Services.AddRazorComponents()\n    .AddInteractiveWebAssemblyComponents();", true)]
+    [InlineData("builder.Services.AddRazorComponents();", false)]
+    [InlineData(null, false)]
+    public void HasInteractiveRenderModeServices_DetectsInteractiveRegistrations(string? program, bool expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.HasInteractiveRenderModeServices(program));
+
+    [Theory]
+    [InlineData("<Routes @rendermode=\"InteractiveAuto\" />", true)]
+    [InlineData("@page \"/counter\"\n@rendermode InteractiveServer", true)]
+    [InlineData("<Routes />", false)]
+    [InlineData(null, false)]
+    public void DeclaresRenderMode_DetectsDirectiveAndAttribute(string? razor, bool expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.DeclaresRenderMode(razor));
+
+    [Theory]
+    [InlineData("a\r\nb\r\n", "\r\n")]
+    [InlineData("a\nb\n", "\n")]
+    [InlineData("", "\n")]
+    [InlineData(null, "\n")]
+    public void DetectLineEnding_ReturnsDominantLineEnding(string? content, string expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.DetectLineEnding(content));
+
+    [Theory]
+    [InlineData("<head></head>", true)]
+    [InlineData("<HEAD></HEAD>", true)]
+    [InlineData("<body></body>", false)]
+    [InlineData(null, false)]
+    public void ContainsHeadClosingTag_IsCaseInsensitive(string? content, bool expected)
+        => Assert.Equal(expected, IgniteUIBlazorHelper.ContainsHeadClosingTag(content));
+
+    [Fact]
+    public void UsesAssetsCollection_TrueOnlyForRazorHostPagesUsingAssets()
+    {
+        Assert.True(IgniteUIBlazorHelper.UsesAssetsCollection(Path.Combine("Components", "App.razor"), "<link rel=\"stylesheet\" href=\"@Assets[\"app.css\"]\" />"));
+        Assert.False(IgniteUIBlazorHelper.UsesAssetsCollection(Path.Combine("Components", "App.razor"), "<link rel=\"stylesheet\" href=\"app.css\" />"));
+        Assert.False(IgniteUIBlazorHelper.UsesAssetsCollection(Path.Combine("wwwroot", "index.html"), "@Assets[\"app.css\"]"));
+        Assert.False(IgniteUIBlazorHelper.UsesAssetsCollection(null, "@Assets[\"app.css\"]"));
+    }
+
+    #endregion
+
+    #region Host page and _Imports.razor resolution
+
+    [Fact]
+    public void FindHostPage_PrefersComponentsAppRazor()
+    {
+        var appRazor = Path.Combine(s_projectDir, "Components", "App.razor");
+        var indexHtml = Path.Combine(s_projectDir, "wwwroot", "index.html");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(appRazor)).Returns(true);
+        fileSystem.Setup(f => f.ReadAllText(appRazor)).Returns("<html><head></head><body></body></html>");
+        fileSystem.Setup(f => f.FileExists(indexHtml)).Returns(true);
+        fileSystem.Setup(f => f.ReadAllText(indexHtml)).Returns("<html><head></head><body></body></html>");
+
+        Assert.Equal(appRazor, IgniteUIBlazorHelper.FindHostPage(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void FindHostPage_FallsBackToIndexHtml_ForWebAssemblyProjects()
+    {
+        var indexHtml = Path.Combine(s_projectDir, "wwwroot", "index.html");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(f => f.FileExists(indexHtml)).Returns(true);
+        fileSystem.Setup(f => f.ReadAllText(indexHtml)).Returns("<html><head></head><body></body></html>");
+
+        Assert.Equal(indexHtml, IgniteUIBlazorHelper.FindHostPage(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void FindHostPage_SkipsCandidatesWithoutHeadElement()
+    {
+        var hostCshtml = Path.Combine(s_projectDir, "Pages", "_Host.cshtml");
+        var layoutCshtml = Path.Combine(s_projectDir, "Pages", "_Layout.cshtml");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(f => f.FileExists(layoutCshtml)).Returns(true);
+        fileSystem.Setup(f => f.ReadAllText(layoutCshtml)).Returns("@page \"/\"\n<component type=\"typeof(App)\" render-mode=\"ServerPrerendered\" />");
+        fileSystem.Setup(f => f.FileExists(hostCshtml)).Returns(true);
+        fileSystem.Setup(f => f.ReadAllText(hostCshtml)).Returns("<html><head></head><body></body></html>");
+
+        Assert.Equal(hostCshtml, IgniteUIBlazorHelper.FindHostPage(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void FindHostPage_ReturnsNull_WhenNoHostPageExists()
+    {
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+
+        Assert.Null(IgniteUIBlazorHelper.FindHostPage(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void GetImportsFilePath_PrefersComponentsImports()
+    {
+        var componentsImports = Path.Combine(s_projectDir, "Components", "_Imports.razor");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+
+        Assert.Equal(componentsImports, IgniteUIBlazorHelper.GetImportsFilePath(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void GetImportsFilePath_UsesRootImports_WhenComponentsImportsMissing()
+    {
+        var rootImports = Path.Combine(s_projectDir, "_Imports.razor");
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(f => f.FileExists(rootImports)).Returns(true);
+
+        Assert.Equal(rootImports, IgniteUIBlazorHelper.GetImportsFilePath(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void GetImportsFilePath_DefaultsToComponentsFolder_WhenItExists()
+    {
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(f => f.DirectoryExists(Path.Combine(s_projectDir, "Components"))).Returns(true);
+
+        Assert.Equal(Path.Combine(s_projectDir, "Components", "_Imports.razor"), IgniteUIBlazorHelper.GetImportsFilePath(fileSystem.Object, s_projectDir));
+    }
+
+    [Fact]
+    public void GetImportsFilePath_DefaultsToProjectRoot_WhenNoComponentsFolder()
+    {
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(false);
+
+        Assert.Equal(Path.Combine(s_projectDir, "_Imports.razor"), IgniteUIBlazorHelper.GetImportsFilePath(fileSystem.Object, s_projectDir));
+    }
+
+    #endregion
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUIIntegrationTestsBase.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUIIntegrationTestsBase.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Tools.Scaffold.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Integration;
+
+/// <summary>
+/// Shared base class for Ignite UI for Blazor ('blazor-igniteui') integration tests across .NET versions.
+/// Verifies the code modification configs shipped for the target framework and provides the
+/// fixtures used by the CLI invocation tests in the per-framework subclasses.
+/// </summary>
+[Trait("Suite", "ScaffoldIntegration")]
+[Trait("Family", "blazor-igniteui")]
+public abstract class BlazorIgniteUIIntegrationTestsBase : IDisposable
+{
+    protected abstract string TargetFramework { get; }
+    protected abstract string TestClassName { get; }
+
+    protected const string LitePackageName = "IgniteUI.Blazor.Lite";
+    protected const string GridLitePackageName = "IgniteUI.Blazor.GridLite";
+    protected const string ControlsUsing = "@using IgniteUI.Blazor.Controls";
+    protected const string LiteBootstrapLightStylesheet = "_content/IgniteUI.Blazor/themes/light/bootstrap.css";
+
+    protected readonly string _testDirectory;
+    protected readonly string _testProjectDir;
+    protected readonly string _testProjectPath;
+
+    protected BlazorIgniteUIIntegrationTestsBase()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), TestClassName, Guid.NewGuid().ToString());
+        _testProjectDir = Path.Combine(_testDirectory, "TestProject");
+        _testProjectPath = Path.Combine(_testProjectDir, "TestProject.csproj");
+        Directory.CreateDirectory(_testProjectDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try { Directory.Delete(_testDirectory, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
+    protected string ProjectContent => $@"<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>";
+
+    #region Code Modification Configs
+
+    [Theory]
+    [InlineData("igniteUIBlazorChanges.json")]
+    [InlineData("igniteUIBlazorWasmChanges.json")]
+    public void CodeModificationConfig_ExistsForTargetFramework(string configFileName)
+    {
+        var configPath = GetCodeModificationConfigPath(configFileName);
+        Assert.True(File.Exists(configPath), $"{configFileName} should exist for {TargetFramework} at '{configPath}'");
+    }
+
+    [Theory]
+    [InlineData("igniteUIBlazorChanges.json")]
+    [InlineData("igniteUIBlazorWasmChanges.json")]
+    public void CodeModificationConfig_RegistersIgniteUIServicesInProgramCs(string configFileName)
+    {
+        var content = File.ReadAllText(GetCodeModificationConfigPath(configFileName));
+
+        Assert.False(string.IsNullOrWhiteSpace(content), $"{configFileName} should not be empty");
+        Assert.Contains("\"Program.cs\"", content);
+        Assert.Contains("AddIgniteUIBlazor()", content);
+        Assert.Contains("IgniteUI.Blazor.Controls", content);
+    }
+
+    [Fact]
+    public void HostedConfig_InsertsBeforeAppBuild()
+    {
+        var content = File.ReadAllText(GetCodeModificationConfigPath("igniteUIBlazorChanges.json"));
+        Assert.Contains("var app = WebApplication.CreateBuilder.Build();", content);
+        Assert.Contains("WebApplication.CreateBuilder.Services.AddIgniteUIBlazor()", content);
+    }
+
+    [Fact]
+    public void WasmConfig_InsertsBeforeRunAsync()
+    {
+        var content = File.ReadAllText(GetCodeModificationConfigPath("igniteUIBlazorWasmChanges.json"));
+        Assert.Contains("await builder.Build().RunAsync();", content);
+        Assert.Contains("builder.Services.AddIgniteUIBlazor()", content);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    protected static string GetActualTemplatesBasePath()
+    {
+        var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+        var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+        var basePath = Path.Combine(assemblyDirectory!, "..", "..", "..", "..", "..", "src", "dotnet-scaffolding", "dotnet-scaffold", "AspNet", "Templates");
+        return Path.GetFullPath(basePath);
+    }
+
+    protected string GetCodeModificationConfigPath(string configFileName)
+        => Path.Combine(GetActualTemplatesBasePath(), TargetFramework, "CodeModificationConfigs", configFileName);
+
+    protected Task<(int ExitCode, string Output, string Error)> RunBuildAsync(string workingDirectory)
+        => ScaffoldCliHelper.RunBuildForFrameworkAsync(workingDirectory, TargetFramework);
+
+    /// <summary>
+    /// Writes a minimal Blazor Web App (server project) into the test project directory.
+    /// </summary>
+    protected void SetupBlazorWebAppProject(string? extraProjectXml = null)
+    {
+        var projectContent = extraProjectXml is null
+            ? ProjectContent
+            : ProjectContent.Replace("</PropertyGroup>", $"{extraProjectXml}\n  </PropertyGroup>");
+        File.WriteAllText(_testProjectPath, projectContent);
+        File.WriteAllText(Path.Combine(_testProjectDir, "Program.cs"), ScaffoldCliHelper.GetBlazorProgramCs("TestProject"));
+        ScaffoldCliHelper.SetupBlazorProjectStructure(_testProjectDir);
+    }
+
+    /// <summary>
+    /// Runs the scaffolder and asserts the Blazor Web App was wired up for both Ignite UI packages
+    /// ('--package All' with the default light bootstrap theme).
+    /// </summary>
+    /// <returns>The scaffolder's console output, for additional assertions by the caller.</returns>
+    protected async Task<string> ScaffoldAllPackagesAndAssertAsync(params string[] extraCliArgs)
+    {
+        var (preExitCode, preOutput, preError) = await RunBuildAsync(_testProjectDir);
+        Assert.True(preExitCode == 0,
+            $"Project should build before scaffolding.\nExit code: {preExitCode}\nOutput: {preOutput}\nError: {preError}");
+
+        string[] args =
+        [
+            "--project", _testProjectPath,
+            "--package", "All",
+            .. extraCliArgs
+        ];
+        var (cliExitCode, cliOutput, cliError) = await ScaffoldCliHelper.RunScaffoldAsync(TargetFramework, "blazor-igniteui", args);
+        Assert.True(cliExitCode == 0, $"CLI scaffold should succeed.\nOutput: {cliOutput}\nError: {cliError}");
+
+        // packages
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(LitePackageName, projectContent);
+        Assert.Contains(GridLitePackageName, projectContent);
+
+        // service registration
+        var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
+        Assert.Contains("using IgniteUI.Blazor.Controls;", programContent);
+        Assert.Contains("builder.Services.AddIgniteUIBlazor();", programContent);
+        Assert.True(programContent.IndexOf("AddIgniteUIBlazor", StringComparison.Ordinal) < programContent.IndexOf("var app = builder.Build();", StringComparison.Ordinal),
+            $"AddIgniteUIBlazor() should be registered before the app is built.\n{programContent}");
+
+        // _Imports.razor
+        var importsContent = File.ReadAllText(Path.Combine(_testProjectDir, "Components", "_Imports.razor"));
+        Assert.Contains(ControlsUsing, importsContent);
+
+        // theme stylesheet in the host page
+        var appRazorContent = File.ReadAllText(Path.Combine(_testProjectDir, "Components", "App.razor"));
+        Assert.Contains(LiteBootstrapLightStylesheet, appRazorContent);
+        Assert.Contains("rel=\"stylesheet\"", appRazorContent);
+
+        Assert.False(cliOutput.Contains("error: NU"),
+            $"Scaffolding should not produce NuGet errors for {TargetFramework}.\nOutput: {cliOutput}");
+        var (postExitCode, postOutput, postError) = await RunBuildAsync(_testProjectDir);
+        Assert.True(postExitCode == 0,
+            $"Project should build after scaffolding.\nExit code: {postExitCode}\nOutput: {postOutput}\nError: {postError}");
+
+        return cliOutput;
+    }
+
+    #endregion
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet10IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet10IntegrationTests.cs
@@ -1,0 +1,471 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Tools.Scaffold.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Integration.Blazor;
+
+public class BlazorIgniteUINet10IntegrationTests : BlazorIgniteUIIntegrationTestsBase
+{
+    protected override string TargetFramework => "net10.0";
+    protected override string TestClassName => nameof(BlazorIgniteUINet10IntegrationTests);
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_CliInvocation()
+    {
+        // Arrange — Blazor Web App (server project)
+        SetupBlazorWebAppProject();
+
+        // Act + Assert — dotnet scaffold aspnet blazor-igniteui --package All
+        await ScaffoldAllPackagesAndAssertAsync();
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_GridLiteOnly_StandaloneWebAssembly()
+    {
+        // Arrange — standalone Blazor WebAssembly project (host page is wwwroot/index.html, root _Imports.razor)
+        File.WriteAllText(_testProjectPath, GetWasmProjectContent());
+        File.WriteAllText(Path.Combine(_testProjectDir, "Program.cs"), GetWasmProgramCs());
+        File.WriteAllText(Path.Combine(_testProjectDir, "App.razor"), GetWasmAppRazor());
+        File.WriteAllText(Path.Combine(_testProjectDir, "_Imports.razor"), GetWasmImportsRazor());
+        Directory.CreateDirectory(Path.Combine(_testProjectDir, "wwwroot"));
+        File.WriteAllText(Path.Combine(_testProjectDir, "wwwroot", "index.html"), GetWasmIndexHtml());
+
+        var (preExitCode, preOutput, preError) = await RunBuildAsync(_testProjectDir);
+        Assert.True(preExitCode == 0,
+            $"Project should build before scaffolding.\nExit code: {preExitCode}\nOutput: {preOutput}\nError: {preError}");
+
+        // Act — dotnet scaffold aspnet blazor-igniteui --package GridLite --theme material --theme-variant dark
+        var (cliExitCode, cliOutput, cliError) = await ScaffoldCliHelper.RunScaffoldAsync(
+            TargetFramework,
+            "blazor-igniteui",
+            "--project", _testProjectPath,
+            "--package", "GridLite",
+            "--theme", "material",
+            "--theme-variant", "dark");
+        Assert.True(cliExitCode == 0, $"CLI scaffold should succeed.\nOutput: {cliOutput}\nError: {cliError}");
+
+        // Assert — only GridLite is referenced and no service registration was added (GridLite needs none)
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(GridLitePackageName, projectContent);
+        Assert.DoesNotContain(LitePackageName, projectContent);
+        var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
+        Assert.DoesNotContain("AddIgniteUIBlazor", programContent);
+
+        // Assert — root _Imports.razor and wwwroot/index.html were updated with the GridLite dark material theme
+        var importsContent = File.ReadAllText(Path.Combine(_testProjectDir, "_Imports.razor"));
+        Assert.Contains(ControlsUsing, importsContent);
+        var indexHtmlContent = File.ReadAllText(Path.Combine(_testProjectDir, "wwwroot", "index.html"));
+        Assert.Contains("<link href=\"_content/IgniteUI.Blazor.GridLite/css/themes/dark/material.css\" rel=\"stylesheet\" />", indexHtmlContent);
+        Assert.DoesNotContain("_content/IgniteUI.Blazor/themes", indexHtmlContent);
+
+        Assert.False(cliOutput.Contains("error: NU"),
+            $"Scaffolding should not produce NuGet errors for {TargetFramework}.\nOutput: {cliOutput}");
+        var (postExitCode, postOutput, postError) = await RunBuildAsync(_testProjectDir);
+        Assert.True(postExitCode == 0,
+            $"Project should build after scaffolding.\nExit code: {postExitCode}\nOutput: {postOutput}\nError: {postError}");
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_SplitWebApp_UpdatesServerAndClient()
+    {
+        // Arrange — Blazor Web App with a WebAssembly client project ('dotnet new blazor -int WebAssembly' layout).
+        // The SERVER project is targeted; the referenced .Client project must be detected and updated as well.
+        SetupBlazorWebAppProject();
+        File.WriteAllText(_testProjectPath, GetSplitServerProjectContent());
+        File.WriteAllText(Path.Combine(_testProjectDir, "Program.cs"), GetSplitServerProgramCs());
+
+        var clientProjectDir = Path.Combine(_testDirectory, "TestProject.Client");
+        Directory.CreateDirectory(clientProjectDir);
+        File.WriteAllText(Path.Combine(clientProjectDir, "TestProject.Client.csproj"), GetSplitClientProjectContent());
+        File.WriteAllText(Path.Combine(clientProjectDir, "Program.cs"), GetSplitClientProgramCs());
+        File.WriteAllText(Path.Combine(clientProjectDir, "_Imports.razor"), GetSplitClientImportsRazor());
+
+        // Act + Assert (server) — the pre-build inside restores both projects, which the client detection relies on
+        var cliOutput = await ScaffoldAllPackagesAndAssertAsync();
+        Assert.Contains("Detected Blazor WebAssembly project", cliOutput);
+
+        // Assert (client) — packages, service registration and @using were applied to the client project too
+        var clientProjectContent = File.ReadAllText(Path.Combine(clientProjectDir, "TestProject.Client.csproj"));
+        Assert.Contains(LitePackageName, clientProjectContent);
+        Assert.Contains(GridLitePackageName, clientProjectContent);
+
+        var clientProgramContent = File.ReadAllText(Path.Combine(clientProjectDir, "Program.cs"));
+        Assert.Contains("using IgniteUI.Blazor.Controls;", clientProgramContent);
+        Assert.Contains("builder.Services.AddIgniteUIBlazor();", clientProgramContent);
+        Assert.True(clientProgramContent.IndexOf("AddIgniteUIBlazor", StringComparison.Ordinal) < clientProgramContent.IndexOf("await builder.Build().RunAsync();", StringComparison.Ordinal),
+            $"AddIgniteUIBlazor() should be registered before the WebAssembly host runs.\n{clientProgramContent}");
+
+        var clientImportsContent = File.ReadAllText(Path.Combine(clientProjectDir, "_Imports.razor"));
+        Assert.Contains(ControlsUsing, clientImportsContent);
+
+        // the theme stylesheet is linked in the server host page only; nothing is created in the client
+        Assert.False(File.Exists(Path.Combine(clientProjectDir, "wwwroot", "index.html")), "The client project must not receive a host page.");
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_LiteOnly_WebApp()
+    {
+        // Arrange — Blazor Web App (server project)
+        SetupBlazorWebAppProject();
+        await AssertBuildsAsync("before scaffolding");
+
+        // Act — dotnet scaffold aspnet blazor-igniteui --package Lite
+        await RunScaffoldAndAssertSuccessAsync("--package", "Lite");
+
+        // Assert — only IgniteUI.Blazor.Lite is referenced, with service registration and the Lite theme
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(LitePackageName, projectContent);
+        Assert.DoesNotContain(GridLitePackageName, projectContent);
+
+        var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
+        Assert.Contains("using IgniteUI.Blazor.Controls;", programContent);
+        Assert.Contains("builder.Services.AddIgniteUIBlazor();", programContent);
+
+        Assert.Contains(ControlsUsing, File.ReadAllText(Path.Combine(_testProjectDir, "Components", "_Imports.razor")));
+
+        var appRazorContent = File.ReadAllText(Path.Combine(_testProjectDir, "Components", "App.razor"));
+        Assert.Contains(LiteBootstrapLightStylesheet, appRazorContent);
+        Assert.DoesNotContain("_content/IgniteUI.Blazor.GridLite", appRazorContent);
+
+        await AssertBuildsAsync("after scaffolding");
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_GridLiteOnly_WebApp()
+    {
+        // Arrange — Blazor Web App whose App.razor uses the fingerprinted asset collection (@Assets, .NET 9+)
+        SetupBlazorWebAppProject();
+        File.WriteAllText(Path.Combine(_testProjectDir, "Components", "App.razor"), GetAppRazorWithAssets());
+        await AssertBuildsAsync("before scaffolding");
+
+        // Act — dotnet scaffold aspnet blazor-igniteui --package GridLite
+        await RunScaffoldAndAssertSuccessAsync("--package", "GridLite");
+
+        // Assert — only GridLite is referenced; it needs no service registration, so Program.cs must be untouched
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(GridLitePackageName, projectContent);
+        Assert.DoesNotContain(LitePackageName, projectContent);
+
+        var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
+        Assert.DoesNotContain("AddIgniteUIBlazor", programContent);
+        Assert.DoesNotContain("IgniteUI.Blazor.Controls", programContent);
+
+        Assert.Contains(ControlsUsing, File.ReadAllText(Path.Combine(_testProjectDir, "Components", "_Imports.razor")));
+
+        // Assert — the GridLite-only stylesheet is linked with the same @Assets syntax as the existing link, right after it
+        var appRazorContent = File.ReadAllText(Path.Combine(_testProjectDir, "Components", "App.razor"));
+        var expectedLink = $"<link rel=\"stylesheet\" href=\"@Assets[\"{GridLiteBootstrapLightStylesheet}\"]\" />";
+        Assert.Contains(expectedLink, appRazorContent);
+        Assert.DoesNotContain("_content/IgniteUI.Blazor/themes", appRazorContent);
+        var existingLinkIndex = appRazorContent.IndexOf("@Assets[\"app.css\"]", StringComparison.Ordinal);
+        var themeLinkIndex = appRazorContent.IndexOf(expectedLink, StringComparison.Ordinal);
+        var headOutletIndex = appRazorContent.IndexOf("<HeadOutlet />", StringComparison.Ordinal);
+        Assert.True(existingLinkIndex < themeLinkIndex && themeLinkIndex < headOutletIndex,
+            $"The theme link should follow the existing stylesheet link inside <head>.\n{appRazorContent}");
+
+        await AssertBuildsAsync("after scaffolding");
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_RerunWithGridLite_KeepsLiteThemeAndSwapsTheme()
+    {
+        // Arrange — Blazor Web App that first gets IgniteUI.Blazor.Lite with the default light bootstrap theme
+        SetupBlazorWebAppProject();
+        await AssertBuildsAsync("before scaffolding");
+        await RunScaffoldAndAssertSuccessAsync("--package", "Lite");
+        Assert.Contains(LiteBootstrapLightStylesheet, File.ReadAllText(Path.Combine(_testProjectDir, "Components", "App.razor")));
+
+        // Act — re-run for GridLite with another theme. Lite is already referenced, so the IgniteUI.Blazor theme (not the
+        // GridLite-only one) must be kept, and the existing link must be swapped rather than duplicated.
+        var cliOutput = await RunScaffoldAndAssertSuccessAsync("--package", "GridLite", "--theme", "material", "--theme-variant", "dark");
+        Assert.Contains("already references IgniteUI.Blazor.Lite", cliOutput);
+
+        // Assert — both packages, exactly one theme link, pointing at the Lite dark material theme
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(LitePackageName, projectContent);
+        Assert.Contains(GridLitePackageName, projectContent);
+
+        var appRazorContent = File.ReadAllText(Path.Combine(_testProjectDir, "Components", "App.razor"));
+        Assert.Equal(1, CountOccurrences(appRazorContent, "_content/IgniteUI"));
+        Assert.Contains("_content/IgniteUI.Blazor/themes/dark/material.css", appRazorContent);
+        Assert.DoesNotContain(LiteBootstrapLightStylesheet, appRazorContent);
+        Assert.DoesNotContain("_content/IgniteUI.Blazor.GridLite", appRazorContent);
+
+        // Assert — the second run duplicated neither the registration nor the using directive
+        Assert.Equal(1, CountOccurrences(File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs")), "AddIgniteUIBlazor"));
+        Assert.Equal(1, CountOccurrences(File.ReadAllText(Path.Combine(_testProjectDir, "Components", "_Imports.razor")), ControlsUsing));
+
+        await AssertBuildsAsync("after scaffolding twice");
+    }
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net10_BlazorServer_WithProjectReference_RelativeProjectPath()
+    {
+        // Arrange — legacy Blazor Server layout (Pages/_Host.cshtml host page, root _Imports.razor) that references a
+        // class library. The scaffolder is invoked from the solution folder with a RELATIVE --project path: this is the
+        // combination that used to crash DetectBlazorWasmStep (relative base path passed to Path.GetFullPath).
+        File.WriteAllText(_testProjectPath, GetBlazorServerProjectContent());
+        File.WriteAllText(Path.Combine(_testProjectDir, "Program.cs"), GetBlazorServerProgramCs());
+        File.WriteAllText(Path.Combine(_testProjectDir, "App.razor"), GetBlazorServerAppRazor());
+        File.WriteAllText(Path.Combine(_testProjectDir, "_Imports.razor"), GetBlazorServerImportsRazor());
+        Directory.CreateDirectory(Path.Combine(_testProjectDir, "Pages"));
+        File.WriteAllText(Path.Combine(_testProjectDir, "Pages", "_Host.cshtml"), GetBlazorServerHostPage());
+        File.WriteAllText(Path.Combine(_testProjectDir, "Pages", "Index.razor"), "@page \"/\"\n<h1>@SharedLib.Greeter.Hello()</h1>\n");
+        Directory.CreateDirectory(Path.Combine(_testProjectDir, "Shared"));
+        File.WriteAllText(Path.Combine(_testProjectDir, "Shared", "MainLayout.razor"), "@inherits LayoutComponentBase\n<main>@Body</main>\n");
+        Directory.CreateDirectory(Path.Combine(_testProjectDir, "wwwroot", "css"));
+        File.WriteAllText(Path.Combine(_testProjectDir, "wwwroot", "css", "site.css"), "body { margin: 0; }\n");
+
+        var libraryDir = Path.Combine(_testDirectory, "SharedLib");
+        Directory.CreateDirectory(libraryDir);
+        File.WriteAllText(Path.Combine(libraryDir, "SharedLib.csproj"), GetClassLibraryProjectContent());
+        File.WriteAllText(Path.Combine(libraryDir, "Greeter.cs"), "namespace SharedLib;\n\npublic static class Greeter\n{\n    public static string Hello() => \"Hello\";\n}\n");
+
+        await AssertBuildsAsync("before scaffolding");
+
+        // Act — dotnet scaffold aspnet blazor-igniteui --project TestProject\TestProject.csproj --package All (from _testDirectory)
+        var relativeProjectPath = Path.Combine("TestProject", "TestProject.csproj");
+        var (cliExitCode, cliOutput, cliError) = await ScaffoldCliHelper.RunScaffoldInDirectoryAsync(
+            _testDirectory,
+            TargetFramework,
+            "blazor-igniteui",
+            "--project", relativeProjectPath,
+            "--package", "All");
+        Assert.True(cliExitCode == 0, $"CLI scaffold should succeed with a relative --project path.\nOutput: {cliOutput}\nError: {cliError}");
+        Assert.DoesNotContain("Unhandled exception", cliOutput + cliError);
+        Assert.False(cliOutput.Contains("error: NU"), $"Scaffolding should not produce NuGet errors.\nOutput: {cliOutput}");
+
+        // Assert — packages and service registration in the server project
+        var projectContent = File.ReadAllText(_testProjectPath);
+        Assert.Contains(LitePackageName, projectContent);
+        Assert.Contains(GridLitePackageName, projectContent);
+        var programContent = File.ReadAllText(Path.Combine(_testProjectDir, "Program.cs"));
+        Assert.Contains("using IgniteUI.Blazor.Controls;", programContent);
+        Assert.Contains("builder.Services.AddIgniteUIBlazor();", programContent);
+        Assert.True(programContent.IndexOf("AddIgniteUIBlazor", StringComparison.Ordinal) < programContent.IndexOf("var app = builder.Build();", StringComparison.Ordinal),
+            $"AddIgniteUIBlazor() should be registered before the app is built.\n{programContent}");
+
+        // Assert — Blazor Server layout: root _Imports.razor gets the using, Pages/_Host.cshtml gets the theme link
+        Assert.Contains(ControlsUsing, File.ReadAllText(Path.Combine(_testProjectDir, "_Imports.razor")));
+        // line endings are normalized because the fixture's verbatim string follows the checkout's line endings
+        var hostPageContent = File.ReadAllText(Path.Combine(_testProjectDir, "Pages", "_Host.cshtml")).ReplaceLineEndings("\n");
+        Assert.Contains($"    <link href=\"css/site.css\" rel=\"stylesheet\" />\n    <link href=\"{LiteBootstrapLightStylesheet}\" rel=\"stylesheet\" />", hostPageContent);
+        Assert.DoesNotContain("_content/IgniteUI", File.ReadAllText(Path.Combine(_testProjectDir, "App.razor")));
+
+        // Assert — the class library reference was inspected without being treated as a WebAssembly client
+        Assert.DoesNotContain("Detected Blazor WebAssembly project", cliOutput);
+        Assert.DoesNotContain("IgniteUI", File.ReadAllText(Path.Combine(libraryDir, "SharedLib.csproj")));
+
+        await AssertBuildsAsync("after scaffolding");
+    }
+
+    private string GetBlazorServerProjectContent() => $@"<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\SharedLib\SharedLib.csproj"" />
+  </ItemGroup>
+</Project>";
+
+    private string GetClassLibraryProjectContent() => $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>";
+
+    private static string GetBlazorServerProgramCs() => @"using TestProject;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+var app = builder.Build();
+app.UseStaticFiles();
+app.UseRouting();
+app.MapBlazorHub();
+app.MapFallbackToPage(""/_Host"");
+app.Run();
+";
+
+    private static string GetBlazorServerHostPage() => @"@page ""/""
+@namespace TestProject.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Components.Web
+<!DOCTYPE html>
+<html lang=""en"">
+<head>
+    <meta charset=""utf-8"" />
+    <base href=""~/"" />
+    <link href=""css/site.css"" rel=""stylesheet"" />
+    <component type=""typeof(HeadOutlet)"" render-mode=""ServerPrerendered"" />
+</head>
+<body>
+    <component type=""typeof(App)"" render-mode=""ServerPrerendered"" />
+    <script src=""_framework/blazor.server.js""></script>
+</body>
+</html>
+";
+
+    private static string GetBlazorServerAppRazor() => @"<Router AppAssembly=""@typeof(App).Assembly"">
+    <Found Context=""routeData"">
+        <RouteView RouteData=""@routeData"" DefaultLayout=""@typeof(MainLayout)"" />
+    </Found>
+    <NotFound>
+        <p>Not found</p>
+    </NotFound>
+</Router>
+";
+
+    private static string GetBlazorServerImportsRazor() => @"@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using TestProject
+@using TestProject.Shared
+";
+
+    private const string GridLiteBootstrapLightStylesheet = "_content/IgniteUI.Blazor.GridLite/css/themes/light/bootstrap.css";
+
+    private async Task AssertBuildsAsync(string phase)
+    {
+        var (exitCode, output, error) = await RunBuildAsync(_testProjectDir);
+        Assert.True(exitCode == 0, $"Project should build {phase}.\nExit code: {exitCode}\nOutput: {output}\nError: {error}");
+    }
+
+    private async Task<string> RunScaffoldAndAssertSuccessAsync(params string[] extraCliArgs)
+    {
+        string[] args = ["--project", _testProjectPath, .. extraCliArgs];
+        var (cliExitCode, cliOutput, cliError) = await ScaffoldCliHelper.RunScaffoldAsync(TargetFramework, "blazor-igniteui", args);
+        Assert.True(cliExitCode == 0, $"CLI scaffold should succeed.\nOutput: {cliOutput}\nError: {cliError}");
+        Assert.False(cliOutput.Contains("error: NU"), $"Scaffolding should not produce NuGet errors.\nOutput: {cliOutput}");
+        return cliOutput;
+    }
+
+    private static int CountOccurrences(string content, string value) => Regex.Matches(content, Regex.Escape(value)).Count;
+
+    /// <summary>
+    /// App.razor in the .NET 9+ template style, where stylesheet links use the fingerprinted asset collection.
+    /// </summary>
+    private static string GetAppRazorWithAssets() => @"<!DOCTYPE html>
+<html lang=""en"">
+<head>
+    <meta charset=""utf-8"" />
+    <base href=""/"" />
+    <link rel=""stylesheet"" href=""@Assets[""app.css""]"" />
+    <HeadOutlet />
+</head>
+<body>
+    <Routes />
+    <script src=""_framework/blazor.web.js""></script>
+</body>
+</html>
+";
+
+    private string GetSplitServerProjectContent() => $@"<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Components.WebAssembly.Server"" Version=""10.0.*"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\TestProject.Client\TestProject.Client.csproj"" />
+  </ItemGroup>
+</Project>";
+
+    private static string GetSplitServerProgramCs() => @"using TestProject.Components;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddRazorComponents()
+    .AddInteractiveWebAssemblyComponents();
+
+var app = builder.Build();
+app.MapRazorComponents<App>()
+    .AddInteractiveWebAssemblyRenderMode();
+app.Run();
+";
+
+    private string GetSplitClientProjectContent() => $@"<Project Sdk=""Microsoft.NET.Sdk.BlazorWebAssembly"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Components.WebAssembly"" Version=""10.0.*"" />
+  </ItemGroup>
+</Project>";
+
+    private static string GetSplitClientProgramCs() => @"using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+await builder.Build().RunAsync();
+";
+
+    private static string GetSplitClientImportsRazor() => @"@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using TestProject.Client
+";
+
+    private string GetWasmProjectContent() => $@"<Project Sdk=""Microsoft.NET.Sdk.BlazorWebAssembly"">
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Components.WebAssembly"" Version=""10.0.*"" />
+  </ItemGroup>
+</Project>";
+
+    private static string GetWasmProgramCs() => @"using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using TestProject;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>(""#app"");
+builder.RootComponents.Add<HeadOutlet>(""head::after"");
+
+await builder.Build().RunAsync();
+";
+
+    private static string GetWasmAppRazor() => @"<Router AppAssembly=""typeof(App).Assembly"">
+    <Found Context=""routeData"">
+        <RouteView RouteData=""routeData"" />
+    </Found>
+</Router>
+";
+
+    private static string GetWasmImportsRazor() => @"@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using TestProject
+";
+
+    private static string GetWasmIndexHtml() => @"<!DOCTYPE html>
+<html lang=""en"">
+<head>
+    <meta charset=""utf-8"" />
+    <title>TestProject</title>
+    <base href=""/"" />
+    <link rel=""stylesheet"" href=""css/app.css"" />
+</head>
+<body>
+    <div id=""app"">Loading...</div>
+    <script src=""_framework/blazor.webassembly.js""></script>
+</body>
+</html>
+";
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet11IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet11IntegrationTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Tools.Scaffold.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Integration.Blazor;
+
+public class BlazorIgniteUINet11IntegrationTests : BlazorIgniteUIIntegrationTestsBase
+{
+    protected override string TargetFramework => "net11.0";
+    protected override string TestClassName => nameof(BlazorIgniteUINet11IntegrationTests);
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net11_CliInvocation()
+    {
+        // Arrange — Blazor Web App; allow warnings so preview-SDK warnings do not fail the build, and use
+        // the preview feeds so the preview-only framework packages resolve during restore/build.
+        // The dnceng mirror feeds only carry Microsoft packages, so nuget.org is added as an extra source:
+        // the third-party Ignite UI packages are otherwise reported as "no versions available".
+        SetupBlazorWebAppProject("    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>");
+        var nugetConfig = ScaffoldCliHelper.PreviewNuGetConfig.Replace(
+            "<clear />",
+            "<clear />\n    <add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" />");
+        File.WriteAllText(Path.Combine(_testProjectDir, "NuGet.config"), nugetConfig);
+
+        // Act + Assert — dotnet scaffold aspnet blazor-igniteui --package All
+        // The Ignite UI packages ship net10.0 assets which net11.0 projects consume; no prerelease needed.
+        await ScaffoldAllPackagesAndAssertAsync();
+    }
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet8IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet8IntegrationTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Tools.Scaffold.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Integration.Blazor;
+
+public class BlazorIgniteUINet8IntegrationTests : BlazorIgniteUIIntegrationTestsBase
+{
+    protected override string TargetFramework => "net8.0";
+    protected override string TestClassName => nameof(BlazorIgniteUINet8IntegrationTests);
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net8_CliInvocation()
+    {
+        // Arrange — Blazor Web App restricted to nuget.org so preview feeds do not interfere
+        SetupBlazorWebAppProject();
+        File.WriteAllText(Path.Combine(_testProjectDir, "NuGet.config"), ScaffoldCliHelper.StableNuGetConfig);
+
+        // Act + Assert — dotnet scaffold aspnet blazor-igniteui --package All
+        await ScaffoldAllPackagesAndAssertAsync();
+    }
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet9IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/BlazorIgniteUINet9IntegrationTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Tools.Scaffold.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Integration.Blazor;
+
+public class BlazorIgniteUINet9IntegrationTests : BlazorIgniteUIIntegrationTestsBase
+{
+    protected override string TargetFramework => "net9.0";
+    protected override string TestClassName => nameof(BlazorIgniteUINet9IntegrationTests);
+
+    [Fact]
+    public async Task Scaffold_BlazorIgniteUI_Net9_CliInvocation()
+    {
+        // Arrange — Blazor Web App restricted to nuget.org so preview feeds do not interfere
+        SetupBlazorWebAppProject();
+        File.WriteAllText(Path.Combine(_testProjectDir, "NuGet.config"), ScaffoldCliHelper.StableNuGetConfig);
+
+        // Act + Assert — dotnet scaffold aspnet blazor-igniteui --package All
+        await ScaffoldAllPackagesAndAssertAsync();
+    }
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddIgniteUIThemeStylesheetStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddIgniteUIThemeStylesheetStepTests.cs
@@ -1,0 +1,289 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using static Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps.AddIgniteUIThemeStylesheetStep;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.ScaffoldSteps;
+
+public class AddIgniteUIThemeStylesheetStepTests
+{
+    private const string LiteBootstrapLight = "_content/IgniteUI.Blazor/themes/light/bootstrap.css";
+    private const string LiteMaterialDark = "_content/IgniteUI.Blazor/themes/dark/material.css";
+    private const string GridLiteBootstrapLight = "_content/IgniteUI.Blazor.GridLite/css/themes/light/bootstrap.css";
+
+    private static readonly string s_appRazorPath = Path.Combine("C:", "src", "MyApp", "Components", "App.razor");
+    private static readonly string s_indexHtmlPath = Path.Combine("C:", "src", "MyApp", "wwwroot", "index.html");
+    private static readonly string s_hostCshtmlPath = Path.Combine("C:", "src", "MyApp", "Pages", "_Host.cshtml");
+
+    // Fixtures are normalized to '\n' so the assertions do not depend on the checkout's line endings.
+    private static readonly string AppRazor = AppRazorRaw.ReplaceLineEndings("\n");
+    private static readonly string IndexHtml = IndexHtmlRaw.ReplaceLineEndings("\n");
+
+    private const string AppRazorRaw = """
+        <!DOCTYPE html>
+        <html lang="en">
+
+        <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <base href="/" />
+            <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
+            <link rel="stylesheet" href="@Assets["app.css"]" />
+            <link rel="stylesheet" href="@Assets["MyApp.styles.css"]" />
+            <ImportMap />
+            <link rel="icon" type="image/png" href="favicon.png" />
+            <HeadOutlet />
+        </head>
+
+        <body>
+            <Routes />
+            <script src="_framework/blazor.web.js"></script>
+        </body>
+
+        </html>
+        """;
+
+    private const string IndexHtmlRaw = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <title>MyApp</title>
+            <base href="/" />
+            <link rel="stylesheet" href="css/app.css" />
+        </head>
+        <body>
+            <div id="app">Loading...</div>
+            <script src="_framework/blazor.webassembly.js"></script>
+        </body>
+        </html>
+        """;
+
+    private readonly Mock<IFileSystem> _mockFileSystem = new();
+    private readonly Mock<ITelemetryService> _mockTelemetryService = new();
+    private readonly ScaffolderContext _context;
+
+    public AddIgniteUIThemeStylesheetStepTests()
+    {
+        var mockScaffolder = new Mock<IScaffolder>();
+        mockScaffolder.Setup(s => s.DisplayName).Returns("TestScaffolder");
+        mockScaffolder.Setup(s => s.Name).Returns("test-scaffolder");
+        _context = new ScaffolderContext(mockScaffolder.Object);
+    }
+
+    private AddIgniteUIThemeStylesheetStep CreateStep(string hostPagePath, string stylesheetPath)
+        => new(NullLogger<AddIgniteUIThemeStylesheetStep>.Instance, _mockFileSystem.Object, _mockTelemetryService.Object)
+        {
+            HostPagePath = hostPagePath,
+            StylesheetPath = stylesheetPath
+        };
+
+    #region ExecuteAsync
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenHostPageMissing()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(s_appRazorPath)).Returns(false);
+        var step = CreateStep(s_appRazorPath, LiteBootstrapLight);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenPathsEmpty()
+    {
+        var step = CreateStep(string.Empty, string.Empty);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesUpdatedHostPage_AndTracksTelemetry()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(s_indexHtmlPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(s_indexHtmlPath)).Returns(IndexHtml);
+        string? written = null;
+        _mockFileSystem.Setup(f => f.WriteAllText(s_indexHtmlPath, It.IsAny<string>())).Callback<string, string>((_, c) => written = c);
+        var step = CreateStep(s_indexHtmlPath, GridLiteBootstrapLight);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.NotNull(written);
+        Assert.Contains($"<link href=\"{GridLiteBootstrapLight}\" rel=\"stylesheet\" />", written);
+        _mockTelemetryService.Verify(t => t.TrackEvent(
+            It.Is<string>(name => name.Contains(nameof(AddIgniteUIThemeStylesheetStep))),
+            It.IsAny<IReadOnlyDictionary<string, string>>(),
+            It.IsAny<IReadOnlyDictionary<string, double>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotWrite_WhenAlreadyLinked()
+    {
+        var content = IndexHtml.Replace("css/app.css", GridLiteBootstrapLight);
+        _mockFileSystem.Setup(f => f.FileExists(s_indexHtmlPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(s_indexHtmlPath)).Returns(content);
+        var step = CreateStep(s_indexHtmlPath, GridLiteBootstrapLight);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenNoHeadElement()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(s_appRazorPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(s_appRazorPath)).Returns("<Routes />");
+        var step = CreateStep(s_appRazorPath, LiteBootstrapLight);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    #endregion
+
+    #region ApplyStylesheetLink
+
+    [Fact]
+    public void ApplyStylesheetLink_InsertsAfterLastLink_UsingAssetsSyntax_ForRazorHostPage()
+    {
+        var updated = ApplyStylesheetLink(s_appRazorPath, AppRazor, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        var expectedLine = $"    <link rel=\"stylesheet\" href=\"@Assets[\"{LiteBootstrapLight}\"]\" />";
+        Assert.Contains(expectedLine, updated);
+        // inserted right after the last <link> (favicon) and before <HeadOutlet />
+        var faviconIndex = updated.IndexOf("favicon.png", System.StringComparison.Ordinal);
+        var insertedIndex = updated.IndexOf(expectedLine, System.StringComparison.Ordinal);
+        var headOutletIndex = updated.IndexOf("<HeadOutlet />", System.StringComparison.Ordinal);
+        Assert.True(faviconIndex < insertedIndex && insertedIndex < headOutletIndex);
+        Assert.Single(Regex.Matches(updated, Regex.Escape(LiteBootstrapLight)));
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_UsesPlainHref_ForHtmlHostPage()
+    {
+        var updated = ApplyStylesheetLink(s_indexHtmlPath, IndexHtml, GridLiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        Assert.Contains($"    <link rel=\"stylesheet\" href=\"css/app.css\" />\n    <link href=\"{GridLiteBootstrapLight}\" rel=\"stylesheet\" />\n</head>", updated);
+        Assert.DoesNotContain("@Assets", updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_UsesPlainHref_ForRazorHostPageWithoutAssets()
+    {
+        var content = AppRazor.Replace("@Assets[\"lib/bootstrap/dist/css/bootstrap.min.css\"]", "lib/bootstrap/dist/css/bootstrap.min.css")
+            .Replace("@Assets[\"app.css\"]", "app.css")
+            .Replace("@Assets[\"MyApp.styles.css\"]", "MyApp.styles.css");
+
+        var updated = ApplyStylesheetLink(s_appRazorPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        Assert.Contains($"    <link href=\"{LiteBootstrapLight}\" rel=\"stylesheet\" />", updated);
+        Assert.DoesNotContain("@Assets", updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_ReturnsUnchanged_WhenAlreadyLinked()
+    {
+        var content = IndexHtml.Replace("css/app.css", LiteBootstrapLight);
+
+        var updated = ApplyStylesheetLink(s_indexHtmlPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.AlreadyLinked, outcome);
+        Assert.Equal(content, updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_SwapsExistingIgniteUITheme_InsteadOfAddingSecondLink()
+    {
+        var content = IndexHtml.Replace("css/app.css", LiteBootstrapLight);
+
+        var updated = ApplyStylesheetLink(s_indexHtmlPath, content, LiteMaterialDark, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Replaced, outcome);
+        Assert.DoesNotContain(LiteBootstrapLight, updated);
+        Assert.Contains(LiteMaterialDark, updated);
+        Assert.Single(Regex.Matches(updated, "_content/IgniteUI"));
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_SwapsGridLiteTheme_ForLiteTheme()
+    {
+        var content = IndexHtml.Replace("css/app.css", GridLiteBootstrapLight);
+
+        var updated = ApplyStylesheetLink(s_indexHtmlPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Replaced, outcome);
+        Assert.DoesNotContain(GridLiteBootstrapLight, updated);
+        Assert.Contains($"href=\"{LiteBootstrapLight}\"", updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_InsertsBeforeHead_WhenNoLinkExists()
+    {
+        var content = "<html>\n<head>\n    <title>Test</title>\n</head>\n<body></body>\n</html>\n";
+
+        var updated = ApplyStylesheetLink(s_hostCshtmlPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        Assert.Equal($"<html>\n<head>\n    <title>Test</title>\n    <link href=\"{LiteBootstrapLight}\" rel=\"stylesheet\" />\n</head>\n<body></body>\n</html>\n", updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_BreaksLine_WhenHeadIsOnSingleLine()
+    {
+        var content = "<html>\n<head><title>Test</title><HeadOutlet /></head>\n<body><Routes /></body>\n</html>\n";
+
+        var updated = ApplyStylesheetLink(s_appRazorPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        Assert.Equal($"<html>\n<head><title>Test</title><HeadOutlet />\n    <link href=\"{LiteBootstrapLight}\" rel=\"stylesheet\" />\n</head>\n<body><Routes /></body>\n</html>\n", updated);
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_PreservesCrlfLineEndings()
+    {
+        var content = IndexHtml.Replace("\n", "\r\n");
+
+        var updated = ApplyStylesheetLink(s_indexHtmlPath, content, GridLiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.Inserted, outcome);
+        Assert.Contains($"    <link rel=\"stylesheet\" href=\"css/app.css\" />\r\n    <link href=\"{GridLiteBootstrapLight}\" rel=\"stylesheet\" />\r\n</head>", updated);
+        // no lone '\n' was introduced
+        Assert.DoesNotContain("\n", updated.Replace("\r\n", string.Empty));
+    }
+
+    [Fact]
+    public void ApplyStylesheetLink_ReturnsNoHeadElement_WhenHeadMissing()
+    {
+        var content = "<Routes />";
+
+        var updated = ApplyStylesheetLink(s_appRazorPath, content, LiteBootstrapLight, out var outcome);
+
+        Assert.Equal(StylesheetLinkOutcome.NoHeadElement, outcome);
+        Assert.Equal(content, updated);
+    }
+
+    #endregion
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddRazorImportsStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddRazorImportsStepTests.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.ScaffoldSteps;
+
+public class AddRazorImportsStepTests
+{
+    private const string Namespace = "IgniteUI.Blazor.Controls";
+    private readonly Mock<IFileSystem> _mockFileSystem = new();
+    private readonly Mock<ITelemetryService> _mockTelemetryService = new();
+    private readonly ScaffolderContext _context;
+    private readonly string _importsPath = Path.Combine("C:", "src", "MyApp", "Components", "_Imports.razor");
+
+    public AddRazorImportsStepTests()
+    {
+        var mockScaffolder = new Mock<IScaffolder>();
+        mockScaffolder.Setup(s => s.DisplayName).Returns("TestScaffolder");
+        mockScaffolder.Setup(s => s.Name).Returns("test-scaffolder");
+        _context = new ScaffolderContext(mockScaffolder.Object);
+    }
+
+    private AddRazorImportsStep CreateStep(string importsPath, params string[] namespaces)
+        => new(NullLogger<AddRazorImportsStep>.Instance, _mockFileSystem.Object, _mockTelemetryService.Object)
+        {
+            ImportsFilePath = importsPath,
+            Namespaces = namespaces
+        };
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenImportsPathIsEmpty()
+    {
+        var step = CreateStep(string.Empty, Namespace);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreatesFile_WhenImportsFileDoesNotExist()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(_importsPath)).Returns(false);
+        string? written = null;
+        _mockFileSystem.Setup(f => f.WriteAllText(_importsPath, It.IsAny<string>())).Callback<string, string>((_, c) => written = c);
+        var step = CreateStep(_importsPath, Namespace);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        _mockFileSystem.Verify(f => f.CreateDirectoryIfNotExists(Path.GetDirectoryName(_importsPath)!), Times.Once);
+        Assert.NotNull(written);
+        Assert.Contains($"@using {Namespace}", written);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AppendsUsing_WhenMissing()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(_importsPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(_importsPath)).Returns("@using Microsoft.AspNetCore.Components.Forms\n@using Microsoft.AspNetCore.Components.Web\n");
+        string? written = null;
+        _mockFileSystem.Setup(f => f.WriteAllText(_importsPath, It.IsAny<string>())).Callback<string, string>((_, c) => written = c);
+        var step = CreateStep(_importsPath, Namespace);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal("@using Microsoft.AspNetCore.Components.Forms\n@using Microsoft.AspNetCore.Components.Web\n@using IgniteUI.Blazor.Controls\n", written);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotWrite_WhenUsingAlreadyPresent()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(_importsPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(_importsPath)).Returns("@using Microsoft.AspNetCore.Components.Web\n@using IgniteUI.Blazor.Controls\n");
+        var step = CreateStep(_importsPath, Namespace);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenNoNamespacesRequested()
+    {
+        var step = CreateStep(_importsPath);
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+        _mockFileSystem.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TracksTelemetryEvent()
+    {
+        _mockFileSystem.Setup(f => f.FileExists(_importsPath)).Returns(true);
+        _mockFileSystem.Setup(f => f.ReadAllText(_importsPath)).Returns(string.Empty);
+        var step = CreateStep(_importsPath, Namespace);
+
+        await step.ExecuteAsync(_context, CancellationToken.None);
+
+        _mockTelemetryService.Verify(t => t.TrackEvent(
+            It.Is<string>(name => name.Contains(nameof(AddRazorImportsStep))),
+            It.IsAny<IReadOnlyDictionary<string, string>>(),
+            It.IsAny<IReadOnlyDictionary<string, double>>()), Times.Once);
+    }
+
+    [Fact]
+    public void AddUsings_PreservesCrlfLineEndings()
+    {
+        var content = "@using A\r\n@using B\r\n";
+
+        var updated = AddRazorImportsStep.AddUsings(content, [Namespace], out var added);
+
+        Assert.Equal("@using A\r\n@using B\r\n@using IgniteUI.Blazor.Controls\r\n", updated);
+        Assert.Equal(new[] { Namespace }, added);
+    }
+
+    [Fact]
+    public void AddUsings_AddsLineBreak_WhenContentDoesNotEndWithNewline()
+    {
+        var updated = AddRazorImportsStep.AddUsings("@using A", [Namespace], out _);
+
+        Assert.Equal("@using A\n@using IgniteUI.Blazor.Controls\n", updated);
+    }
+
+    [Fact]
+    public void AddUsings_AddsOnlyMissingNamespaces()
+    {
+        var updated = AddRazorImportsStep.AddUsings("@using A\n", ["A", "B", "C"], out var added);
+
+        Assert.Equal("@using A\n@using B\n@using C\n", updated);
+        Assert.Equal(new[] { "B", "C" }, added);
+    }
+
+    [Theory]
+    [InlineData("@using IgniteUI.Blazor.Controls", true)]
+    [InlineData("  @using   IgniteUI.Blazor.Controls  ", true)]
+    [InlineData("@using IgniteUI.Blazor.Controls;", true)]
+    [InlineData("@using Microsoft.AspNetCore.Components.Web\r\n@using IgniteUI.Blazor.Controls\r\n", true)]
+    [InlineData("@using IgniteUI.Blazor.Controls.Extra", false)]
+    [InlineData("@using IgniteUI.Blazor", false)]
+    [InlineData("@* @using IgniteUI.Blazor.Controls *@", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void ContainsUsing_MatchesWholeDirectiveOnly(string? content, bool expected)
+        => Assert.Equal(expected, AddRazorImportsStep.ContainsUsing(content, Namespace));
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/DetectBlazorWasmStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/DetectBlazorWasmStepTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.ScaffoldSteps;
+
+public class DetectBlazorWasmStepTests
+{
+    [Fact]
+    public void GetReferenceFullPath_ResolvesRelativeReference_AgainstAbsoluteProjectDirectory()
+    {
+        var projectDir = Path.Combine(Path.GetTempPath(), "Solution", "App");
+        var projectPath = Path.Combine(projectDir, "App.csproj");
+        var reference = Path.Combine("..", "App.Client", "App.Client.csproj");
+
+        var result = DetectBlazorWasmStep.GetReferenceFullPath(projectPath, reference);
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(Path.GetTempPath(), "Solution", "App.Client", "App.Client.csproj")), result);
+    }
+
+    [Fact]
+    public void GetReferenceFullPath_FullyQualifiesRelativeProjectPath_BeforeResolving()
+    {
+        // '--project .\App\App.csproj' style input: Path.GetFullPath(reference, basePath) throws for a relative base path,
+        // which is exactly the failure this helper guards against.
+        var projectPath = Path.Combine("App", "App.csproj");
+        var reference = Path.Combine("..", "SharedLib", "SharedLib.csproj");
+
+        var result = DetectBlazorWasmStep.GetReferenceFullPath(projectPath, reference);
+
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathFullyQualified(result));
+        Assert.Equal(Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "SharedLib", "SharedLib.csproj")), result);
+    }
+
+    [Fact]
+    public void GetReferenceFullPath_ReturnsAbsoluteReference_Unchanged()
+    {
+        var projectPath = Path.Combine("App", "App.csproj");
+        var reference = Path.Combine(Path.GetTempPath(), "Elsewhere", "Lib.csproj");
+
+        var result = DetectBlazorWasmStep.GetReferenceFullPath(projectPath, reference);
+
+        Assert.Equal(Path.GetFullPath(reference), result);
+    }
+
+    [Theory]
+    [InlineData(null, "Lib.csproj")]
+    [InlineData("", "Lib.csproj")]
+    [InlineData("App.csproj", null)]
+    [InlineData("App.csproj", "")]
+    public void GetReferenceFullPath_ReturnsNull_ForMissingInputs(string? projectPath, string? reference)
+        => Assert.Null(DetectBlazorWasmStep.GetReferenceFullPath(projectPath, reference));
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/ValidateIgniteUIBlazorStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/ValidateIgniteUIBlazorStepTests.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Internal.Services;
+using Microsoft.DotNet.Scaffolding.Internal.Telemetry;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.ScaffoldSteps;
+
+public class ValidateIgniteUIBlazorStepTests
+{
+    private readonly Mock<IFileSystem> _mockFileSystem;
+    private readonly Mock<ILogger<ValidateIgniteUIBlazorStep>> _mockLogger;
+    private readonly TestTelemetryService _testTelemetryService;
+    private readonly ScaffolderContext _context;
+    private readonly string _testProjectPath;
+
+    public ValidateIgniteUIBlazorStepTests()
+    {
+        _mockFileSystem = new Mock<IFileSystem>();
+        _mockLogger = new Mock<ILogger<ValidateIgniteUIBlazorStep>>();
+        _testTelemetryService = new TestTelemetryService();
+        _testProjectPath = Path.Combine("test", "project", "TestProject.csproj");
+
+        var mockScaffolder = new Mock<IScaffolder>();
+        mockScaffolder.Setup(s => s.DisplayName).Returns("TestScaffolder");
+        mockScaffolder.Setup(s => s.Name).Returns("test-scaffolder");
+        _context = new ScaffolderContext(mockScaffolder.Object);
+    }
+
+    private ValidateIgniteUIBlazorStep CreateStep()
+        => new(_mockFileSystem.Object, _mockLogger.Object, _testTelemetryService);
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenProjectIsEmpty()
+    {
+        var step = CreateStep();
+        step.Project = string.Empty;
+        step.Package = "Lite";
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Single(_testTelemetryService.TrackedEvents);
+        Assert.Equal("Failure", _testTelemetryService.TrackedEvents[0].Properties["Result"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenProjectDoesNotExist()
+    {
+        _mockFileSystem.Setup(fs => fs.FileExists(_testProjectPath)).Returns(false);
+        var step = CreateStep();
+        step.Project = _testProjectPath;
+        step.Package = "Lite";
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Single(_testTelemetryService.TrackedEvents);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Grid")]
+    [InlineData("Both")]
+    public async Task ExecuteAsync_ReturnsFalse_WhenPackageIsInvalid(string? package)
+    {
+        _mockFileSystem.Setup(fs => fs.FileExists(_testProjectPath)).Returns(true);
+        var step = CreateStep();
+        step.Project = _testProjectPath;
+        step.Package = package;
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Single(_testTelemetryService.TrackedEvents);
+        Assert.False(_context.Properties.ContainsKey("IgniteUIBlazorSettings"));
+    }
+
+    [Fact]
+    public void Properties_CanBeSet()
+    {
+        var step = CreateStep();
+        step.Project = _testProjectPath;
+        step.Package = "All";
+        step.Theme = "material";
+        step.ThemeVariant = "dark";
+        step.Prerelease = true;
+
+        Assert.Equal(_testProjectPath, step.Project);
+        Assert.Equal("All", step.Package);
+        Assert.Equal("material", step.Theme);
+        Assert.Equal("dark", step.ThemeVariant);
+        Assert.True(step.Prerelease);
+    }
+
+    [Fact]
+    public void Properties_DefaultToNullAndFalse()
+    {
+        var step = CreateStep();
+
+        Assert.Null(step.Project);
+        Assert.Null(step.Package);
+        Assert.Null(step.Theme);
+        Assert.Null(step.ThemeVariant);
+        Assert.False(step.Prerelease);
+    }
+
+    private class TestTelemetryService : ITelemetryService
+    {
+        public List<(string EventName, IReadOnlyDictionary<string, string> Properties, IReadOnlyDictionary<string, double> Measurements)> TrackedEvents { get; } = new();
+
+        public void TrackEvent(string eventName, IReadOnlyDictionary<string, string> properties, IReadOnlyDictionary<string, double> measurements)
+        {
+            TrackedEvents.Add((eventName, properties, measurements));
+        }
+
+        public void Flush()
+        {
+        }
+    }
+}

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/AspNetOptionCoverageTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/AspNetOptionCoverageTests.cs
@@ -290,4 +290,68 @@ public class AspNetOptionCoverageTests
         => Assert.False(_options.ApplicationId.Required);
 
     #endregion
+
+    #region --package (IgniteUIPackage)
+
+    [Fact]
+    public void IgniteUIPackage_HasCorrectCliOption()
+        => Assert.Equal(Constants.CliOptions.IgniteUIPackageOption, _options.IgniteUIPackage.CliOption);
+
+    [Fact]
+    public void IgniteUIPackage_IsRequired()
+        => Assert.True(_options.IgniteUIPackage.Required);
+
+    [Fact]
+    public void IgniteUIPackage_HasCustomPickerValues()
+        => Assert.Equal(new[] { "Lite", "GridLite", "All" }, _options.IgniteUIPackage.CustomPickerValues!);
+
+    [Fact]
+    public void IgniteUIPackage_HasNonEmptyDescription()
+        => Assert.False(string.IsNullOrWhiteSpace(_options.IgniteUIPackage.Description));
+
+    [Fact]
+    public void IgniteUIPackage_HasNonEmptyDisplayName()
+        => Assert.False(string.IsNullOrWhiteSpace(_options.IgniteUIPackage.DisplayName));
+
+    #endregion
+
+    #region --theme (IgniteUITheme)
+
+    [Fact]
+    public void IgniteUITheme_HasCorrectCliOption()
+        => Assert.Equal(Constants.CliOptions.IgniteUIThemeOption, _options.IgniteUITheme.CliOption);
+
+    [Fact]
+    public void IgniteUITheme_IsNotRequired()
+        => Assert.False(_options.IgniteUITheme.Required);
+
+    [Fact]
+    public void IgniteUITheme_HasCustomPickerValues()
+        => Assert.Equal(new[] { "bootstrap", "material", "fluent", "indigo" }, _options.IgniteUITheme.CustomPickerValues!);
+
+    [Fact]
+    public void IgniteUITheme_HasNonEmptyDescription()
+        => Assert.False(string.IsNullOrWhiteSpace(_options.IgniteUITheme.Description));
+
+    #endregion
+
+    #region --theme-variant (IgniteUIThemeVariant)
+
+    [Fact]
+    public void IgniteUIThemeVariant_HasCorrectCliOption()
+        => Assert.Equal(Constants.CliOptions.IgniteUIThemeVariantOption, _options.IgniteUIThemeVariant.CliOption);
+
+    [Fact]
+    public void IgniteUIThemeVariant_IsNotRequired()
+        => Assert.False(_options.IgniteUIThemeVariant.Required);
+
+    [Fact]
+    public void IgniteUIThemeVariant_HasCustomPickerValues()
+        => Assert.Equal(new[] { "light", "dark" }, _options.IgniteUIThemeVariant.CustomPickerValues!);
+
+    [Fact]
+    public void IgniteUIThemeVariant_HasNonEmptyDescription()
+        => Assert.False(string.IsNullOrWhiteSpace(_options.IgniteUIThemeVariant.Description));
+
+    #endregion
 }

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/CliOptionInventoryTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/CliOptionInventoryTests.cs
@@ -47,6 +47,9 @@ public class CliOptionInventoryTests
         Constants.CliOptions.TenantIdOption,            // --tenantId
         Constants.CliOptions.UseExistingApplicationOption, // --use-existing-application
         Constants.CliOptions.ApplicationIdOption,       // --applicationId
+        Constants.CliOptions.IgniteUIPackageOption,      // --package
+        Constants.CliOptions.IgniteUIThemeOption,        // --theme
+        Constants.CliOptions.IgniteUIThemeVariantOption, // --theme-variant
     };
 
     /// <summary>
@@ -85,6 +88,7 @@ public class CliOptionInventoryTests
         ["blazor-identity"] = new() { "--project", "--dataContext", "--dbProvider", "--overwrite", "--prerelease" },
         ["identity"] = new() { "--project", "--dataContext", "--dbProvider", "--overwrite", "--prerelease" },
         ["entra-id"] = new() { "--username", "--project", "--tenantId", "--use-existing-application", "--applicationId" },
+        ["blazor-igniteui"] = new() { "--project", "--package", "--theme", "--theme-variant", "--prerelease" },
     };
 
     /// <summary>
@@ -136,6 +140,9 @@ public class CliOptionInventoryTests
             options.Username.CliOption!,
             options.TenantId.CliOption!,
             options.ApplicationId.CliOption!,
+            options.IgniteUIPackage.CliOption!,
+            options.IgniteUITheme.CliOption!,
+            options.IgniteUIThemeVariant.CliOption!,
         };
 
         var missingFromManifest = declaredFlags.Except(AllAspNetCliFlags).ToList();
@@ -191,6 +198,9 @@ public class CliOptionInventoryTests
             options.Username.CliOption!,
             options.TenantId.CliOption!,
             options.ApplicationId.CliOption!,
+            options.IgniteUIPackage.CliOption!,
+            options.IgniteUITheme.CliOption!,
+            options.IgniteUIThemeVariant.CliOption!,
         };
 
         var staleFlags = AllAspNetCliFlags.Except(declaredFlags).ToList();

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/ScaffoldingMatrix.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/CI/ScaffoldingMatrix.cs
@@ -37,7 +37,8 @@ public static class ScaffoldingMatrix
         "area",
         "blazor-identity",
         "identity",
-        "entra-id"
+        "entra-id",
+        "blazor-igniteui"
     ];
 
     /// <summary>Aspire scaffolder families.</summary>

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/Helpers/ScaffoldCliHelper.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/Helpers/ScaffoldCliHelper.cs
@@ -164,7 +164,20 @@ internal static class ScaffoldCliHelper
     /// <param name="command">The scaffold sub-command (e.g., "minimalapi", "mvccontroller", "blazor-empty").</param>
     /// <param name="args">CLI arguments for the command (e.g., "--project", path, "--name", "Foo").</param>
     /// <returns>A tuple of (ExitCode, StandardOutput, StandardError).</returns>
-    public static async Task<(int ExitCode, string Output, string Error)> RunScaffoldAsync(string targetFramework, string command, params string[] args)
+    public static Task<(int ExitCode, string Output, string Error)> RunScaffoldAsync(string targetFramework, string command, params string[] args)
+        => RunScaffoldInDirectoryAsync(workingDirectory: null, targetFramework, command, args);
+
+    /// <summary>
+    /// Same as <see cref="RunScaffoldAsync"/>, but runs the tool with <paramref name="workingDirectory"/> as its current
+    /// directory so that relative CLI arguments such as <c>--project .\App\App.csproj</c> resolve against it. This mirrors
+    /// how users invoke <c>dotnet scaffold</c> from a solution folder; always passing absolute paths hides path-resolution bugs.
+    /// </summary>
+    /// <param name="workingDirectory">Working directory for the tool process, or null to inherit the test host's.</param>
+    /// <param name="targetFramework">The target framework moniker to run the tool under (e.g., "net8.0", "net9.0", "net10.0", "net11.0").</param>
+    /// <param name="command">The scaffold sub-command (e.g., "minimalapi", "mvccontroller", "blazor-empty").</param>
+    /// <param name="args">CLI arguments for the command (e.g., "--project", path, "--name", "Foo").</param>
+    /// <returns>A tuple of (ExitCode, StandardOutput, StandardError).</returns>
+    public static async Task<(int ExitCode, string Output, string Error)> RunScaffoldInDirectoryAsync(string? workingDirectory, string targetFramework, string command, params string[] args)
     {
         var scaffoldCsproj = GetScaffoldProjectPath();
         var configuration = GetBuildConfiguration();
@@ -179,6 +192,11 @@ internal static class ScaffoldCliHelper
                 CreateNoWindow = true
             }
         };
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            process.StartInfo.WorkingDirectory = workingDirectory;
+        }
+
         ConfigureDotNetEnvironment(process.StartInfo);
         process.StartInfo.ArgumentList.Add("run");
         process.StartInfo.ArgumentList.Add("--no-build");


### PR DESCRIPTION
- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines
- [x] Review the guidelines for CONTRIBUTING.md for more details.

How was this tested?

I performed some manual tests on different project types and subsequently added automated integration test scenarios based on the same. Here are some of the scenarios I tested:

- Running the scaffolder against an existing Blazor Sever project, which already has references to old versions of the packages. This scenario was throwing initially, hence the change in `DetectBlazorWasmStep`, which was validated with an integration test (failure before the change, pass after).
- Running the scaffolder against an existing split project with no reference - scaffolder updates both server and client when invoked against the server project, and only the client, treating it like a standalone WASM when executed against the client one.
- Running the scaffolder with only one package selected against different project types - Lite, then GridLite
- More variations of the above



